### PR TITLE
Remove Gradle API from dependencies

### DIFF
--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -39,7 +39,6 @@ plugins {
 }
 
 dependencies {
-    implementation(gradleApi())
     implementation(Dependencies.Libraries.Kotlin)
     implementation(Dependencies.Libraries.KotlinReflect)
     implementation(Dependencies.Libraries.OkHttp)

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -1,6 +1,5 @@
 Dependencies List
 
-.gradle:caches:6.8.3                                            :  139 Mb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-reflect:1.4.20                      :    2 Mb
@@ -10,13 +9,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.20                  :   15 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20180813                                          :   63 Kb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         : 1607 b 
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :    8 Mb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :    2 Mb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         : 1453 Kb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :  186 Kb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :   21 Kb
-gradle-6.8.3-all:6czipnbiesy2sl92ioo8dht91:gradle-6.8.3         :   15 Kb
 
-Total transitive dependencies size                              :  156 Mb
+Total transitive dependencies size                              :    5 Mb
 


### PR DESCRIPTION
### What does this PR do?

This change remove Gradle API from dependencies, because it is automatically added by `java-gradle-plugin` as stated in the https://docs.gradle.org/current/userguide/custom_plugins.html#sec:custom_plugins_standalone_project:

> The easiest and the recommended way to package and publish a plugin is to use the Java Gradle Plugin Development Plugin. This plugin will automatically apply the Java Plugin, add the gradleApi() dependency to the api configuration, generate the required plugin descriptors in the resulting JAR file and configure the Plugin Marker Artifact to be used when publishing.

Moreover, in the end `gradleApi` is added as `api` dependency (https://github.com/gradle/gradle/blob/cb232651cd8fd2856f76e651d397b301c9b42936/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L150), not as `implementation`, because references to gradle are missing in the final POM, ex. https://repo1.maven.org/maven2/com/datadoghq/dd-sdk-android-gradle-plugin/1.0.1/dd-sdk-android-gradle-plugin-1.0.1.pom and the necessary classes will be in the classpath anyway during Gradle execution.

