### PR TITLE
Add a note about Gradle configuration cache support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ datadog {
 }
 ```
 
+### Gradle configuration cache support
+
+This plugin supports [Gradle configuration cache](https://docs.gradle.org/7.1/userguide/configuration_cache.html) starting from the version `1.1.0`, but to have this support you need to disable SDK dependency check by setting `checkProjectDependencies` to `none`:
+
+```
+datadog {
+    ...
+    checkProjectDependencies = "none"
+    ...
+}
+```
+
 ## Troubleshooting
 
 If you encounter any issue when using the Gradle Plugin for Datadog Android SDK, please take a look at 


### PR DESCRIPTION
### What does this PR do?

Follow-up for the change https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/40, adds an explanation about Gradle configuration cache support to `README`. Should be merged only after `1.1.0` is published.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

