### PR TITLE
Use embedded Kotlin for the build script, bump Kotlin version to 1.4.20

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,9 +13,6 @@ plugins {
 }
 
 buildscript {
-    dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
-    }
     repositories {
         mavenCentral()
     }
@@ -34,8 +31,7 @@ repositories {
 dependencies {
 
     // Dependencies used to configure the gradle plugins
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+    implementation(embeddedKotlin("gradle-plugin"))
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.1")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
     implementation("com.android.tools.build:gradle:4.1.2")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -10,7 +10,7 @@ object Dependencies {
 
     object Versions {
         // Commons
-        const val Kotlin = "1.4.0"
+        const val Kotlin = "1.4.20"
         const val OkHttp = "3.12.6"
 
         // Android
@@ -37,7 +37,7 @@ object Dependencies {
 
     object Libraries {
 
-        const val Kotlin = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.Kotlin}"
+        const val Kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.Kotlin}"
         const val KotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
 
         const val OkHttp = "com.squareup.okhttp3:okhttp:${Versions.OkHttp}"

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -80,11 +80,11 @@ org.codehaus.mojo:animal-sniffer-annotations:1.18               :    3 Kb
 org.glassfish.jaxb:jaxb-runtime:2.3.1                           : 1067 Kb
 org.glassfish.jaxb:txw2:2.3.1                                   :   68 Kb
 org.jdom:jdom2:2.0.6                                            :  297 Kb
-org.jetbrains.kotlin:kotlin-reflect:1.4.0                       :    2 Mb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0                 :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72                  :    3 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72                  :   15 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.0                        : 1452 Kb
+org.jetbrains.kotlin:kotlin-reflect:1.4.20                      :    2 Mb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.20                  :   21 Kb
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.20                  :   15 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains.trove4j:trove4j:20160824                          :  559 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20180813                                          :   63 Kb

--- a/samples/basic/build.gradle
+++ b/samples/basic/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 //apply plugin: 'dd-sdk-android-gradle-plugin'
 
 import com.datadog.gradle.Dependencies

--- a/samples/variants/build.gradle
+++ b/samples/variants/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 //apply plugin: 'dd-sdk-android-gradle-plugin'
 
 import com.datadog.gradle.Dependencies


### PR DESCRIPTION
### What does this PR do?

Better version of #19. It takes advantage of Gradle 6.8.3 shipped with embedded Kotlin version 1.4.20 (originally update was done here https://github.com/gradle/gradle/commit/b5f89f1a7c1accc84806751c2c8941fae43cd33a to 1.4.10 and then also here https://github.com/gradle/gradle/commit/6f634d19a5bf4cb21af1ed9b2bffe3089a33efc3 to 1.4.20).

With Kotlin 1.4 there is no need to declare `stdlib` explicitly, it is added automatically: https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library (so I removed it in the `buildSrc`, but kept in the individual build scripts, just in case).

More on embedded Kotlin: https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:kotlin


