### PR TITLE
RUMM-1622: Remove Bintray/JCenter repo references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ buildscript {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Gradle) }
-        jcenter()
         mavenLocal()
     }
 
@@ -28,7 +27,6 @@ allprojects {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
-        jcenter()
         flatDir { dirs("libs") }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.android.tools.build:gradle:4.2.1")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.10")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.32")
 
     // check api surface
     implementation("com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm:c35b50fa44")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -30,9 +30,9 @@ object Dependencies {
         const val MockitoKotlin = "2.2.0"
 
         // Tools
-        const val Detekt = "1.6.0"
+        const val Detekt = "1.17.0"
         const val KtLint = "9.4.0"
-        const val Dokka = "1.4.10"
+        const val Dokka = "1.4.32"
     }
 
     object Libraries {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -2,6 +2,7 @@ package com.datadog.gradle.plugin
 
 /**
  * Base extension used to configure the `dd-android-gradle-plugin`.
+ * @param name Name of the given configuration.
  */
 open class DdExtensionConfiguration(
     val name: String = ""

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryInfo.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/RepositoryInfo.kt
@@ -6,6 +6,9 @@ import org.json.JSONObject
 /**
  * Represents the information on the version control repository associated
  * with the current Gradle Project.
+ * @param url Repository URL.
+ * @param hash Commit hash.
+ * @param sourceFiles Source files at the given commit.
  * @see [RepositoryDetector]
  */
 data class RepositoryInfo(


### PR DESCRIPTION
### What does this PR do?

This change is similar to DataDog/dd-sdk-android#704, removes Bintray/JCenter repo references and updates libs which were hosted there before.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

