### PR TITLE
RUMM-1056: Make variants property non-nullable

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -120,7 +120,7 @@ class DdAndroidGradlePlugin : Plugin<Project> {
         extension: DdExtension,
         flavorName: String
     ): DdExtensionConfiguration {
-        val flavorConfig = extension.variants?.findByName(flavorName)
+        val flavorConfig = extension.variants.findByName(flavorName)
 
         return DdExtensionConfiguration().apply {
             versionName = flavorConfig?.versionName ?: extension.versionName

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtension.kt
@@ -19,15 +19,27 @@ open class DdExtension : DdExtensionConfiguration() {
      */
     var enabled: Boolean = true
 
+    // introduced because cannot use lateinit with `variants` because of name
+    // ambiguity (method vs property). Consider switching to constructor injection
+    // via https://docs.gradle.org/current/javadoc/org/gradle/api/model/ObjectFactory.html#domainObjectContainer-java.lang.Class-
+    // once it is stable
+    private lateinit var _variants: NamedDomainObjectContainer<DdExtensionConfiguration>
+
     /**
      * Container for the variant's configurations.
      */
-    var variants: NamedDomainObjectContainer<DdExtensionConfiguration>? = null
+    var variants: NamedDomainObjectContainer<DdExtensionConfiguration>
+        get() = _variants
+        set(value) {
+            _variants = value
+        }
 
     /**
      * Closure method to create a DSL for variant configurations.
      */
     fun variants(configureClosure: Closure<DdExtensionConfiguration>) {
-        variants?.configure(configureClosure)
+        if (::_variants.isInitialized) {
+            _variants.configure(configureClosure)
+        }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -291,7 +291,7 @@ internal class DdAndroidGradlePluginTest {
         @Forgery variantConfig: DdExtensionConfiguration
     ) {
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants?.findByName(flavorName)) doReturn variantConfig
+        whenever(fakeExtension.variants.findByName(flavorName)) doReturn variantConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, flavorName)
@@ -311,7 +311,7 @@ internal class DdAndroidGradlePluginTest {
             this.versionName = versionName
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants?.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, flavorName)
@@ -331,7 +331,7 @@ internal class DdAndroidGradlePluginTest {
             this.serviceName = serviceName
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants?.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, flavorName)
@@ -351,7 +351,7 @@ internal class DdAndroidGradlePluginTest {
             this.site = site.name
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants?.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, flavorName)


### PR DESCRIPTION
### What does this PR do?

This change makes variants property non-nullable to avoid force-casting (`variants!!`) in the build script.

### Motivation

Knowledge that force-casting is bad.

### Additional Notes

Solution looks a bit hacky. Better way is to do injection with `ObjectFactory` as described here https://docs.gradle.org/current/userguide/custom_gradle_types.html#collection_types, but the problem is that this method is incubating, so I guess it doesn't guarantee binary compatibility yet (although it is available since Gradle 5.5).

### Review checklist (to be filled by reviewers)

- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

