### PR TITLE
RUMM-1543 remove 'size:large' tag from docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ ci-image:
   stage: ci-image
   when: manual
   except: [ tags, schedules ]
-  tags: [ "runner:docker", "size:large" ]
+  tags: [ "runner:docker" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   script:
     - docker build --tag $CI_IMAGE_DOCKER -f Dockerfile.gitlab .
@@ -38,7 +38,7 @@ ci-image:
 create_key:
   stage: security
   when: manual
-  tags: [ "runner:docker", "size:large" ]
+  tags: [ "runner:docker" ]
   variables:
     PROJECT_NAME: "dd-sdk-android-gradle-plugin"
     EXPORT_TO_KEYSERVER: "true"
@@ -53,7 +53,7 @@ create_key:
 # STATIC ANALYSIS
 
 analysis:ktlint:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: analysis
   timeout: 30m
@@ -62,7 +62,7 @@ analysis:ktlint:
     - GRADLE_OPTS="-XX:MaxPermSize=512m -Xmx2560m" ./gradlew :dd-sdk-android-gradle-plugin:ktlintCheck --stacktrace --no-daemon
 
 analysis:detekt:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: analysis
   timeout: 30m
@@ -71,7 +71,7 @@ analysis:detekt:
     - GRADLE_OPTS="-XX:MaxPermSize=512m -Xmx2560m" ./gradlew :dd-sdk-android-gradle-plugin:detekt --stacktrace --no-daemon
 
 analysis:licenses:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: analysis
   timeout: 30m
@@ -80,7 +80,7 @@ analysis:licenses:
     - GRADLE_OPTS="-XX:MaxPermSize=512m -Xmx2560m" ./gradlew :dd-sdk-android-gradle-plugin:checkThirdPartyLicences --stacktrace --no-daemon
 
 analysis:woke:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: analysis
   timeout: 30m
@@ -91,7 +91,7 @@ analysis:woke:
 # TESTS
 
 test:plugin:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
@@ -108,7 +108,7 @@ test:plugin:
 # PUBLISH ARTIFACTS ON MAVEN
 
 publish:release-plugin:
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   only:
     - tags
   image: $CI_IMAGE_DOCKER


### PR DESCRIPTION
### What does this PR do?

Remove the `size:large` tag as it's no-op.