### PR TITLE
RUMM-1845: Add a note to the docs that upload mapping task is not a part of the default build graph

### DIFF
--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -95,9 +95,11 @@ property as : `fooBar`
 
 ### Integration with CI/CD pipeline
 
-By default, the upload mapping task is independent of any other task in the build graph. That means that you need to run it manually when mapping needs to be uploaded.
+By default, the upload mapping task is independent from other tasks in the build graph. Run the task manually when you need to upload mapping.
 
-However, if this step should be done in the CI/CD pipeline and it needs to be a part of build graph, you can make upload task to run after mapping file is generated in the following manner:
+If you want to run this task in a CI/CD pipeline, and the task is required as part of the build graph, you can set the upload task to run after the mapping file is generated.
+
+For example:
 
 ```groovy
 tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -93,6 +93,15 @@ property as : `fooBar`
 | `remoteRepositoryUrl`      | The url of the remote repository where the source code was deployed.  If not provided this value will be resolved from your current GIT configuration during the task execution time.                     |
 | `checkProjectDependencies` | This property controls if plugin should check if Datadog SDK is included in the dependencies and if it is not:  "none" - ignore, "warn" - log a warning, "fail" - fail the build with an error (default). |
 
+### Integration with CI/CD pipeline
+
+By default, the upload mapping task is independent of any other task in the build graph. That means that you need to run it manually when mapping needs to be uploaded.
+
+However, if this step should be done in the CI/CD pipeline and it needs to be a part of build graph, you can make upload task to run after mapping file is generated in the following manner:
+
+```groovy
+tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
+```
 
 ## Troubleshoot errors
 


### PR DESCRIPTION
### What does this PR do?

This change adds a section to the docs explaining that upload mapping task is not a part of the default build graph by default (it means it needs to be run manually once mapping file is generated, unlike for `Crashlytics`, for example) and adds a code example on adding it to the default build graph.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

