### PR TITLE
RUMM-1954: Support AGP 7.1.x

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -207,7 +207,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "inside the action method. " +
             "There is already an opened issue here: https://github.com/gradle/gradle/issues/12871"
     )
-    fun `M success W assembleRelease { configuration cache, checkProjectDependecies enabled }`() {
+    fun `M success W assembleRelease { configuration cache, checkProjectDependencies enabled }`() {
         // TODO: https://datadoghq.atlassian.net/browse/RUMM-1894
 
         // Given
@@ -234,7 +234,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "the --configuration-cache. There is no workaround this yet and this is " +
             "also present in some internal build.gradle tasks (see the test comment above)"
     )
-    fun `M success W assembleDebug { configuration cache, checkProjectDependecies enabled }`() {
+    fun `M success W assembleDebug { configuration cache, checkProjectDependencies enabled }`() {
         // TODO: https://datadoghq.atlassian.net/browse/RUMM-1893
 
         // Given
@@ -305,7 +305,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
-    fun `M success W assembleRelease { Datadog SDK not in deps, checkDepedencies to warn }`() {
+    fun `M success W assembleRelease { Datadog SDK not in deps, checkDependencies to warn }`() {
         // Given
         stubGradleBuildFromResourceFile(
             "build_with_check_deps_set_to_warn.gradle.kts",
@@ -331,7 +331,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
-    fun `M success W assembleDebug { Datadog SDK not in deps, checkDepedencies to warn }`() {
+    fun `M success W assembleDebug { Datadog SDK not in deps, checkDependencies to warn }`() {
         // Given
         stubGradleBuildFromResourceFile(
             "build_with_check_deps_set_to_warn.gradle.kts",
@@ -557,7 +557,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 resolutionStrategy {
                     eachPlugin {
                         if (requested.id.id == "com.android.application") {
-                            useModule("com.android.tools.build:gradle:7.0.3")
+                            useModule("com.android.tools.build:gradle:7.1.2")
                         }
                         if (requested.id.id == "kotlin-android") {
                             useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ json = "20180813"
 okHttp = "3.12.13"
 
 # Android
-androidToolsPlugin = "7.0.3"
+androidToolsPlugin = "7.1.2"
 
 # AndroidX
 androidx-core ="1.3.2"


### PR DESCRIPTION
### What does this PR do?

This change brings support of AGP 7.1: it renamed compilation tasks and the task we were relying on is still there, but it is not a part of build process.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

