### PR TITLE
RUMM-1824: Fix dependency check task crash in the multi-module setup

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -18,7 +18,7 @@ import org.gradle.plugins.signing.SigningExtension
 
 object MavenConfig {
 
-    val VERSION = Version(1, 1, 0, Version.Type.Dev)
+    val VERSION = Version(1, 2, 1, Version.Type.Dev)
     const val GROUP_ID = "com.datadoghq"
     const val PUBLICATION = "pluginMaven"
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory
  */
 class DdAndroidGradlePlugin @Inject constructor(
     @Suppress("UnstableApiUsage") private val execOps: ExecOperations
-) :
-    Plugin<Project> {
+) : Plugin<Project> {
 
     // region Plugin
 
@@ -150,7 +149,7 @@ class DdAndroidGradlePlugin @Inject constructor(
                 checkDepsTaskName,
                 DdCheckSdkDepsTask::class.java
             ) {
-                it.configuration.set(variant.compileConfiguration)
+                it.configurationName.set(variant.compileConfiguration.name)
                 it.sdkCheckLevel.set(resolvedCheckDependencyFlag)
                 it.variantName.set(variant.name)
             }


### PR DESCRIPTION
### What does this PR do?

Fixes #62. The problem comes in the multi-module setup, when there is module `A` with some flavors (say `foo` and `bar`) which is using another module `B` without mentioned flavors.

Because the way task execution works, gradle tries to unwrap `Configuration` input, but it fails to do that, because there is no 1:1 match between `A` and `B` configurations (but AGP itself is able to match them, because it applies fallback).

This change proposes to use configuration name instead in the input, so that it can be later pulled from the configurations list (using `project` in the task is not compatible with configuration cache, but using `Configuration` in the input is not compatible as well, so we don't break anything from this point).

Because now inputs don't change if configuration itself is changed, task is cached more aggressively (it can be skipped 2nd time, even if dependency tree has changed), we will leverage task outputs to control if task can be cached or not. This has an edge case: if there was successful execution with DD dependency in the tree and then DD dependency was removed, then task won't be executed, but I think we can allow that.

Other options considered:

1. Try to resolve configuration at the task creation step - most probably will fail (because AGP didn't apply fallbacks yet), and resolving configuration at the script configuration step is not nice.
2.  Use variant compilation outputs as task input - will solve caching issue, but that will postpone the check even further in the task execution graph (and these outputs will most of the time different if output contains some code-generated timestamp, build number, etc., making the task non-incremental essentially).
Also this change bumps version to `1.2.1`, because I think it is worth to do patch release.

Additional read:

https://docs.gradle.org/current/userguide/more_about_tasks.html
https://docs.gradle.org/current/userguide/custom_tasks.html

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

