### PR TITLE
RUMM-1103 handle partial variant configurations

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -190,7 +190,8 @@ class DdAndroidGradlePlugin : Plugin<Project> {
         configuration.updateWith(extension)
 
         val flavors = variant.productFlavors.map { it.name }
-        val iterator = VariantIterator(flavors)
+        val buildType = variant.buildType.name
+        val iterator = VariantIterator(flavors + buildType)
         iterator.forEach {
             val config = extension.variants.findByName(it)
             if (config != null) {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -10,6 +10,7 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.datadog.gradle.plugin.internal.GitRepositoryDetector
 import com.datadog.gradle.plugin.internal.MissingSdkException
+import com.datadog.gradle.plugin.internal.VariantIterator
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -82,7 +83,7 @@ class DdAndroidGradlePlugin : Plugin<Project> {
             DdMappingFileUploadTask::class.java,
             GitRepositoryDetector()
         )
-        val extensionConfiguration = resolveExtensionConfiguration(extension, flavorName)
+        val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
 
         configureVariantTask(uploadTask, apiKey, flavorName, extensionConfiguration, variant)
 
@@ -130,7 +131,6 @@ class DdAndroidGradlePlugin : Plugin<Project> {
             )
             return null
         } else {
-
             // this will postpone the check until the actual compilation for the particular variant.
             // by doing this we are avoiding pulling all the configurations for all the variants
             // after build script is evaluated, which may be a heavy task for the big projects
@@ -143,7 +143,7 @@ class DdAndroidGradlePlugin : Plugin<Project> {
 
                     val extensionConfiguration = resolveExtensionConfiguration(
                         extension,
-                        variant.flavorName
+                        variant
                     )
 
                     val sdkCheckLevel = extensionConfiguration.checkProjectDependencies
@@ -184,17 +184,20 @@ class DdAndroidGradlePlugin : Plugin<Project> {
 
     internal fun resolveExtensionConfiguration(
         extension: DdExtension,
-        flavorName: String
+        variant: ApplicationVariant
     ): DdExtensionConfiguration {
-        val flavorConfig = extension.variants.findByName(flavorName)
+        val configuration = DdExtensionConfiguration()
+        configuration.updateWith(extension)
 
-        return DdExtensionConfiguration().apply {
-            versionName = flavorConfig?.versionName ?: extension.versionName
-            serviceName = flavorConfig?.serviceName ?: extension.serviceName
-            site = flavorConfig?.site ?: extension.site
-            checkProjectDependencies = flavorConfig?.checkProjectDependencies
-                ?: extension.checkProjectDependencies
+        val flavors = variant.productFlavors.map { it.name }
+        val iterator = VariantIterator(flavors)
+        iterator.forEach {
+            val config = extension.variants.findByName(it)
+            if (config != null) {
+                configuration.updateWith(config)
+            }
         }
+        return configuration
     }
 
     internal fun isDatadogDependencyPresent(dependencies: Set<ResolvedDependency>): Boolean {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -32,4 +32,11 @@ open class DdExtensionConfiguration(
      * with an error (default).
      */
     var checkProjectDependencies: SdkCheckLevel? = null
+
+    internal fun updateWith(config: DdExtensionConfiguration) {
+        config.versionName?.let { versionName = it }
+        config.serviceName?.let { serviceName = it }
+        config.site?.let { site = it }
+        config.checkProjectDependencies?.let { checkProjectDependencies = it }
+    }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
@@ -1,16 +1,16 @@
 package com.datadog.gradle.plugin.internal
 
 /**
- * This Iterator will take a list of flavor name and iterate over all possible
- * (partial) variants from those.
+ * This Iterator will take a list of flavor name and trailing build type and iterate over all
+ * possible (partial) variants from those.
  *
  * The partial variants will be iterated over in increasing order of priority.
  * Product flavors that belong to the first flavor dimension have a higher priority than
  * those belonging to the second flavor dimension.
  *
- * E.g.: for the variant with flavor names ["pro", "green", "europe"], the iterator will
+ * E.g.: for the variant with flavor names ["pro", "green", "release"], the iterator will
  * return the following values (in order):
- * "europe", "green", "greenEurope", "pro", "proEurope", "proGreen", "proGreenEurope"
+ * "release", "green", "greenRelease", "pro", "proRelease", "proGreen", "proGreenRelease"
  */
 internal class VariantIterator(
     private val names: List<String>
@@ -30,7 +30,7 @@ internal class VariantIterator(
 
         // The idea of this algorithm is to generate all possible combination
         // while also keeping the order based on priorities.
-        // Given a list of n flavor names, we construct matching list of n booleans to decide
+        // Given a list of n names, we construct matching list of n booleans to decide
         // which of those name tokens we keep for the variant names.
         // Because the first name has a higher priority, the sequence would be (for 3 names):
         // false-false-true, false-true-false, false-true-true, true-false-false, and so on…
@@ -38,10 +38,11 @@ internal class VariantIterator(
         // - the iterator iterates from 1 to (2^n - 1)
         // - at each step, we generate the binary representation of the current index
         // - we pad the binary with '0' to match the names size
-        // - we convert the  binary represnetation string into a boolean array
+        // - we convert the  binary representation string into a boolean array
         // - we zip the array with the name
         val mask = index.toString(2).padStart(names.size, '0').map { it == '1' }
-        val filteredNames = mask.zip(names) { b, s -> if (b) s else null }.filterNotNull()
+        val filteredNames = mask.zip(names) { bool, string -> if (bool) string else null }
+            .filterNotNull()
 
         index++
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
@@ -27,9 +27,28 @@ internal class VariantIterator(
         if (index >= max) {
             throw NoSuchElementException()
         }
+
+        // The idea of this algorithm is to generate all possible combination
+        // while also keeping the order based on priorities.
+        // Given a list of n flavor names, we construct matching list of n booleans to decide
+        // which of those name tokens we keep for the variant names.
+        // Because the first name has a higher priority, the sequence would be (for 3 names):
+        // false-false-true, false-true-false, false-true-true, true-false-false, and so on…
+        // This sequence matches exactly the binary representation of integers starting from 1, so:
+        // - the iterator iterates from 1 to (2^n - 1)
+        // - at each step, we generate the binary representation of the current index
+        // - we pad the binary with '0' to match the names size
+        // - we convert the  binary represnetation string into a boolean array
+        // - we zip the array with the name
         val mask = index.toString(2).padStart(names.size, '0').map { it == '1' }
         val filteredNames = mask.zip(names) { b, s -> if (b) s else null }.filterNotNull()
+
         index++
-        return filteredNames.first() + filteredNames.drop(1).joinToString("") { it.capitalize() }
+
+        return buildVariantName(filteredNames)
+    }
+
+    private fun buildVariantName(flavorNames: List<String>): String {
+        return flavorNames.first() + flavorNames.drop(1).joinToString("") { it.capitalize() }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/VariantIterator.kt
@@ -1,0 +1,35 @@
+package com.datadog.gradle.plugin.internal
+
+/**
+ * This Iterator will take a list of flavor name and iterate over all possible
+ * (partial) variants from those.
+ *
+ * The partial variants will be iterated over in increasing order of priority.
+ * Product flavors that belong to the first flavor dimension have a higher priority than
+ * those belonging to the second flavor dimension.
+ *
+ * E.g.: for the variant with flavor names ["pro", "green", "europe"], the iterator will
+ * return the following values (in order):
+ * "europe", "green", "greenEurope", "pro", "proEurope", "proGreen", "proGreenEurope"
+ */
+internal class VariantIterator(
+    private val names: List<String>
+) : Iterator<String> {
+
+    private var index = 1
+    private val max = 1 shl names.size
+
+    override fun hasNext(): Boolean {
+        return index < max
+    }
+
+    override fun next(): String {
+        if (index >= max) {
+            throw NoSuchElementException()
+        }
+        val mask = index.toString(2).padStart(names.size, '0').map { it == '1' }
+        val filteredNames = mask.zip(names) { b, s -> if (b) s else null }.filterNotNull()
+        index++
+        return filteredNames.first() + filteredNames.drop(1).joinToString("") { it.capitalize() }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -310,10 +310,10 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return config 𝕎 resolveExtensionConfiguration() { variant w full config }`(
         @Forgery variantConfig: DdExtensionConfiguration
     ) {
-        val flavorName = fakeFlavorNames.variantName()
+        val variantName = fakeFlavorNames.variantName()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn variantConfig
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn variantConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
@@ -330,13 +330,13 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w version only }`(
         @StringForgery versionName: String
     ) {
-        val flavorName = fakeFlavorNames.variantName()
+        val variantName = fakeFlavorNames.variantName()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.versionName = versionName
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
@@ -353,13 +353,13 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w service only }`(
         @StringForgery serviceName: String
     ) {
-        val flavorName = fakeFlavorNames.variantName()
+        val variantName = fakeFlavorNames.variantName()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.serviceName = serviceName
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
@@ -376,13 +376,13 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w site only }`(
         @Forgery site: DdConfiguration.Site
     ) {
-        val flavorName = fakeFlavorNames.variantName()
+        val variantName = fakeFlavorNames.variantName()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.site = site.name
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
@@ -400,13 +400,13 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w sdkCheck only }`(
         @Forgery sdkCheckLevel: SdkCheckLevel
     ) {
-        val flavorName = fakeFlavorNames.variantName()
+        val variantName = fakeFlavorNames.variantName()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.checkProjectDependencies = sdkCheckLevel
         }
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn incompleteConfig
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
@@ -492,10 +492,10 @@ internal class DdAndroidGradlePluginTest {
     fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w build type }`(
         @Forgery configuration: DdExtensionConfiguration
     ) {
-        val flavorName = fakeFlavorNames.variantName() + fakeBuildTypeName.capitalize()
+        val variantName = fakeFlavorNames.variantName() + fakeBuildTypeName.capitalize()
         mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorName)) doReturn configuration
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn configuration
 
         // When
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -60,6 +60,9 @@ internal class DdAndroidGradlePluginTest {
     @StringForgery(case = Case.LOWER)
     lateinit var fakeFlavorNames: List<String>
 
+    @StringForgery(regex = "debug|preRelease|release")
+    lateinit var fakeBuildTypeName: String
+
     @BeforeEach
     fun `set up`() {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
@@ -86,6 +89,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
         whenever(mockBuildType.isMinifyEnabled) doReturn true
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -123,6 +127,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
         whenever(mockBuildType.isMinifyEnabled) doReturn true
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -163,6 +168,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
         whenever(mockBuildType.isMinifyEnabled) doReturn true
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -200,6 +206,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
         whenever(mockBuildType.isMinifyEnabled) doReturn false
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -229,6 +236,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
         whenever(mockBuildType.isMinifyEnabled) doReturn true
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -287,7 +295,7 @@ internal class DdAndroidGradlePluginTest {
     @Test
     fun `𝕄 return default config 𝕎 resolveExtensionConfiguration() {no variant config}`() {
         // When
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
 
         // Then
@@ -303,7 +311,7 @@ internal class DdAndroidGradlePluginTest {
         @Forgery variantConfig: DdExtensionConfiguration
     ) {
         val flavorName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         fakeExtension.variants = mock()
         whenever(fakeExtension.variants.findByName(flavorName)) doReturn variantConfig
 
@@ -323,7 +331,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery versionName: String
     ) {
         val flavorName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.versionName = versionName
         }
@@ -346,7 +354,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery serviceName: String
     ) {
         val flavorName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.serviceName = serviceName
         }
@@ -369,7 +377,7 @@ internal class DdAndroidGradlePluginTest {
         @Forgery site: DdConfiguration.Site
     ) {
         val flavorName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.site = site.name
         }
@@ -393,7 +401,7 @@ internal class DdAndroidGradlePluginTest {
         @Forgery sdkCheckLevel: SdkCheckLevel
     ) {
         val flavorName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames)
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.checkProjectDependencies = sdkCheckLevel
         }
@@ -408,6 +416,96 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
         assertThat(config.checkProjectDependencies).isEqualTo(sdkCheckLevel)
+    }
+
+    @Test
+    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { simple variants }`(
+        @StringForgery(case = Case.LOWER) flavorA: String,
+        @StringForgery(case = Case.LOWER) flavorB: String,
+        @StringForgery(case = Case.LOWER) flavorC: String,
+        @Forgery variantConfigA: DdExtensionConfiguration,
+        @Forgery variantConfigB: DdExtensionConfiguration,
+        @Forgery variantConfigC: DdExtensionConfiguration
+    ) {
+        val flavorNames = listOf(flavorA, flavorB, flavorC)
+        variantConfigA.apply {
+            versionName = null
+            checkProjectDependencies = null
+        }
+        variantConfigB.apply {
+            serviceName = null
+            checkProjectDependencies = null
+        }
+        variantConfigC.apply { site = null }
+        mockVariant.mockFlavors(flavorNames, fakeBuildTypeName)
+        fakeExtension.variants = mock()
+        whenever(fakeExtension.variants.findByName(flavorA)) doReturn variantConfigA
+        whenever(fakeExtension.variants.findByName(flavorB)) doReturn variantConfigB
+        whenever(fakeExtension.variants.findByName(flavorC)) doReturn variantConfigC
+
+        // When
+        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
+
+        // Then
+        assertThat(config.versionName).isEqualTo(variantConfigB.versionName)
+        assertThat(config.serviceName).isEqualTo(variantConfigA.serviceName)
+        assertThat(config.site).isEqualTo(variantConfigA.site)
+        assertThat(config.checkProjectDependencies)
+            .isEqualTo(variantConfigC.checkProjectDependencies)
+    }
+
+    @Test
+    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { complex variants }`(
+        @StringForgery(case = Case.LOWER) flavorA: String,
+        @StringForgery(case = Case.LOWER) flavorB: String,
+        @StringForgery(case = Case.LOWER) flavorC: String,
+        @Forgery variantConfigAB: DdExtensionConfiguration,
+        @Forgery variantConfigAC: DdExtensionConfiguration,
+        @Forgery variantConfigBC: DdExtensionConfiguration
+    ) {
+        val flavorNames = listOf(flavorA, flavorB, flavorC)
+        variantConfigAB.apply { versionName = null }
+        variantConfigAC.apply { serviceName = null }
+        variantConfigBC.apply { site = null }
+        variantConfigBC.apply { checkProjectDependencies = null }
+        mockVariant.mockFlavors(flavorNames, fakeBuildTypeName)
+        fakeExtension.variants = mock()
+        whenever(fakeExtension.variants.findByName(flavorA + flavorB.capitalize()))
+            .doReturn(variantConfigAB)
+        whenever(fakeExtension.variants.findByName(flavorA + flavorC.capitalize()))
+            .doReturn(variantConfigAC)
+        whenever(fakeExtension.variants.findByName(flavorB + flavorC.capitalize()))
+            .doReturn(variantConfigBC)
+
+        // When
+        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
+
+        // Then
+        assertThat(config.versionName).isEqualTo(variantConfigAC.versionName)
+        assertThat(config.serviceName).isEqualTo(variantConfigAB.serviceName)
+        assertThat(config.site).isEqualTo(variantConfigAB.site)
+        assertThat(config.checkProjectDependencies)
+            .isEqualTo(variantConfigAB.checkProjectDependencies)
+    }
+
+    @Test
+    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w build type }`(
+        @Forgery configuration: DdExtensionConfiguration
+    ) {
+        val flavorName = fakeFlavorNames.variantName() + fakeBuildTypeName.capitalize()
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        fakeExtension.variants = mock()
+        whenever(fakeExtension.variants.findByName(flavorName)) doReturn configuration
+
+        // When
+        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
+
+        // Then
+        assertThat(config.versionName).isEqualTo(configuration.versionName)
+        assertThat(config.serviceName).isEqualTo(configuration.serviceName)
+        assertThat(config.site).isEqualTo(configuration.site)
+        assertThat(config.checkProjectDependencies)
+            .isEqualTo(configuration.checkProjectDependencies)
     }
 
     // endregion
@@ -429,6 +527,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.versionName) doReturn versionName
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
 
@@ -467,6 +566,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.versionName) doReturn versionName
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
 
@@ -505,6 +605,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.versionName) doReturn versionName
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
 
@@ -540,6 +641,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.versionName) doReturn versionName
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
 
@@ -575,6 +677,7 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.versionName) doReturn versionName
         whenever(mockVariant.applicationId) doReturn packageName
         whenever(mockVariant.buildType) doReturn mockBuildType
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         val fakeCompileTask = fakeProject.task("compile${variantName.capitalize()}Sources")
 
@@ -719,65 +822,6 @@ internal class DdAndroidGradlePluginTest {
         ).isFalse()
     }
 
-    @Test
-    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { simple variants }`(
-        @StringForgery(case = Case.LOWER) flavorA: String,
-        @StringForgery(case = Case.LOWER) flavorB: String,
-        @StringForgery(case = Case.LOWER) flavorC: String,
-        @Forgery variantConfigA: DdExtensionConfiguration,
-        @Forgery variantConfigB: DdExtensionConfiguration,
-        @Forgery variantConfigC: DdExtensionConfiguration
-    ) {
-        val flavorNames = listOf(flavorA, flavorB, flavorC)
-        variantConfigA.apply { versionName = null }
-        variantConfigB.apply { serviceName = null }
-        variantConfigC.apply { site = null }
-        mockVariant.mockFlavors(flavorNames)
-        fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorA)) doReturn variantConfigA
-        whenever(fakeExtension.variants.findByName(flavorB)) doReturn variantConfigB
-        whenever(fakeExtension.variants.findByName(flavorC)) doReturn variantConfigC
-
-        // When
-        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
-
-        // Then
-        assertThat(config.versionName).isEqualTo(variantConfigB.versionName)
-        assertThat(config.serviceName).isEqualTo(variantConfigA.serviceName)
-        assertThat(config.site).isEqualTo(variantConfigA.site)
-    }
-
-    @Test
-    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { complex variants }`(
-        @StringForgery(case = Case.LOWER) flavorA: String,
-        @StringForgery(case = Case.LOWER) flavorB: String,
-        @StringForgery(case = Case.LOWER) flavorC: String,
-        @Forgery variantConfigAB: DdExtensionConfiguration,
-        @Forgery variantConfigAC: DdExtensionConfiguration,
-        @Forgery variantConfigBC: DdExtensionConfiguration
-    ) {
-        val flavorNames = listOf(flavorA, flavorB, flavorC)
-        variantConfigAB.apply { versionName = null }
-        variantConfigAC.apply { serviceName = null }
-        variantConfigBC.apply { site = null }
-        mockVariant.mockFlavors(flavorNames)
-        fakeExtension.variants = mock()
-        whenever(fakeExtension.variants.findByName(flavorA + flavorB.capitalize()))
-            .doReturn(variantConfigAB)
-        whenever(fakeExtension.variants.findByName(flavorA + flavorC.capitalize()))
-            .doReturn(variantConfigAC)
-        whenever(fakeExtension.variants.findByName(flavorB + flavorC.capitalize()))
-            .doReturn(variantConfigBC)
-
-        // When
-        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
-
-        // Then
-        assertThat(config.versionName).isEqualTo(variantConfigAC.versionName)
-        assertThat(config.serviceName).isEqualTo(variantConfigAB.serviceName)
-        assertThat(config.site).isEqualTo(variantConfigAB.site)
-    }
-
     // endregion
 
     // region Internal
@@ -786,7 +830,10 @@ internal class DdAndroidGradlePluginTest {
         return first() + drop(1).joinToString("") { it.capitalize() }
     }
 
-    private fun ApplicationVariant.mockFlavors(flavorNames: List<String>) {
+    private fun ApplicationVariant.mockFlavors(
+        flavorNames: List<String>,
+        buildTypeName: String
+    ) {
         val mockFlavors: MutableList<ProductFlavor> = mutableListOf()
         for (flavorName in flavorNames) {
             mockFlavors.add(
@@ -795,7 +842,11 @@ internal class DdAndroidGradlePluginTest {
                 }
             )
         }
+        val mockBuildType: BuildType = mock()
+        whenever(mockBuildType.name) doReturn buildTypeName
+
         whenever(productFlavors) doReturn mockFlavors
+        whenever(buildType) doReturn mockBuildType
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
@@ -1,0 +1,140 @@
+package com.datadog.gradle.plugin.internal
+
+import com.datadog.gradle.plugin.Configurator
+import fr.xgouchet.elmyr.Case
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class VariantIteratorTest {
+
+    @Test
+    fun `𝕄 iterate 𝕎 forEach() { 1 dimension }`(
+        @StringForgery(case = Case.LOWER) a: String
+    ) {
+        // Given
+        val iterator = VariantIterator(listOf(a))
+
+        // When
+        val output = mutableListOf<String>()
+        iterator.forEach { output.add(it) }
+
+        // Then
+        assertThat(output)
+            .containsExactly(a)
+    }
+
+    @Test
+    fun `𝕄 iterate 𝕎 forEach() { 2 dimensions }`(
+        @StringForgery(case = Case.LOWER) a: String,
+        @StringForgery(case = Case.LOWER) b: String
+    ) {
+        // Given
+        val B = b.capitalize()
+        val iterator = VariantIterator(listOf(a, b))
+
+        // When
+        val output = mutableListOf<String>()
+        iterator.forEach { output.add(it) }
+
+        // Then
+        assertThat(output)
+            .containsExactly(b, a, a + B)
+    }
+
+    @Test
+    fun `𝕄 iterate 𝕎 forEach() { 3 dimensions }`(
+        @StringForgery(case = Case.LOWER) a: String,
+        @StringForgery(case = Case.LOWER) b: String,
+        @StringForgery(case = Case.LOWER) c: String
+    ) {
+        // Given
+        val B = b.capitalize()
+        val C = c.capitalize()
+        val iterator = VariantIterator(listOf(a, b, c))
+
+        // When
+        val output = mutableListOf<String>()
+        iterator.forEach { output.add(it) }
+
+        // Then
+        assertThat(output)
+            .containsExactly(c, b, b + C, a, a + C, a + B, a + B + C)
+    }
+
+    @Test
+    fun `𝕄 iterate 𝕎 forEach() { 4 dimensions }`(
+        @StringForgery(case = Case.LOWER) a: String,
+        @StringForgery(case = Case.LOWER) b: String,
+        @StringForgery(case = Case.LOWER) c: String,
+        @StringForgery(case = Case.LOWER) d: String
+    ) {
+        // Given
+        val B = b.capitalize()
+        val C = c.capitalize()
+        val D = d.capitalize()
+        val iterator = VariantIterator(listOf(a, b, c, d))
+
+        // When
+        val output = mutableListOf<String>()
+        iterator.forEach { output.add(it) }
+
+        // Then
+        assertThat(output)
+            .containsExactly(
+                d, c, c + D,
+                b, b + D, b + C, b + C + D,
+                a, a + D, a + C, a + C + D,
+                a + B, a + B + D, a + B + C,
+                a + B + C + D
+            )
+    }
+
+    @Test
+    fun `𝕄 iterate 𝕎 forEach() { anySize }`(
+        @StringForgery(case = Case.LOWER) names: List<String>
+    ) {
+        // Given
+        val limitedNames = names.take(10) // limit the complexity of the data
+        val iterator = VariantIterator(limitedNames)
+
+        // When
+        val output = mutableListOf<String>()
+        iterator.forEach { output.add(it) }
+
+        // Then
+        val firstFlavor = limitedNames.first()
+        val lastFlavor = limitedNames.last()
+        val lastFlavorCapitalized = lastFlavor.capitalize()
+        assertThat(output.first()).isEqualTo(lastFlavor)
+        assertThat(output.last()).isEqualTo(
+            firstFlavor + limitedNames.drop(1).joinToString("") { it.capitalize() }
+        )
+        assertThat(output).allMatch {
+            // first flavor always appear first
+            if (it.contains(firstFlavor)) {
+                it.startsWith(firstFlavor)
+            } else true
+        }.allMatch {
+            // last flavor always appear last
+            if (it.contains(lastFlavorCapitalized)) {
+                it.endsWith(lastFlavorCapitalized)
+            } else if (it.contains(lastFlavor)) {
+                it == (lastFlavor)
+            } else true
+        }
+    }
+}

--- a/samples/variants/build.gradle
+++ b/samples/variants/build.gradle
@@ -29,7 +29,7 @@ android {
         java.srcDir("src/main/kotlin")
     }
 
-    flavorDimensions("version")
+    flavorDimensions("version", "colour")
     productFlavors {
         demo {
             dimension "version"
@@ -45,6 +45,16 @@ android {
             dimension "version"
             applicationIdSuffix ".pro"
             versionNameSuffix "-pro"
+        }
+
+        red {
+            dimension "colour"
+        }
+        green {
+            dimension "colour"
+        }
+        blue {
+            dimension "colour"
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Let customer define plugin configuration with partial variant names. 

### Additional Notes

This uses the same priority as the one defined in the Android compiler when resolving Source Sets.
