### PR TITLE
RUMM-1058 Allow disabling the plugin

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -9,7 +9,6 @@ package com.datadog.gradle.plugin
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import java.io.File
-import java.lang.IllegalStateException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -52,10 +51,7 @@ class DdAndroidGradlePlugin : Plugin<Project> {
         val environmentKey = System.getenv(DD_API_KEY)
         if (!environmentKey.isNullOrBlank()) return environmentKey
 
-        throw IllegalStateException(
-            "Make sure you define an API KEY to upload your mapping files to Datadog. " +
-                "Create a DD_API_KEY environment variable or gradle property."
-        )
+        return ""
     }
 
     @Suppress("DefaultLocale")

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -66,6 +66,11 @@ class DdAndroidGradlePlugin : Plugin<Project> {
             return null
         }
 
+        if (!extension.enabled) {
+            // lets not create any task
+            return null
+        }
+
         val flavorName = variant.flavorName
         val uploadTaskName = UPLOAD_TASK_NAME + variant.name.capitalize()
         val uploadTask = target.tasks.create(uploadTaskName, DdMappingFileUploadTask::class.java)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
@@ -15,6 +15,11 @@ import org.gradle.api.NamedDomainObjectContainer
 open class DdExtension : DdExtensionConfiguration() {
 
     /**
+     * Whether the plugin should be enabled or not.
+     */
+    var enabled: Boolean = true
+
+    /**
      * Container for the variant's configurations.
      */
     var variants: NamedDomainObjectContainer<DdExtensionConfiguration>? = null

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -114,7 +114,8 @@ open class DdMappingFileUploadTask : DefaultTask() {
     @Suppress("CheckInternal")
     private fun validateConfiguration() {
         check(apiKey.isNotBlank()) {
-            "You need to provide a valid client token for variant $variantName"
+            "Make sure you define an API KEY to upload your mapping files to Datadog. " +
+                "Create a DD_API_KEY environment variable or gradle property."
         }
         check(envName.isNotBlank()) {
             "You need to provide a valid environment name for variant $variantName"

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -12,13 +12,11 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.lang.IllegalStateException
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -233,10 +231,12 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
-    fun `𝕄 throw exception 𝕎 resolveApiKey() {key not defined anywhere}`() {
-        assertThrows<IllegalStateException> {
-            testedPlugin.resolveApiKey(fakeProject)
-        }
+    fun `𝕄 returns empty String 𝕎 resolveApiKey() {key not defined anywhere}`() {
+        // When
+        val apiKey = testedPlugin.resolveApiKey(fakeProject)
+
+        // Then
+        assertThat(apiKey).isEmpty()
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -201,6 +201,35 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task).isNull()
     }
 
+    @Test
+    fun `𝕄 do nothing 𝕎 configureVariant() {plugin disabled}`(
+        @StringForgery(case = Case.LOWER) flavorName: String,
+        @StringForgery(case = Case.LOWER) buildTypeName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        fakeExtension.enabled = false
+        val variantName = "$flavorName${buildTypeName.capitalize()}"
+        whenever(mockVariant.name) doReturn variantName
+        whenever(mockVariant.flavorName) doReturn flavorName
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+        whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.isMinifyEnabled) doReturn true
+
+        // When
+        val task = testedPlugin.configureVariant(
+            fakeProject,
+            mockVariant,
+            fakeApiKey,
+            fakeExtension
+        )
+
+        // Then
+        assertThat(task).isNull()
+    }
+
     // endregion
 
     // region resolveApiKey


### PR DESCRIPTION
### What does this PR do?

Let customer disable the plugin to only analyse and create variants when necessary. 
Also delays the validation of API Key, allowing developers to have the plugin initialise on computers where the API Key is undefined.