### PR TITLE
RUMM-1411 Remove credentials if any from GIT remote URL

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -12,16 +12,21 @@ import com.datadog.gradle.plugin.internal.GitRepositoryDetector
 import com.datadog.gradle.plugin.internal.MissingSdkException
 import com.datadog.gradle.plugin.internal.VariantIterator
 import java.io.File
+import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.process.ExecOperations
 import org.slf4j.LoggerFactory
 
 /**
  * Plugin adding tasks for Android projects using Datadog's SDK for Android.
  */
-class DdAndroidGradlePlugin : Plugin<Project> {
+class DdAndroidGradlePlugin @Inject constructor(
+    @Suppress("UnstableApiUsage") private val execOps: ExecOperations
+) :
+    Plugin<Project> {
 
     // region Plugin
 
@@ -81,7 +86,7 @@ class DdAndroidGradlePlugin : Plugin<Project> {
         val uploadTask = target.tasks.create(
             uploadTaskName,
             DdMappingFileUploadTask::class.java,
-            target.objects.newInstance(GitRepositoryDetector::class.java)
+            GitRepositoryDetector(execOps)
         )
         val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/FullUriGitRemoteUrlSanitizer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/FullUriGitRemoteUrlSanitizer.kt
@@ -1,0 +1,26 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+import java.net.URI
+import java.net.URISyntaxException
+import kotlin.jvm.Throws
+
+internal open class FullUriGitRemoteUrlSanitizer : UrlSanitizer {
+    @Throws(exceptionClasses = [URISyntaxException::class])
+    override fun sanitize(url: String): String {
+        val parsedUri = URI(url)
+        return if (parsedUri.userInfo.isNullOrEmpty()) {
+            url
+        } else {
+            val sanitizedUri = URI(
+                parsedUri.scheme,
+                null,
+                parsedUri.host,
+                parsedUri.port,
+                parsedUri.path,
+                parsedUri.query,
+                parsedUri.fragment
+            )
+            sanitizedUri.toString()
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizer.kt
@@ -1,0 +1,43 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+import java.util.Locale
+
+/**
+ * It will strip out the user information from the provided URL by applying the following rules:
+ * 1. In case the URL is a valid schema URL : ((ssh|http[s]?):\\) it will strip out the user
+ * information if any from it
+ * 2. In case the URL is a valid schema URL but by mistake the user forgot to add the schema:
+ * [username]:[password]@github.com/(.+).git it will strip out the user information if any and will
+ * return the new url
+ * 3. In case the URL is of a GIT SSH short format: [user@]github.com:(.+).git it will do
+ * nothing assuming that there is no password normally provided in a GIT SSH short format URL.
+ */
+internal class GitRemoteUrlSanitizer(
+    private val sanitizerResolver: (String) -> UrlSanitizer = {
+        if (it.matches(VALID_SCHEMA_URL_FORMAT_REGEX)) {
+            FullUriGitRemoteUrlSanitizer()
+        } else {
+            ShortUriGitRemoteUrlSanitizer()
+        }
+    }
+) : UrlSanitizer {
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    override fun sanitize(url: String): String {
+        try {
+            return sanitizerResolver(url).sanitize(url)
+        } catch (e: Exception) {
+            throw UriParsingException(WRONG_URL_FORMAT_ERROR_MESSAGE.format(url, Locale.US), e)
+        }
+    }
+
+    companion object {
+        const val WRONG_URL_FORMAT_ERROR_MESSAGE =
+            "The detected GIT remote url: [%s] is not a valid GIT url and it " +
+                "will not be browsable from the Error Tracking panel. " +
+                "You can provide a different URL through the plugin extension."
+        const val VALID_SCHEMA_URL_FORMAT_PATTERN = "^(ssh|http|https)://(.+)$"
+        val VALID_SCHEMA_URL_FORMAT_REGEX =
+            Regex(VALID_SCHEMA_URL_FORMAT_PATTERN, RegexOption.IGNORE_CASE)
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/ShortUriGitRemoteUrlSanitizer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/ShortUriGitRemoteUrlSanitizer.kt
@@ -1,0 +1,12 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+internal class ShortUriGitRemoteUrlSanitizer : FullUriGitRemoteUrlSanitizer() {
+    override fun sanitize(url: String): String {
+        val sanitizedUri = super.sanitize("$SSH_SCHEMA_PREFIX$url")
+        return sanitizedUri.removePrefix(SSH_SCHEMA_PREFIX)
+    }
+
+    companion object {
+        const val SSH_SCHEMA_PREFIX = "ssh://"
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/UriParsingException.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/UriParsingException.kt
@@ -1,0 +1,6 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+import java.lang.IllegalArgumentException
+
+internal class UriParsingException(message: String, throwable: Throwable) :
+    IllegalArgumentException(message, throwable)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/UrlSanitizer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/sanitizer/UrlSanitizer.kt
@@ -1,0 +1,5 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+internal interface UrlSanitizer {
+    fun sanitize(url: String): String
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -67,7 +67,7 @@ internal class DdAndroidGradlePluginTest {
     fun `set up`() {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
         fakeProject = ProjectBuilder.builder().build()
-        testedPlugin = DdAndroidGradlePlugin()
+        testedPlugin = DdAndroidGradlePlugin(mock())
     }
 
     // region configureVariant()

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizerTest.kt
@@ -1,0 +1,438 @@
+package com.datadog.gradle.plugin.internal.sanitizer
+
+import com.datadog.gradle.plugin.Configurator
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.lang.RuntimeException
+import java.util.Locale
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class GitRemoteUrlSanitizerTest {
+    lateinit var testedUrlSanitizer: GitRemoteUrlSanitizer
+
+    @BeforeEach
+    fun `set up`() {
+        testedUrlSanitizer = GitRemoteUrlSanitizer()
+    }
+
+    // region Tests
+
+    @Test
+    fun `M sanitize a HTTP url W sanitize()`(
+        @StringForgery(regex = "http[s]?")
+        fakeSchema: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            fakeSchema,
+            fakePort,
+            null,
+            null,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(fakeRemoteUrl)
+    }
+
+    @Test
+    fun `M sanitize a HTTP url W sanitize() { username and password provided }`(
+        @StringForgery(regex = "http[s]?")
+        fakeSchema: String,
+        @StringForgery fakeUserName: String,
+        @StringForgery fakePassword: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            fakeSchema,
+            fakePort,
+            fakeUserName,
+            fakePassword,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                fakeSchema,
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M sanitize a HTTP url W sanitize() { username provided }`(
+        @StringForgery(regex = "http[s]?")
+        fakeSchema: String,
+        @StringForgery fakeUserName: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            fakeSchema,
+            fakePort,
+            fakeUserName,
+            null,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                fakeSchema,
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M sanitize a short format SSH url W sanitize()`(
+        @StringForgery fakeUserName: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeShortFormatRemoteUrl(
+            fakeUserName,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(fakeRemoteUrl)
+    }
+
+    @Test
+    fun `M sanitize a SSH url W sanitize()`(
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            "ssh",
+            fakePort,
+            null,
+            null,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(fakeRemoteUrl)
+    }
+
+    @Test
+    fun `M sanitize a SSH url W sanitize() { username and password provided }`(
+        @StringForgery fakeUserName: String,
+        @StringForgery fakePassword: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            "ssh",
+            fakePort,
+            fakeUserName,
+            fakePassword,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                "ssh",
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M sanitize a SSH url W sanitize() { username provided }`(
+        @StringForgery fakeUserName: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            "ssh",
+            fakePort,
+            fakeUserName,
+            null,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                "ssh",
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M sanitize a missing schema url W sanitize()`(
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            null,
+            fakePort,
+            null,
+            null,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(fakeRemoteUrl)
+    }
+
+    @Test
+    fun `M sanitize a missing schema url W sanitize() { username and password provided }`(
+        @StringForgery fakeUserName: String,
+        @StringForgery fakePassword: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            null,
+            fakePort,
+            fakeUserName,
+            fakePassword,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                null,
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M sanitize a missing schema url W sanitize() { username provided }`(
+        @StringForgery fakePassword: String,
+        @StringForgery(
+            regex = "[a-z0-9]+\\.[a-z]{3}"
+        )
+        fakeHost: String,
+        @IntForgery(1, 99999) fakePort: Int,
+        @StringForgery fakeOwner: String,
+        @StringForgery fakeRepository: String
+    ) {
+        // Given
+        val fakeRemoteUrl = generateFakeFullRemoteUrl(
+            null,
+            fakePort,
+            null,
+            fakePassword,
+            fakeHost,
+            fakeOwner,
+            fakeRepository
+        )
+
+        // Then
+        assertThat(testedUrlSanitizer.sanitize(fakeRemoteUrl)).isEqualTo(
+            generateFakeFullRemoteUrl(
+                null,
+                fakePort,
+                null,
+                null,
+                fakeHost,
+                fakeOwner,
+                fakeRepository
+            )
+        )
+    }
+
+    @Test
+    fun `M throw a personal UriParsingException W sanitize() { strategy throws exception }`(
+        @StringForgery(regex = "[a-z]+@github\\.com/[a-z]+/[a-z0-9_]+\\.git")
+        fakeRemoteUrl: String,
+        @StringForgery fakeExceptioMessage: String
+    ) {
+        // Given
+        val fakeException = RuntimeException(fakeExceptioMessage)
+        val mockedResolvedSanitizer: UrlSanitizer = mock()
+        testedUrlSanitizer = GitRemoteUrlSanitizer(
+            sanitizerResolver = {
+                mockedResolvedSanitizer
+            }
+        )
+        doThrow(fakeException).whenever(mockedResolvedSanitizer).sanitize(fakeRemoteUrl)
+
+        // When
+        val caughtException = catchThrowable {
+            testedUrlSanitizer.sanitize(fakeRemoteUrl)
+        }
+
+        // Then
+        assertThat(caughtException).isInstanceOf(UriParsingException::class.java)
+        val expectedErrorMessage = GitRemoteUrlSanitizer.WRONG_URL_FORMAT_ERROR_MESSAGE.format(
+            fakeRemoteUrl,
+            Locale.US
+        )
+        assertThat(caughtException.message).startsWith(expectedErrorMessage)
+        assertThat(caughtException.cause).isEqualTo(fakeException)
+    }
+
+    // endregion
+
+    // region Internals
+
+    private fun generateFakeFullRemoteUrl(
+        schema: String?,
+        port: Int,
+        username: String?,
+        password: String?,
+        host: String,
+        owner: String,
+        repository: String
+    ): String {
+        val builder = StringBuilder()
+        if (schema != null) {
+            builder.append(schema)
+            builder.append("://")
+        }
+        if (username != null) {
+            builder.append(username)
+            if (password != null) {
+                builder.append(":")
+                builder.append(username)
+            }
+            builder.append("@")
+        }
+        builder.append(host)
+        builder.append(":")
+        builder.append(port)
+        builder.append("/")
+        builder.append(owner)
+        builder.append("/")
+        builder.append(repository)
+        builder.append(".git")
+        return builder.toString()
+    }
+
+    private fun generateFakeShortFormatRemoteUrl(
+        username: String?,
+        host: String,
+        owner: String,
+        repository: String
+    ): String {
+        return "$username&$host/$owner/$repository.git"
+    }
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

There were reported situations when the client was using an `HTTPS` Git Remote URL which contained also the `username` and `password`: `https://username:password@github.com/username/repository.git`. In this case we were uploading the full URL together with the `mapping.txt` file to our DD servers.

In this PR we are sanitizing the URL and we remove the user information if any.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

