### PR TITLE
RUMM-1010: Warn or fail the build when Datadog SDK is missing in the project dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ datadog {
     versionName = "1.3.0" // Optional, by default it is read from your Android plugin configuration's version name
     serviceName = "my-service" // Optional, by default it is read from your Android plugin configuration's package name
     site = "US" // Optional, can be "US", "EU" or "GOV". Default is "US"
+    checkProjectDependencies = "warn" // Optional, can be "warn", "fail" or "none". Default is "fail". Will check if Datadog SDK is in the project dependencies.
 }
 ```
 
@@ -40,6 +41,7 @@ datadog {
     variants {
         fr {
             site = "EU"
+            checkProjectDependencies = "warn"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ datadog {
     variants {
         fr {
             site = "EU"
-            checkProjectDependencies = "warn"
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Dokka)
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Bintray)
         // Uncomment to use the samples
-        // classpath("com.datadoghq:dd-sdk-android-gradle-plugin:1.0.0-alpha3")
+        // classpath("com.datadoghq:dd-sdk-android-gradle-plugin:1.0.0-alpha4")
     }
 }
 
@@ -31,6 +31,7 @@ allprojects {
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
         jcenter()
         flatDir { dirs("libs") }
+        maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Datadog) }
     }
 }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -75,7 +75,7 @@ object Dependencies {
 
     object Repositories {
         const val Gradle = "https://plugins.gradle.org/m2/"
-        const val Google = "https://maven.google.com"
         const val Jitpack = "https://jitpack.io"
+        const val Datadog = "https://dl.bintray.com/datadog/datadog-maven"
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -25,4 +25,11 @@ open class DdExtensionConfiguration(
      * The Datadog site to upload your data to (one of "US", "EU", "GOV").
      */
     var site: String? = null
+
+    /**
+     * This property controls if plugin should check if Datadog SDK is included in the dependencies
+     * and if it is not: "none" - ignore, "warn" - log a warning, "fail" - fail the build
+     * with an error (default).
+     */
+    var checkProjectDependencies: SdkCheckLevel? = null
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/SdkCheckLevel.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/SdkCheckLevel.kt
@@ -1,0 +1,22 @@
+package com.datadog.gradle.plugin
+
+/**
+ * Defines the action which plugin should take if Datadog SDK is missing
+ * in the project dependencies.
+ */
+enum class SdkCheckLevel {
+    /**
+     * Do nothing if SDK is missing in the dependencies.
+     */
+    NONE,
+
+    /**
+     * Log a warning if SDK is missing in the dependencies.
+     */
+    WARN,
+
+    /**
+     * Fail the build if SDK is missing in the dependencies.
+     */
+    FAIL
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/MissingSdkException.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/MissingSdkException.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.internal
+
+internal class MissingSdkException(message: String) : RuntimeException(message)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -517,6 +517,41 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
+    fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { sdk is missing w none set }`(
+        @StringForgery(case = Case.LOWER) flavorName: String,
+        @StringForgery(case = Case.LOWER) buildTypeName: String,
+        @StringForgery versionName: String,
+        @StringForgery packageName: String
+    ) {
+        // Given
+        fakeExtension.checkProjectDependencies = SdkCheckLevel.NONE
+        val variantName = "$flavorName${buildTypeName.capitalize()}"
+        whenever(mockVariant.name) doReturn variantName
+        whenever(mockVariant.flavorName) doReturn flavorName
+        whenever(mockVariant.versionName) doReturn versionName
+        whenever(mockVariant.applicationId) doReturn packageName
+        whenever(mockVariant.buildType) doReturn mockBuildType
+
+        val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
+
+        val mockConfiguration = mock<Configuration>()
+        val mockResolvedConfiguration = mock<ResolvedConfiguration>()
+
+        whenever(mockResolvedConfiguration.firstLevelModuleDependencies) doReturn emptySet()
+        whenever(mockConfiguration.resolvedConfiguration) doReturn mockResolvedConfiguration
+        whenever(mockVariant.runtimeConfiguration) doReturn mockConfiguration
+
+        // When + Then
+        assertDoesNotThrow {
+            testedPlugin.configureVariantForSdkCheck(
+                fakeProject,
+                mockVariant,
+                fakeExtension
+            )!!.actions.first().execute(fakeCompileTask)
+        }
+    }
+
+    @Test
     fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { sdk is there }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
@@ -16,6 +16,7 @@ internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensi
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}")
             versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
             site = forge.aValueFrom(DdConfiguration.Site::class.java).name
+            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
@@ -18,6 +18,7 @@ internal class DdExtensionForgeryFactory : ForgeryFactory<DdExtension> {
             versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
             site = forge.aValueFrom(DdConfiguration.Site::class.java).name
             variants = mock()
+            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
         }
     }
 }

--- a/samples/variants/build.gradle
+++ b/samples/variants/build.gradle
@@ -55,20 +55,23 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+
+    // implementation 'com.datadoghq:dd-sdk-android:1.8.0'
 }
 
 //datadog {
 //    site = "US"
+//    checkProjectDependencies = "fail"
 //    variants {
 //        demo {
-//            environmentName = "demo"
+//            versionName = "demo"
 //        }
 //        full {
-//            environmentName = "full"
+//            versionName = "full"
 //        }
 //        pro {
 //            site = "GOV"
-//            environmentName = "pro"
+//            versionName = "pro"
 //        }
 //    }
 //}


### PR DESCRIPTION
### What does this PR do?

This changes build a link between Datadog SDK Gradle plugin and Datadog SDK itself: plugin will be able to notify the user if Datadog SDK is missing in the project dependencies (strictly speaking in the runtime classpath). This is achieved by introducing new `checkProjectDependencies` property of the plugin extension, which has 3 options: `none` - take no action if Datadog SDK is missing, `warn` - log a warning if Datadog SDK is missing, `fail` - fail the build if Datadog SDK is missing. This property can be applied either on the global level or per flavor:

```
datadog {
    site = "US"
    checkProjectDependencies = "fail"
    variants {
        fr {
            site = "EU"
            checkProjectDependencies = "none"
        }
    }
}
```

### Motivation

Get a better feedback to the Datadog SDK user if setup is wrong.

### Additional Notes

Check is done at the pre-compilation step (lazy way), to save build script configuration time which may be large for the big projects since we need to check full dependency tree (not necessarily Datadog SDK will be top level dependency for the project, it may also come from the other modules).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

