### PR TITLE
Use Kotlin stdlib8 instead of plain stdlib

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -37,7 +37,7 @@ object Dependencies {
 
     object Libraries {
 
-        const val Kotlin = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.Kotlin}"
+        const val Kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.Kotlin}"
         const val KotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
 
         const val OkHttp = "com.squareup.okhttp3:okhttp:${Versions.OkHttp}"

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -82,8 +82,8 @@ org.glassfish.jaxb:txw2:2.3.1                                   :   68 Kb
 org.jdom:jdom2:2.0.6                                            :  297 Kb
 org.jetbrains.kotlin:kotlin-reflect:1.4.0                       :    2 Mb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0                 :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72                  :    3 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72                  :   15 Kb
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0                   :    3 Kb
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0                   :   15 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.0                        : 1452 Kb
 org.jetbrains.trove4j:trove4j:20160824                          :  559 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb


### PR DESCRIPTION
### What does this PR do?

This change resolves the following compilation warning:

```
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /Users/<user>/.gradle/wrapper/dists/gradle-6.8.3-all/6czipnbiesy2sl92ioo8dht91/gradle-6.8.3/lib/kotlin-stdlib-1.4.20.jar (version 1.4)
    /Users/<user>/.gradle/wrapper/dists/gradle-6.8.3-all/6czipnbiesy2sl92ioo8dht91/gradle-6.8.3/lib/kotlin-stdlib-common-1.4.20.jar (version 1.4)
    /Users/<user>/.gradle/wrapper/dists/gradle-6.8.3-all/6czipnbiesy2sl92ioo8dht91/gradle-6.8.3/lib/kotlin-stdlib-jdk7-1.4.20.jar (version 1.4)
    /Users/<user>/.gradle/wrapper/dists/gradle-6.8.3-all/6czipnbiesy2sl92ioo8dht91/gradle-6.8.3/lib/kotlin-stdlib-jdk8-1.4.20.jar (version 1.4)
    /Users/<user>/.gradle/wrapper/dists/gradle-6.8.3-all/6czipnbiesy2sl92ioo8dht91/gradle-6.8.3/lib/kotlin-reflect-1.4.20.jar (version 1.4)
    /Users/<user>/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.0/aa2101a19d8688e368ae6e35e8967550ced73884/kotlin-reflect-1.4.0.jar (version 1.4)
    /Users/<user>/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.3.72/916d54b9eb6442b615e6f1488978f551c0674720/kotlin-stdlib-jdk8-1.3.72.jar (version 1.3)
    /Users/<user>/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.72/3adfc2f4ea4243e01204be8081fe63bde6b12815/kotlin-stdlib-jdk7-1.3.72.jar (version 1.3)
    /Users/<user>/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.4.0/63e75298e93d4ae0b299bb869cf0c627196f8843/kotlin-stdlib-1.4.0.jar (version 1.4)
    /Users/<user>/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.4.0/1c752cce0ead8d504ccc88a4fed6471fd83ab0dd/kotlin-stdlib-common-1.4.0.jar (version 1.4)
```
Which is caused by the fact that AGP depends on the Kotlin `stdlib8:1.3.72` (which is an extension of `stdlib` with Java 8 specific elements, while plain `stdlib` is `Java 6` compatible in simple words), dependency tree of `compileClasspath` configuration looks like that (simplified):

```
\--- com.android.tools.build:gradle:4.1.2
     +--- com.android.tools.build:builder:4.1.2
     |    +--- com.android.tools:sdklib:27.1.2
     |    |    +--- com.android.tools:repository:27.1.2
     |    |    |    +--- com.google.jimfs:jimfs:1.1
     |    |    |    |    \--- com.google.guava:guava:18.0 -> 28.1-jre (*)
     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72
     |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.0 (*)
     |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72
     |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 -> 1.4.0 (*)
```

Forcing to use `stdlib8` instead of `stdlib` resolves the issue. Everything works fine after the change, I checked it by publishing plugin to the local Maven and then using it in the real build.

More info on `stdlib` variants: https://stackoverflow.com/questions/51858596/which-standard-library-to-use-in-kotlin

