### PR TITLE
Fix flaky VariantIterator test when one variant can contain another variant name

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
@@ -108,7 +108,11 @@ internal class VariantIteratorTest {
         @StringForgery(case = Case.LOWER) names: List<String>
     ) {
         // Given
-        val limitedNames = names.take(10) // limit the complexity of the data
+        // filtering is needed, because say there are 2 names: ["a", "bab"]. In this example
+        // assertion of allMatch below will fail, because "bab" contains "a" variant name,
+        // but doesn't start with it (as we would expect in case of combination)
+        val limitedNames = names.filter { item -> !names.any { it != item && it.contains(item) } }
+            .take(10) // limit the complexity of the data
         val iterator = VariantIterator(limitedNames)
 
         // When


### PR DESCRIPTION
### What does this PR do?

This change fixes flaky test in the case when one variant name contains another variant name. This makes assertion fail and I didn't find a good way to fix it at the assertion level, so let's apply more rules to the input.

