### PR TITLE
RUMM-1972 Provide mappingFilePath through plugin configuration

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -91,10 +91,8 @@ class DdAndroidGradlePlugin @Inject constructor(
         configureVariantTask(uploadTask, apiKey, flavorName, extensionConfiguration, variant)
 
         val outputsDir = File(target.buildDir, "outputs")
-        val mappingDir = File(outputsDir, "mapping")
-        val flavorDir = File(mappingDir, variant.name)
-        uploadTask.mappingFilePath = File(flavorDir, "mapping.txt").path
-
+        uploadTask.mappingFilePath =
+            resolveMappingFilePath(extensionConfiguration, outputsDir, variant)
         val reportsDir = File(outputsDir, "reports")
         val datadogDir = File(reportsDir, "datadog")
         uploadTask.repositoryFile = File(datadogDir, "repository.json")
@@ -155,6 +153,21 @@ class DdAndroidGradlePlugin @Inject constructor(
             }
             compileTask.finalizedBy(checkDepsTaskProvider)
             return checkDepsTaskProvider
+        }
+    }
+
+    private fun resolveMappingFilePath(
+        extensionConfiguration: DdExtensionConfiguration,
+        outputsDir: File,
+        variant: ApplicationVariant
+    ): String {
+        val customPath = extensionConfiguration.mappingFilePath
+        return if (customPath != null) {
+            customPath
+        } else {
+            val mappingDir = File(outputsDir, "mapping")
+            val flavorDir = File(mappingDir, variant.name)
+            File(flavorDir, "mapping.txt").path
         }
     }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -40,11 +40,18 @@ open class DdExtensionConfiguration(
      */
     var checkProjectDependencies: SdkCheckLevel? = null
 
+    /**
+     * The absolute path to the mapping file to be used for deobfuscation. If not provided the
+     * default one will be used: [buildDir]/output/mapping/[variant]/mapping.txt
+     */
+    var mappingFilePath: String? = null
+
     internal fun updateWith(config: DdExtensionConfiguration) {
         config.versionName?.let { versionName = it }
         config.serviceName?.let { serviceName = it }
         config.site?.let { site = it }
         config.remoteRepositoryUrl?.let { remoteRepositoryUrl = it }
         config.checkProjectDependencies?.let { checkProjectDependencies = it }
+        config.mappingFilePath?.let { mappingFilePath = it }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -104,10 +104,9 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.variantName).isEqualTo(flavorName)
         assertThat(task.versionName).isEqualTo(versionName)
         assertThat(task.serviceName).isEqualTo(packageName)
-        assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo(fakeExtension.site)
-        assertThat(task.mappingFilePath)
-            .isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
+        assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
+        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
     }
 
     @Test
@@ -145,10 +144,9 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.variantName).isEqualTo(flavorName)
         assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
-        assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo(fakeExtension.site)
-        assertThat(task.mappingFilePath)
-            .isEqualTo("${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt")
+        assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
+        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
     }
 
     @Test
@@ -163,6 +161,7 @@ internal class DdAndroidGradlePluginTest {
         fakeExtension.versionName = null
         fakeExtension.site = null
         fakeExtension.remoteRepositoryUrl = null
+        fakeExtension.mappingFilePath = null
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
@@ -331,6 +330,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfig.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfig.checkProjectDependencies)
+        assertThat(config.mappingFilePath).isEqualTo(variantConfig.mappingFilePath)
     }
 
     @Test
@@ -376,6 +376,32 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
+        assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
+        assertThat(config.checkProjectDependencies)
+            .isEqualTo(fakeExtension.checkProjectDependencies)
+    }
+
+    @Test
+    fun `𝕄 return combined config 𝕎 resolveExtensionConfiguration() { variant w mappingPath }`(
+        @StringForgery(regex = "/([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt") mappingFilePath: String
+    ) {
+        val variantName = fakeFlavorNames.variantName()
+        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        val incompleteConfig = DdExtensionConfiguration().apply {
+            this.mappingFilePath = mappingFilePath
+        }
+        fakeExtension.variants = mock()
+        whenever(fakeExtension.variants.findByName(variantName)) doReturn incompleteConfig
+
+        // When
+        val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
+
+        // Then
+        assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
+        assertThat(config.mappingFilePath).isEqualTo(mappingFilePath)
+        assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies)
             .isEqualTo(fakeExtension.checkProjectDependencies)
@@ -400,6 +426,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(site.name)
+        assertThat(config.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
         assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies).isEqualTo(
             fakeExtension.checkProjectDependencies
@@ -425,6 +452,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.versionName).isEqualTo(fakeExtension.versionName)
         assertThat(config.serviceName).isEqualTo(fakeExtension.serviceName)
         assertThat(config.site).isEqualTo(fakeExtension.site)
+        assertThat(config.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
         assertThat(config.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(config.checkProjectDependencies).isEqualTo(sdkCheckLevel)
     }
@@ -452,6 +480,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.checkProjectDependencies).isEqualTo(
             fakeExtension.checkProjectDependencies
         )
+        assertThat(config.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
     }
 
     @Test
@@ -489,6 +518,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfigC.checkProjectDependencies)
         assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfigA.remoteRepositoryUrl)
+        assertThat(config.mappingFilePath).isEqualTo(variantConfigA.mappingFilePath)
     }
 
     @Test
@@ -536,6 +566,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.checkProjectDependencies)
             .isEqualTo(variantConfigAB.checkProjectDependencies)
         assertThat(config.remoteRepositoryUrl).isEqualTo(variantConfigAB.remoteRepositoryUrl)
+        assertThat(config.mappingFilePath).isEqualTo(variantConfigAB.mappingFilePath)
     }
 
     @Test
@@ -558,6 +589,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(config.checkProjectDependencies)
             .isEqualTo(configuration.checkProjectDependencies)
         assertThat(config.remoteRepositoryUrl).isEqualTo(configuration.remoteRepositoryUrl)
+        assertThat(config.mappingFilePath).isEqualTo(configuration.mappingFilePath)
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
@@ -19,6 +19,9 @@ internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensi
                 "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git"
             )
             checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
+            mappingFilePath = forge.aStringMatching(
+                "([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt"
+            )
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
@@ -18,6 +18,12 @@ internal class DdExtensionForgeryFactory : ForgeryFactory<DdExtension> {
             site = forge.aValueFrom(DatadogSite::class.java).name
             variants = mock()
             checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
+            remoteRepositoryUrl = forge.aStringMatching(
+                "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git"
+            )
+            mappingFilePath = forge.aStringMatching(
+                "([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt"
+            )
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new property for the plugin extension configuration -> `mappingFilePath`. Using this new property users will be able to provide their own custom `mappingFilePath` for each application variant in case they are using any other third party code obfuscator than the default one.

Close issue #71 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

