### PR TITLE
RUMM-1127 Fail the build task if mapping file size exceeds the 50 MB …

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/MaxSizeExceededException.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/MaxSizeExceededException.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.internal
+
+internal class MaxSizeExceededException(message: String) : RuntimeException(message)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -66,7 +66,12 @@ internal class OkHttpUploader : Uploader {
         repositoryInfo: RepositoryInfo?
     ): MultipartBody {
         val mappingFileBody = MultipartBody.create(MEDIA_TYPE_TXT, mappingFile)
-
+        if (mappingFileBody.contentLength() > MAX_MAP_FILE_SIZE_IN_BYTES) {
+            throw MaxSizeExceededException(
+                MAX_MAP_SIZE_EXCEEDED_ERROR_FORMAT
+                    .format(mappingFile.absolutePath)
+            )
+        }
         val builder = MultipartBody.Builder()
         builder.setType(MultipartBody.FORM)
             .addFormDataPart("version", identifier.version)
@@ -118,7 +123,10 @@ internal class OkHttpUploader : Uploader {
         internal val NETWORK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(45)
         internal val MEDIA_TYPE_TXT = MediaType.parse("text/plain")
         internal val MEDIA_TYPE_JSON = MediaType.parse("application/json")
-
+        internal const val MAX_MAP_FILE_SIZE_IN_BYTES = 50L * 1024L * 1024L // 50 MB
+        internal val MAX_MAP_SIZE_EXCEEDED_ERROR_FORMAT =
+            "The proguard mapping file at: [%s] size exceeded the maximum 50 MB size. " +
+                "This task cannot be performed."
         internal val succesfulCodes = arrayOf(
             HttpURLConnection.HTTP_OK,
             HttpURLConnection.HTTP_CREATED,


### PR DESCRIPTION

### What does this PR do?

In this PR we will check and fail the `uploadMapping` task if the `mappingFile.txt` size exceeds the 50 MB max size.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

