### PR TITLE
RUMM-1795 Ensure git files are reported with full path from repo root

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetector.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetector.kt
@@ -76,6 +76,7 @@ internal class GitRepositoryDetector(
         val sourceSetFiles = execOperations.execShell(
             "git",
             "ls-files",
+            "--full-name", // RUMM-1795 ensures path are reported from the repo root
             sourceSetRoot.absolutePath
         )
             .trim()

--- a/samples/basic/build.gradle
+++ b/samples/basic/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
 
     // implementation(libs.datadogSdk)
-
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Ensure git files are reported with full path from repo root.

### Motivation

In some cases the `cwd` is not the repo root, meaning that the path we get from `git ls-files` are not correct. Adding the `--full-name` forces git to report the paths from the repo root.