### PR TITLE
RUMM-1055 Increase the OkHttpClient call/write timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Dokka)
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Bintray)
         // Uncomment to use the samples
-        // classpath("com.datadoghq:dd-sdk-android-gradle-plugin:1.0.0-alpha1")
+        // classpath("com.datadoghq:dd-sdk-android-gradle-plugin:1.0.0-alpha3")
     }
 }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -10,6 +10,7 @@ import com.datadog.gradle.plugin.DdAndroidGradlePlugin.Companion.LOGGER
 import java.io.File
 import java.lang.IllegalStateException
 import java.net.HttpURLConnection
+import java.util.concurrent.TimeUnit
 import okhttp3.MediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
@@ -19,6 +20,12 @@ import okhttp3.Response
 internal class OkHttpUploader : Uploader {
 
     // region Uploader
+
+    internal val client = OkHttpClient
+        .Builder()
+        .callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .build()
 
     @Suppress("TooGenericExceptionCaught")
     override fun upload(
@@ -30,7 +37,6 @@ internal class OkHttpUploader : Uploader {
         LOGGER.info("Uploading mapping file for $identifier:\n")
         val body = createBody(identifier, mappingFile, repositoryFile)
 
-        val client = OkHttpClient.Builder().build()
         val request = Request.Builder()
             .url(url)
             .post(body)
@@ -102,6 +108,7 @@ internal class OkHttpUploader : Uploader {
 
     companion object {
 
+        internal val NETWORK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(45)
         internal val MEDIA_TYPE_TXT = MediaType.parse("text/plain")
         internal val MEDIA_TYPE_JSON = MediaType.parse("application/json")
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -41,7 +41,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class OkHttpUploaderTest {
 
-    lateinit var testedUploader: Uploader
+    lateinit var testedUploader: OkHttpUploader
 
     @TempDir
     lateinit var tempDir: File
@@ -90,6 +90,20 @@ internal class OkHttpUploaderTest {
     fun `tear down`() {
         mockWebServer.shutdown()
         dispatchedRequest = null
+    }
+
+    @Test
+    fun `M use an OkHttpClient W callTimeout { 45 seconds }`() {
+        assertThat(testedUploader.client.callTimeoutMillis()).isEqualTo(
+            OkHttpUploader.NETWORK_TIMEOUT_MS.toInt()
+        )
+    }
+
+    @Test
+    fun `M use an OkHttpClient W writeTimeout { 45 seconds }`() {
+        assertThat(testedUploader.client.writeTimeoutMillis()).isEqualTo(
+            OkHttpUploader.NETWORK_TIMEOUT_MS.toInt()
+        )
     }
 
     @Test

--- a/samples/basic/build.gradle
+++ b/samples/basic/build.gradle
@@ -39,5 +39,5 @@ dependencies {
 
 //datadog {
 //    site = "US"
-//    environmentName = "prod"
+//    versionName = "prod"
 //}


### PR DESCRIPTION
### What does this PR do?

Increases the OkHttpClient call and write timeout to 45 seconds for the gradle task which uploads the proguard mapping file to Datadog endpoint.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

