### PR TITLE
RUMM-1451: Support Gradle configuration cache

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -5,6 +5,7 @@ build,org.jetbrains.dokka,Apache-2.0,"Copyright 2014-2019 JetBrains s.r.o. and D
 import,com.android.tools.build,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
 import,com.squareup.okhttp3,Apache-2.0,"Copyright 2019 Square, Inc"
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
+import,org.json,JSON,Copyright (c) 2002 JSON.org
 import(test),com.github.xgouchet.Elmyr,MIT,Copyright 2017-2019 Xavier F. Gouchet
 import(test),com.nhaarman.mockitokotlin2,MIT,"Copyright (c) 2018 Niek Haarman, Copyright (c) 2007 Mockito contributors"
 import(test),net.wuerl.kotlin,Apache-2.0,Copyright 2016 Andreas Würl

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(embeddedKotlin("gradle-plugin"))
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.1")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
-    implementation("com.android.tools.build:gradle:4.1.2")
+    implementation("com.android.tools.build:gradle:4.2.1")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.10")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -12,6 +12,7 @@ object Dependencies {
         // Commons
         const val Kotlin = "1.4.20"
         const val OkHttp = "3.12.6"
+        const val Json = "20180813"
 
         // Android
         const val AndroidToolsPlugin = "4.1.2"
@@ -40,6 +41,8 @@ object Dependencies {
         const val KotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
 
         const val OkHttp = "com.squareup.okhttp3:okhttp:${Versions.OkHttp}"
+
+        const val Json = "org.json:json:${Versions.Json}"
 
         @JvmField
         val JUnit5 = arrayOf(

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -15,7 +15,7 @@ object Dependencies {
         const val Json = "20180813"
 
         // Android
-        const val AndroidToolsPlugin = "4.1.2"
+        const val AndroidToolsPlugin = "4.2.1"
 
         // JUnit
         const val JUnitJupiter = "5.6.2"

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -43,11 +43,14 @@ dependencies {
     implementation(Dependencies.Libraries.Kotlin)
     implementation(Dependencies.Libraries.KotlinReflect)
     implementation(Dependencies.Libraries.OkHttp)
-    implementation(Dependencies.ClassPaths.AndroidTools)
+    implementation(Dependencies.Libraries.Json)
+    // because auto-wiring into Android projects
+    compileOnly(Dependencies.ClassPaths.AndroidTools)
 
     testImplementation(Dependencies.Libraries.JUnit5)
     testImplementation(Dependencies.Libraries.TestTools)
     testImplementation(Dependencies.Libraries.OkHttpMock)
+    testImplementation(Dependencies.ClassPaths.AndroidTools)
 
     detekt(Dependencies.Libraries.DetektCli)
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -84,6 +84,8 @@ open class DdMappingFileUploadTask
     init {
         group = "datadog"
         description = "Uploads the Proguard/R8 mapping file to Datadog"
+        // it is never up-to-date, because request may fail
+        outputs.upToDateWhen { false }
     }
 
     // region Task
@@ -98,7 +100,7 @@ open class DdMappingFileUploadTask
         val mappingFile = File(mappingFilePath)
         if (!validateMappingFile(mappingFile)) return
 
-        val repositories = repositoryDetector.detectRepositories(project, sourceSetRoots)
+        val repositories = repositoryDetector.detectRepositories(sourceSetRoots)
         if (repositories.isNotEmpty()) {
             generateRepositoryFile(repositories)
         }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryDetector.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryDetector.kt
@@ -11,12 +11,10 @@ interface RepositoryDetector {
 
     /**
      * Perform a local analysis of the repository.
-     * @param project the Gradle [Project] to analyse
      * @param sourceSetRoots the list of relevant sourceSet root folders
      * @return a list of [RepositoryInfo] describing the underlying Gradle [Project]
      */
     fun detectRepositories(
-        project: Project,
         sourceSetRoots: List<File>
     ): List<RepositoryInfo>
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetector.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetector.kt
@@ -4,30 +4,33 @@ import com.datadog.gradle.plugin.DdAndroidGradlePlugin.Companion.LOGGER
 import com.datadog.gradle.plugin.RepositoryDetector
 import com.datadog.gradle.plugin.RepositoryInfo
 import java.io.File
-import org.gradle.api.Project
+import javax.inject.Inject
+import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecException
 
 // TODO RUMM-1095 handle git submodules
 // TODO RUMM-1096 handle git subtrees
 // TODO RUMM-1093 let customer override `origin` with custom remote name
-internal class GitRepositoryDetector : RepositoryDetector {
+internal open class GitRepositoryDetector
+@Inject constructor(
+    @Suppress("UnstableApiUsage") private val execOperations: ExecOperations
+) : RepositoryDetector {
 
     @Suppress("StringLiteralDuplication")
     override fun detectRepositories(
-        project: Project,
         sourceSetRoots: List<File>
     ): List<RepositoryInfo> {
         try {
-            project.execShell("git", "rev-parse", "--is-inside-work-tree")
+            execOperations.execShell("git", "rev-parse", "--is-inside-work-tree")
         } catch (e: ExecException) {
             LOGGER.error("Project is not a git repository", e)
             return emptyList()
         }
 
-        val remoteUrl = project.execShell("git", "remote", "get-url", "origin").trim()
-        val commitHash = project.execShell("git", "rev-parse", "HEAD").trim()
+        val remoteUrl = execOperations.execShell("git", "remote", "get-url", "origin").trim()
+        val commitHash = execOperations.execShell("git", "rev-parse", "HEAD").trim()
 
-        val trackedFiles = listTrackedFilesPath(project, sourceSetRoots)
+        val trackedFiles = listTrackedFilesPath(sourceSetRoots)
 
         return listOf(
             RepositoryInfo(
@@ -41,26 +44,24 @@ internal class GitRepositoryDetector : RepositoryDetector {
     // region Internal
 
     private fun listTrackedFilesPath(
-        project: Project,
         sourceSetRoots: List<File>
     ): List<String> {
         val files = mutableListOf<String>()
         sourceSetRoots.forEach { sourceSetRoot ->
             if (sourceSetRoot.exists() && sourceSetRoot.isDirectory) {
-                listFilePathsInFolder(project, sourceSetRoot, files)
+                listFilePathsInFolder(sourceSetRoot, files)
             }
         }
         return files
     }
 
     private fun listFilePathsInFolder(
-        project: Project,
         sourceSetRoot: File,
         files: MutableList<String>
     ) {
 
         // output will be relative to the project root
-        val sourceSetFiles = project.execShell(
+        val sourceSetFiles = execOperations.execShell(
             "git",
             "ls-files",
             sourceSetRoot.absolutePath

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -22,11 +22,14 @@ internal class OkHttpUploader : Uploader {
 
     // region Uploader
 
-    internal val client = OkHttpClient
-        .Builder()
-        .callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-        .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-        .build()
+    // we cannot make it a property with a backing field, because serialization of this field is not
+    // supported (serialization is used by configuration cache)
+    internal val client
+        get() = OkHttpClient
+            .Builder()
+            .callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .build()
 
     @Suppress("TooGenericExceptionCaught")
     override fun upload(
@@ -102,7 +105,7 @@ internal class OkHttpUploader : Uploader {
             statusCode == null -> throw RuntimeException(
                 "Unable to upload mapping file for $identifier; check your network connection"
             )
-            statusCode in succesfulCodes -> LOGGER.info(
+            statusCode in successfulCodes -> LOGGER.info(
                 "Mapping file upload successful for $identifier"
             )
             statusCode == HttpURLConnection.HTTP_FORBIDDEN -> throw IllegalStateException(
@@ -124,10 +127,10 @@ internal class OkHttpUploader : Uploader {
         internal val MEDIA_TYPE_TXT = MediaType.parse("text/plain")
         internal val MEDIA_TYPE_JSON = MediaType.parse("application/json")
         internal const val MAX_MAP_FILE_SIZE_IN_BYTES = 50L * 1024L * 1024L // 50 MB
-        internal val MAX_MAP_SIZE_EXCEEDED_ERROR_FORMAT =
+        internal const val MAX_MAP_SIZE_EXCEEDED_ERROR_FORMAT =
             "The proguard mapping file at: [%s] size exceeded the maximum 50 MB size. " +
                 "This task cannot be performed."
-        internal val succesfulCodes = arrayOf(
+        internal val successfulCodes = arrayOf(
             HttpURLConnection.HTTP_OK,
             HttpURLConnection.HTTP_CREATED,
             HttpURLConnection.HTTP_ACCEPTED

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/ProjectExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/ProjectExt.kt
@@ -2,10 +2,11 @@ package com.datadog.gradle.plugin.internal
 
 import com.datadog.gradle.plugin.DdAndroidGradlePlugin.Companion.LOGGER
 import java.io.ByteArrayOutputStream
-import org.gradle.api.Project
+import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecException
 
-internal fun Project.execShell(vararg command: String): String {
+@Suppress("UnstableApiUsage")
+internal fun ExecOperations.execShell(vararg command: String): String {
     val outputStream = ByteArrayOutputStream()
     val errorStream = ByteArrayOutputStream()
     try {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -627,7 +627,7 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
-    fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { sdk is missing w none set }`(
+    fun `𝕄 do nothing 𝕎 configureVariantForSdkCheck() { none set }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -653,13 +653,13 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.runtimeConfiguration) doReturn mockConfiguration
 
         // When + Then
-        assertDoesNotThrow {
+        assertThat(
             testedPlugin.configureVariantForSdkCheck(
                 fakeProject,
                 mockVariant,
                 fakeExtension
-            )!!.actions.first().execute(fakeCompileTask)
-        }
+            )!!.actions
+        ).isEmpty()
     }
 
     @Test

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -110,7 +110,7 @@ internal class DdMappingFileUploadTaskTest {
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
         val expectedUrl = DdConfiguration(fakeSite, fakeApiKey).buildUrl()
-        whenever(mockRepositoryDetector.detectRepositories(any(), any()))
+        whenever(mockRepositoryDetector.detectRepositories(any()))
             .doReturn(listOf(fakeRepoInfo))
 
         // When
@@ -143,7 +143,7 @@ internal class DdMappingFileUploadTaskTest {
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
         val expectedUrl = DdConfiguration(fakeSite, fakeApiKey).buildUrl()
-        whenever(mockRepositoryDetector.detectRepositories(any(), any()))
+        whenever(mockRepositoryDetector.detectRepositories(any()))
             .doReturn(emptyList())
 
         // When
@@ -213,7 +213,7 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.repositoryFile = fakeRepositoryFile
         testedTask.site = ""
         val expectedUrl = DdConfiguration(DdConfiguration.Site.US, fakeApiKey).buildUrl()
-        whenever(mockRepositoryDetector.detectRepositories(any(), any()))
+        whenever(mockRepositoryDetector.detectRepositories(any()))
             .doReturn(listOf(fakeRepoInfo))
 
         // When

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
@@ -10,6 +10,8 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
+import org.gradle.api.internal.project.DefaultProject
+import org.gradle.process.internal.DefaultExecOperations
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -42,6 +44,7 @@ internal class GitRepositoryDetectorTest {
 
     lateinit var fakeTrackedFiles: List<String>
 
+    @Suppress("UnstableApiUsage")
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeProject = ProjectBuilder.builder()
@@ -50,7 +53,9 @@ internal class GitRepositoryDetectorTest {
 
         initializeSourceSets(forge)
 
-        testedDetector = GitRepositoryDetector()
+        testedDetector = GitRepositoryDetector(
+            DefaultExecOperations((fakeProject as DefaultProject).processOperations)
+        )
     }
 
     @Test
@@ -59,7 +64,7 @@ internal class GitRepositoryDetectorTest {
         initializeGit()
 
         // When
-        val result = testedDetector.detectRepositories(fakeProject, fakeSourceSetFolders)
+        val result = testedDetector.detectRepositories(fakeSourceSetFolders)
 
         // Then
         assertThat(result).hasSize(1)
@@ -73,7 +78,7 @@ internal class GitRepositoryDetectorTest {
     @Test
     fun `𝕄 return empty list 𝕎 detectRepository() { not inside a git repository }`() {
         // When
-        val result = testedDetector.detectRepositories(fakeProject, fakeSourceSetFolders)
+        val result = testedDetector.detectRepositories(fakeSourceSetFolders)
 
         // Then
         assertThat(result).hasSize(0)

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -1,100 +1,15 @@
 Dependencies List
 
 .gradle:caches:6.8.3                                            :  139 Mb
-androidx.databinding:databinding-common:4.1.2                   :   15 Kb
-androidx.databinding:databinding-compiler-common:4.1.2          :  472 Kb
-com.android.databinding:baseLibrary:4.1.2                       :   15 Kb
-com.android.tools.analytics-library:crash:27.1.2                :   13 Kb
-com.android.tools.analytics-library:protos:27.1.2               :    3 Mb
-com.android.tools.analytics-library:shared:27.1.2               :  101 Kb
-com.android.tools.analytics-library:tracker:27.1.2              :   37 Kb
-com.android.tools.build.jetifier:jetifier-core:1.0.0-beta09     :  125 Kb
-com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta09:  164 Kb
-com.android.tools.build:aapt2-proto:4.1.2-6503028               :  657 Kb
-com.android.tools.build:aaptcompiler:4.1.2                      :  464 Kb
-com.android.tools.build:apksig:4.1.2                            :  385 Kb
-com.android.tools.build:apkzlib:4.1.2                           :  199 Kb
-com.android.tools.build:builder-model:4.1.2                     :   50 Kb
-com.android.tools.build:builder-test-api:4.1.2                  :   15 Kb
-com.android.tools.build:builder:4.1.2                           :    9 Mb
-com.android.tools.build:bundletool:0.14.0                       :    7 Mb
-com.android.tools.build:gradle-api:4.1.2                        :  142 Kb
-com.android.tools.build:gradle:4.1.2                            :    5 Mb
-com.android.tools.build:manifest-merger:27.1.2                  :  198 Kb
-com.android.tools.build:transform-api:2.0.0-deprecated-use-gradle-api:  261 b 
-com.android.tools.ddms:ddmlib:27.1.2                            :  467 Kb
-com.android.tools.layoutlib:layoutlib-api:27.1.2                :  112 Kb
-com.android.tools.lint:lint-gradle-api:27.1.2                   :   19 Kb
-com.android.tools.lint:lint-model:27.1.2                        :  171 Kb
-com.android.tools:annotations:27.1.2                            :   10 Kb
-com.android.tools:common:27.1.2                                 :  274 Kb
-com.android.tools:dvlib:27.1.2                                  :   40 Kb
-com.android.tools:repository:27.1.2                             :  198 Kb
-com.android.tools:sdk-common:27.1.2                             : 1496 Kb
-com.android.tools:sdklib:27.1.2                                 :  621 Kb
-com.android:signflinger:4.1.2                                   :   15 Kb
-com.android:zipflinger:4.1.2                                    :   47 Kb
-com.google.auto.value:auto-value-annotations:1.6.2              :    5 Kb
-com.google.code.findbugs:jsr305:3.0.2                           :   19 Kb
-com.google.code.gson:gson:2.8.5                                 :  235 Kb
-com.google.crypto.tink:tink:1.3.0-rc2                           : 1112 Kb
-com.google.errorprone:error_prone_annotations:2.3.2             :   12 Kb
-com.google.flatbuffers:flatbuffers-java:1.12.0                  :   63 Kb
-com.google.guava:failureaccess:1.0.1                            :    4 Kb
-com.google.guava:guava:28.1-jre                                 :    2 Mb
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava:    2 Kb
-com.google.j2objc:j2objc-annotations:1.3                        :    8 Kb
-com.google.jimfs:jimfs:1.1                                      :  201 Kb
-com.google.protobuf:protobuf-java-util:3.10.0                   :   72 Kb
-com.google.protobuf:protobuf-java:3.10.0                        : 1625 Kb
-com.google.test.platform:core-proto:0.0.2-dev                   :  858 Kb
-com.googlecode.json-simple:json-simple:1.1                      :   15 Kb
-com.googlecode.juniversalchardet:juniversalchardet:1.0.3        :  215 Kb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
-com.squareup:javapoet:1.10.0                                    :   95 Kb
-com.squareup:javawriter:2.5.0                                   :   12 Kb
-com.sun.activation:javax.activation:1.2.0                       :   76 Kb
-com.sun.istack:istack-commons-runtime:3.0.7                     :   24 Kb
-com.sun.xml.fastinfoset:FastInfoset:1.2.15                      :  304 Kb
-commons-codec:commons-codec:1.10                                :  277 Kb
-commons-io:commons-io:2.4                                       :  180 Kb
-commons-logging:commons-logging:1.2                             :   60 Kb
-it.unimi.dsi:fastutil:7.2.0                                     :   16 Mb
-javax.activation:javax.activation-api:1.2.0                     :   55 Kb
-javax.inject:javax.inject:1                                     :    2 Kb
-javax.xml.bind:jaxb-api:2.3.1                                   :  125 Kb
-net.sf.jopt-simple:jopt-simple:4.9                              :   64 Kb
-net.sf.kxml:kxml2:2.3.0                                         :   42 Kb
-net.sf.proguard:proguard-base:6.0.3                             : 1246 Kb
-net.sf.proguard:proguard-gradle:6.0.3                           :   12 Kb
-org.antlr:antlr4:4.5.3                                          : 1450 Kb
-org.apache.commons:commons-compress:1.12                        :  432 Kb
-org.apache.httpcomponents:httpclient:4.5.6                      :  749 Kb
-org.apache.httpcomponents:httpcore:4.4.10                       :  318 Kb
-org.apache.httpcomponents:httpmime:4.5.6                        :   40 Kb
-org.bouncycastle:bcpkix-jdk15on:1.56                            :  669 Kb
-org.bouncycastle:bcprov-jdk15on:1.56                            :    3 Mb
-org.checkerframework:checker-qual:2.8.1                         :  195 Kb
-org.codehaus.mojo:animal-sniffer-annotations:1.18               :    3 Kb
-org.glassfish.jaxb:jaxb-runtime:2.3.1                           : 1067 Kb
-org.glassfish.jaxb:txw2:2.3.1                                   :   68 Kb
-org.jdom:jdom2:2.0.6                                            :  297 Kb
 org.jetbrains.kotlin:kotlin-reflect:1.4.20                      :    2 Mb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.20                  :   21 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.20                  :   15 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
-org.jetbrains.trove4j:trove4j:20160824                          :  559 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20180813                                          :   63 Kb
-org.jvnet.staxex:stax-ex:1.8                                    :   35 Kb
-org.ow2.asm:asm-analysis:7.0                                    :   32 Kb
-org.ow2.asm:asm-commons:7.0                                     :   77 Kb
-org.ow2.asm:asm-tree:7.0                                        :   49 Kb
-org.ow2.asm:asm-util:7.0                                        :   78 Kb
-org.ow2.asm:asm:7.0                                             :  111 Kb
-org.tensorflow:tensorflow-lite-metadata:0.1.0-rc1               :  330 Kb
 gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         : 1607 b 
 gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :    8 Mb
 gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :    2 Mb
@@ -103,5 +18,5 @@ gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :  186 Kb
 gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :   21 Kb
 gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :   15 Kb
 
-Total transitive dependencies size                              :  224 Mb
+Total transitive dependencies size                              :  156 Mb
 


### PR DESCRIPTION
### What does this PR do?

This change adds support of configuration cache. Currently, if we run task with `--configuration-cache` flag, the following errors happen claiming it cannot serialize task:

1. Execution of upload task:

```
value NativePRNG failed Java Object Serialization
field secureRandom of sun.security.ssl.SSLContextImpl$TLSContext
bean of type sun.security.ssl.SSLContextImpl$TLSContext
field context of sun.security.ssl.SSLSocketFactoryImpl
bean of type sun.security.ssl.SSLSocketFactoryImpl
field sslSocketFactory of okhttp3.OkHttpClient
bean of type okhttp3.OkHttpClient
field client of com.datadog.gradle.plugin.internal.OkHttpUploader
bean of type com.datadog.gradle.plugin.internal.OkHttpUploader
field uploader of com.datadog.gradle.plugin.DdMappingFileUploadTasktask:samples:variants:uploadMappingFullRedRelease of type com.datadog.gradle.plugin.DdMappingFileUploadTask
```

This happens because of the OkHttp client, which is not actually needed during the serialization, so we can remove it from serialization by removing backing field from `client`. Simply adding `@Transient` doesn't work, because on deserialization we get `null`. This non-obvious issue is described in the following ticket https://youtrack.jetbrains.com/issue/KT-23998.

Also we have to remove usages of `project.exec` and replace it with `ExecOperations`. `ExecOperations` is incubating as of Gradle 6.8.3, but it is available since Gradle 6.1 and was de-incubated with Gradle 7 https://github.com/gradle/gradle/pull/15574.

2. Execution of SDK library check task (which is linked to the compilation task): see in #39. This happens because `Configuration` access from task level is not supported by configuration cache. And the necessary API to access it in the lazy way is missing: see https://github.com/gradle/gradle/issues/12871 and https://issuetracker.google.com/issues/162074215. For now we will just skip configuration access if plugin configuration has sdk check level set to `none` to allow using configuration cache for experienced users.

Apart of the issues above related purely to the configuration cache, this change also does the following:

1. Makes Android Gradle plugin `compileOnly`, so that it is not included in the final artifact. Since our plugin is supposed to be used with Android Gradle plugin being in the classpath, it is safe thing to do, and having version `4.1.2` included in the artifact was causing issues when newer Android Gradle Plugin exists in classpath as well.
2. Newer versions of Android Gradle plugin don't have `org.json` in transitive dependencies, so it was expicitly added to the list of dependencies.
3. Upload task will never be `up-to-date` now so that it can be always executed. Because it could be cached before even if network request failed.

Fixes #39.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

