### PR TITLE
RUMM-1023 Allow customizing the version and service name

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
@@ -20,6 +20,20 @@ open class DdExtension : Serializable {
     var environmentName: String = ""
 
     /**
+     * The environment name for the application.
+     * By default (null) it will read the version name of your application from your gradle
+     * configuration.
+     */
+    var versionName: String? = null
+
+    /**
+     * The service name for the application.
+     * By default (null) it will read the package name of your application from your gradle
+     * configuration.
+     */
+    var serviceName: String? = null
+
+    /**
      * The Datadog site to upload your data to (one of "US", "EU", "GOV").
      */
     var site: String = DdConfiguration.Site.US.name

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/Configurator.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/Configurator.kt
@@ -14,5 +14,6 @@ internal class Configurator : ForgeConfigurator {
     override fun configure(forge: Forge) {
         forge.addFactory(IdentifierForgeryFactory())
         forge.addFactory(ConfigurationForgeryFactory())
+        forge.addFactory(ExtensionForgeryFactory())
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -1,0 +1,186 @@
+package com.datadog.gradle.plugin
+
+import com.android.build.gradle.api.ApplicationVariant
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DdAndroidGradlePluginTest {
+
+    lateinit var testedPlugin: DdAndroidGradlePlugin
+
+    lateinit var fakeProject: Project
+
+    @Mock
+    lateinit var mockVariant: ApplicationVariant
+
+    @Forgery
+    lateinit var fakeExtension: DdExtension
+
+    @StringForgery(StringForgeryType.HEXADECIMAL)
+    lateinit var fakeApiKey: String
+
+    @BeforeEach
+    fun `set up`() {
+        fakeProject = ProjectBuilder.builder().build()
+
+        testedPlugin = DdAndroidGradlePlugin()
+    }
+
+    @Test
+    fun `𝕄 configure the upload task with the variant info 𝕎 configureVariant()`(
+        @StringForgery variantName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        fakeExtension.versionName = null
+        fakeExtension.serviceName = null
+        whenever(mockVariant.name) doReturn variantName
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+
+        // When
+        val task = testedPlugin.configureVariant(
+            fakeProject,
+            mockVariant,
+            fakeApiKey,
+            fakeExtension
+        )
+
+        // Then
+        check(task is DdMappingFileUploadTask)
+        assertThat(task.name).isEqualTo("uploadMapping${variantName.capitalize()}")
+        assertThat(task.apiKey).isEqualTo(fakeApiKey)
+        assertThat(task.variantName).isEqualTo(variantName)
+        assertThat(task.versionName).isEqualTo(versionName)
+        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.envName).isEqualTo(fakeExtension.environmentName)
+        assertThat(task.site).isEqualTo(fakeExtension.site)
+        assertThat(task.mappingFilePath).isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
+    }
+
+
+    @Test
+    fun `𝕄 remove buildType 𝕎 configureVariant() {Debug variant}`(
+        @StringForgery variantName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        fakeExtension.versionName = null
+        fakeExtension.serviceName = null
+        val fullVariant = "${variantName}Debug"
+        whenever(mockVariant.name) doReturn fullVariant
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+
+        // When
+        val task = testedPlugin.configureVariant(
+            fakeProject,
+            mockVariant,
+            fakeApiKey,
+            fakeExtension
+        )
+
+        // Then
+        check(task is DdMappingFileUploadTask)
+        assertThat(task.name).isEqualTo("uploadMapping${fullVariant.capitalize()}")
+        assertThat(task.apiKey).isEqualTo(fakeApiKey)
+        assertThat(task.variantName).isEqualTo(variantName)
+        assertThat(task.versionName).isEqualTo(versionName)
+        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.envName).isEqualTo(fakeExtension.environmentName)
+        assertThat(task.site).isEqualTo(fakeExtension.site)
+        assertThat(task.mappingFilePath).isEqualTo("${fakeProject.buildDir}/outputs/mapping/$fullVariant/mapping.txt")
+    }
+
+
+    @Test
+    fun `𝕄 remove buildType 𝕎 configureVariant() {Release variant}`(
+        @StringForgery variantName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        fakeExtension.versionName = null
+        fakeExtension.serviceName = null
+        val fullVariant = "${variantName}Release"
+        whenever(mockVariant.name) doReturn fullVariant
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+
+        // When
+        val task = testedPlugin.configureVariant(
+            fakeProject,
+            mockVariant,
+            fakeApiKey,
+            fakeExtension
+        )
+
+        // Then
+        check(task is DdMappingFileUploadTask)
+        assertThat(task.name).isEqualTo("uploadMapping${fullVariant.capitalize()}")
+        assertThat(task.apiKey).isEqualTo(fakeApiKey)
+        assertThat(task.variantName).isEqualTo(variantName)
+        assertThat(task.versionName).isEqualTo(versionName)
+        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.envName).isEqualTo(fakeExtension.environmentName)
+        assertThat(task.site).isEqualTo(fakeExtension.site)
+        assertThat(task.mappingFilePath).isEqualTo("${fakeProject.buildDir}/outputs/mapping/$fullVariant/mapping.txt")
+    }
+    @Test
+    fun `𝕄 configure the upload task with the extension info 𝕎 configureVariant()`(
+        @StringForgery variantName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        whenever(mockVariant.name) doReturn variantName
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+
+        // When
+        val task = testedPlugin.configureVariant(
+            fakeProject,
+            mockVariant,
+            fakeApiKey,
+            fakeExtension
+        )
+
+        // Then
+        check(task is DdMappingFileUploadTask)
+        assertThat(task.name).isEqualTo("uploadMapping${variantName.capitalize()}")
+        assertThat(task.apiKey).isEqualTo(fakeApiKey)
+        assertThat(task.variantName).isEqualTo(variantName)
+        assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
+        assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(task.envName).isEqualTo(fakeExtension.environmentName)
+        assertThat(task.site).isEqualTo(fakeExtension.site)
+        assertThat(task.mappingFilePath).isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/ExtensionForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/ExtensionForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin
+
+import com.datadog.gradle.plugin.internal.DdAppIdentifier
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ExtensionForgeryFactory : ForgeryFactory<DdExtension> {
+    override fun getForgery(forge: Forge): DdExtension {
+        return DdExtension().apply {
+            serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}")
+            environmentName = forge.anAlphabeticalString()
+            versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Let the customer override the `serviceName` and `versionName` used in the `uploadMapping*` task