### PR TITLE
Fix POM file missing dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ publish:release-plugin:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin main
-    - ./gradlew :dd-sdk-android-gradle-plugin:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-gradle-plugin:publishPluginMavenPublicationToMavenRepository --stacktrace --no-daemon
 
 # SLACK NOTIFICATIONS
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -20,7 +20,7 @@ object MavenConfig {
 
     val VERSION = Version(1, 0, 0)
     const val GROUP_ID = "com.datadoghq"
-    const val PUBLICATION = "release"
+    const val PUBLICATION = "pluginMaven"
 }
 
 @Suppress("UnstableApiUsage")
@@ -65,8 +65,8 @@ fun Project.publishingConfig(projectDescription: String) {
                 }
             }
 
-            publications.create(MavenConfig.PUBLICATION, MavenPublication::class.java) {
-                artifact(tasks.findByName("jar"))
+            publications.getByName(MavenConfig.PUBLICATION) {
+                check(this is MavenPublication)
                 artifact(tasks.findByName("generateSourcesJar"))
                 artifact(tasks.findByName("generateJavadocJar"))
 


### PR DESCRIPTION
The Maven plugin creates a publication automatically for jar outputs with the relevant dependencies.
Instead of creating a "blank" publication, we can reuse the existing one and add the missing info there.
