### PR TITLE
RUMM-1412 Add remote repository URL into the plugin extension

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -190,6 +190,7 @@ class DdAndroidGradlePlugin @Inject constructor(
         uploadTask.site = extensionConfiguration.site ?: ""
         uploadTask.versionName = extensionConfiguration.versionName ?: variant.versionName
         uploadTask.serviceName = extensionConfiguration.serviceName ?: variant.applicationId
+        uploadTask.remoteRepositoryUrl = extensionConfiguration.remoteRepositoryUrl ?: ""
     }
 
     internal fun resolveExtensionConfiguration(

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -27,6 +27,12 @@ open class DdExtensionConfiguration(
     var site: String? = null
 
     /**
+     * The url of the remote repository where the source code was deployed. If not provided this
+     * value will be resolved from your current GIT configuration during the task execution time.
+     */
+    var remoteRepositoryUrl: String? = null
+
+    /**
      * This property controls if plugin should check if Datadog SDK is included in the dependencies
      * and if it is not: "none" - ignore, "warn" - log a warning, "fail" - fail the build
      * with an error (default).
@@ -37,6 +43,7 @@ open class DdExtensionConfiguration(
         config.versionName?.let { versionName = it }
         config.serviceName?.let { serviceName = it }
         config.site?.let { site = it }
+        config.remoteRepositoryUrl?.let { remoteRepositoryUrl = it }
         config.checkProjectDependencies?.let { checkProjectDependencies = it }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -64,6 +64,12 @@ open class DdMappingFileUploadTask
     var site: String = ""
 
     /**
+     * The url of the remote repository where the source code was deployed.
+     */
+    @get: Input
+    var remoteRepositoryUrl: String = ""
+
+    /**
      * The path to the mapping file to upload.
      */
     @get:Input
@@ -100,7 +106,8 @@ open class DdMappingFileUploadTask
         val mappingFile = File(mappingFilePath)
         if (!validateMappingFile(mappingFile)) return
 
-        val repositories = repositoryDetector.detectRepositories(sourceSetRoots)
+        val repositories =
+            repositoryDetector.detectRepositories(sourceSetRoots, remoteRepositoryUrl)
         if (repositories.isNotEmpty()) {
             generateRepositoryFile(repositories)
         }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryDetector.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryDetector.kt
@@ -12,9 +12,13 @@ interface RepositoryDetector {
     /**
      * Perform a local analysis of the repository.
      * @param sourceSetRoots the list of relevant sourceSet root folders
+     * @param extensionProvidedRemoteUrl the remote repository url provided in the plugin extension. If this
+     * value is empty (not provided) we will automatically extract the default URL from GIT
+     * configuration.
      * @return a list of [RepositoryInfo] describing the underlying Gradle [Project]
      */
     fun detectRepositories(
-        sourceSetRoots: List<File>
+        sourceSetRoots: List<File>,
+        extensionProvidedRemoteUrl: String = ""
     ): List<RepositoryInfo>
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -107,6 +107,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.variantName).isEqualTo(flavorName)
         assertThat(task.versionName).isEqualTo(versionName)
         assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.mappingFilePath)
             .isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
@@ -145,6 +146,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.variantName).isEqualTo(flavorName)
         assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.mappingFilePath)
             .isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
@@ -161,6 +163,7 @@ internal class DdAndroidGradlePluginTest {
         fakeExtension.serviceName = null
         fakeExtension.versionName = null
         fakeExtension.site = null
+        fakeExtension.remoteRepositoryUrl = null
         val variantName = "$flavorName${buildTypeName.capitalize()}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
@@ -186,6 +189,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.variantName).isEqualTo(flavorName)
         assertThat(task.versionName).isEqualTo(versionName)
         assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo("")
         assertThat(task.mappingFilePath)
             .isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
@@ -302,6 +306,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(fakeExtension.checkProjectDependencies)
     }
@@ -322,6 +327,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(variantConfig.versionName)
         assertThat(config.serviceName).isEqualTo(variantConfig.serviceName)
         assertThat(config.site).isEqualTo(variantConfig.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfig.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfig.checkProjectDependencies)
     }
@@ -345,6 +351,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(fakeExtension.checkProjectDependencies)
     }
@@ -368,6 +375,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(fakeExtension.checkProjectDependencies)
     }
@@ -391,6 +399,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(site.name)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies).isEqualTo(
             fakeExtension.checkProjectDependencies
         )
@@ -415,7 +424,33 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies).isEqualTo(sdkCheckLevel)
+    }
+
+    @Test
+    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w remoteUrl only }`(
+        @Forgery fakeConfig: DdExtensionConfiguration
+    ) {
+        val variantName = fakeFlavorNames.variantName()
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        val incompleteConfig = DdExtensionConfiguration().apply {
+            this.remoteRepositoryUrl = fakeConfig.remoteRepositoryUrl
+        }
+        fakeExtension.variants = mock()
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
+
+        // When
+        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
+
+        // Then
+        assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
+        assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(incompleteConfig.remoteRepositoryUrl)
+        assertThat(config.checkProjectDependencies).isEqualTo(
+            fakeExtension.checkProjectDependencies
+        )
     }
 
     @Test
@@ -452,6 +487,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.site).isEqualTo(variantConfigA.site)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfigC.checkProjectDependencies)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfigA.remoteRepositoryUrl)
     }
 
     @Test
@@ -486,6 +522,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.site).isEqualTo(variantConfigAB.site)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfigAB.checkProjectDependencies)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfigAB.remoteRepositoryUrl)
     }
 
     @Test
@@ -506,6 +543,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.site).isEqualTo(configuration.site)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(configuration.checkProjectDependencies)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(configuration.remoteRepositoryUrl)
     }
 
     // endregion
@@ -706,12 +744,7 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
-    fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { extension is disabled }`(
-        @StringForgery(case = Case.LOWER) flavorName: String,
-        @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
-    ) {
+    fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { extension is disabled }`() {
         // Given
         fakeExtension.enabled = false
 
@@ -728,9 +761,7 @@ internal class DdAndroidGradlePluginTest {
     @Test
     fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { compilation task not found }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
-        @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
+        @StringForgery(case = Case.LOWER) buildTypeName: String
     ) {
 
         // let's check that there are no tasks just in case if setup is modified

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
@@ -16,6 +16,9 @@ internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensi
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}")
             versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
             site = forge.aValueFrom(DdConfiguration.Site::class.java).name
+            remoteRepositoryUrl = forge.aStringMatching(
+                "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git"
+            )
             checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
         }
     }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
@@ -86,6 +86,34 @@ internal class GitRepositoryDetectorTest {
     }
 
     @Test
+    fun `𝕄 use the sanitized config remote URL 𝕎 detectRepository() { remote URL provided }`(
+        @StringForgery(regex = "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git")
+        fakeConfigRemoteUrl: String,
+        @StringForgery(regex = "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git")
+        fakeSanitizedConfigRemoteUrl: String
+    ) {
+        // Given
+        initializeGit()
+        whenever(mockedUrlSanitizer.sanitize(fakeConfigRemoteUrl)).thenReturn(
+            fakeSanitizedConfigRemoteUrl
+        )
+
+        // When
+        val result = testedDetector.detectRepositories(
+            fakeSourceSetFolders,
+            fakeConfigRemoteUrl
+        )
+
+        // Then
+        assertThat(result).hasSize(1)
+        val repository = result.first()
+        assertThat(repository.url).isEqualTo(fakeSanitizedConfigRemoteUrl)
+        assertThat(repository.hash).isNotNull().isNotBlank()
+        assertThat(repository.sourceFiles)
+            .containsExactlyInAnyOrder(*fakeTrackedFiles.toTypedArray())
+    }
+
+    @Test
     fun `𝕄 return empty list 𝕎 detectRepository() { not inside a git repository }`() {
         // When
         val result = testedDetector.detectRepositories(fakeSourceSetFolders)

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -73,6 +73,39 @@ datadog {
 {{% /tab %}}
 {{< /tabs >}}
 
+### Plugin Configuration Options
+
+There are several plugin properties that can be configured through the plugin extension. In case you are using multiple variants you can set a property value for a specific flavour in the variant.
+
+**Example:**
+
+For a variant `fooBarRelease` you could have the following configuration:
+
+```groovy
+datadog {
+    foo {
+        versionName = "foo"
+    }
+    bar {
+        versionName = "bar"
+    }
+    fooBar {
+        versionName = "fooBar"
+    }
+}
+```
+
+The task config for this variant will be merged from all the 3 provided flavours configs in the
+following order: `bar` -> `foo` -> `fooBar` which will resolve the final value for the `versionName`
+property as : `fooBar`
+
+| Property name              | Description                                                                                                                                                                                               |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `versionName`              | The version name of the application.                                                                                                                                                                      |
+| `serviceName`              | The service name of the application.                                                                                                                                                                      |
+| `site`                     | The Datadog site to upload your data to (one of "US", "EU", "GOV").                                                                                                                                       |
+| `remoteRepositoryUrl`      | The url of the remote repository where the source code was deployed.  If not provided this value will be resolved from your current GIT configuration during the task execution time.                     |
+| `checkProjectDependencies` | This property controls if plugin should check if Datadog SDK is included in the dependencies and if it is not:  "none" - ignore, "warn" - log a warning, "fail" - fail the build with an error (default). |
 
 
 ## Troubleshoot errors


### PR DESCRIPTION
### What does this PR do?

This **PR** adds the capability to be able to set the GIT remote URL of your source code  through the `dd-sdk-android-gradle-plugin` extension. This property is optional in the plugin extension and if not provided will be resolved from the user's GIT configuration during the `uploadMapping` task execution.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

