### PR TITLE
RUMM-1778 delay the android extension check

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -32,20 +32,19 @@ class DdAndroidGradlePlugin @Inject constructor(
     /** @inheritdoc */
     override fun apply(target: Project) {
 
-        val androidExtension = target.extensions.findByType(AppExtension::class.java)
-        if (androidExtension == null) {
-            LOGGER.error(ERROR_NOT_ANDROID)
-            return
-        }
-
         val extension = target.extensions.create(EXT_NAME, DdExtension::class.java)
         extension.variants = target.container(DdExtensionConfiguration::class.java)
         val apiKey = resolveApiKey(target)
 
         target.afterEvaluate {
-            androidExtension.applicationVariants.all { variant ->
-                configureVariantForUploadTask(target, variant, apiKey, extension)
-                configureVariantForSdkCheck(target, variant, extension)
+            val androidExtension = target.extensions.findByType(AppExtension::class.java)
+            if (androidExtension == null) {
+                LOGGER.error(ERROR_NOT_ANDROID)
+            } else {
+                androidExtension.applicationVariants.all { variant ->
+                    configureVariantForUploadTask(target, variant, apiKey, extension)
+                    configureVariantForSdkCheck(target, variant, extension)
+                }
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

Delay the android extension check.

### Motivation

In some cases, the order in which plugins are applied doesn't match the order in the `plugins { }` block, meaning that the Datadog plugin can be started before the Android one is applied, meaning the extension is not there yet. Delaying it ensures the plugin gets applied properly