### PR TITLE
RUMM-2163: Disable dependencies check task by default

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -139,7 +139,9 @@ class DdAndroidGradlePlugin @Inject constructor(
                 extension,
                 variant
             )
-            if (extensionConfiguration.checkProjectDependencies == SdkCheckLevel.NONE) {
+            if (extensionConfiguration.checkProjectDependencies == SdkCheckLevel.NONE ||
+                extensionConfiguration.checkProjectDependencies == null
+            ) {
                 return null
             }
             val checkDepsTaskName = "checkSdkDeps${variant.name.capitalize()}"

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -35,9 +35,10 @@ open class DdExtensionConfiguration(
 
     /**
      * This property controls if plugin should check if Datadog SDK is included in the dependencies
-     * and if it is not: "none" - ignore, "warn" - log a warning, "fail" - fail the build
-     * with an error (default).
+     * and if it is not: "none" - ignore (default), "warn" - log a warning, "fail" - fail the build
+     * with an error.
      */
+    // TODO RUMM-2344
     var checkProjectDependencies: SdkCheckLevel? = null
 
     /**

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -12,8 +12,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.Ignore
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -201,13 +201,14 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .isEqualTo(TaskOutcome.SUCCESS)
     }
 
-    @Ignore(
+    @Disabled(
         "This test is ignored for now because of these tasks: " +
             "collect[Flavour1][Flavour2]ReleaseDependencies. This is caused under the hood" +
             "by this task: PerModuleReportDependenciesTask which accesses the project object" +
             "inside the action method. " +
             "There is already an opened issue here: https://github.com/gradle/gradle/issues/12871"
     )
+    @Test
     fun `M success W assembleRelease { configuration cache, checkProjectDependencies enabled }`() {
         // TODO: https://datadoghq.atlassian.net/browse/RUMM-1894
 
@@ -229,12 +230,13 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .isEqualTo(TaskOutcome.SUCCESS)
     }
 
-    @Ignore(
+    @Disabled(
         "This test is ignored for now as we are using the Configuration object at the " +
             "task action level in our DdCheckSdkDepsTask and this is breaking " +
             "the --configuration-cache. There is no workaround this yet and this is " +
             "also present in some internal build.gradle tasks (see the test comment above)"
     )
+    @Test
     fun `M success W assembleDebug { configuration cache, checkProjectDependencies enabled }`() {
         // TODO: https://datadoghq.atlassian.net/browse/RUMM-1893
 
@@ -277,13 +279,14 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .isEqualTo(TaskOutcome.SUCCESS)
     }
 
-    @Ignore(
+    @Disabled(
         "This test is ignored for now because of these tasks: " +
             "collect[Flavour1][Flavour2]ReleaseDependencies. This is caused under the hood" +
             "by this task: PerModuleReportDependenciesTask which accesses the project object" +
             "inside the action method. " +
             "There is already an opened issue here: https://github.com/gradle/gradle/issues/12871"
     )
+    @Test
     fun `M success W assembleRelease { configuration cache, checkDependencies disabled  }`() {
         // TODO: https://datadoghq.atlassian.net/browse/RUMM-1894
 
@@ -357,6 +360,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         }
     }
 
+    @Disabled("RUMM-2344")
     @Test
     fun `M fail W assembleRelease { Datadog SDK not in deps }`() {
         // Given
@@ -373,6 +377,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .buildAndFail()
     }
 
+    @Disabled("RUMM-2344")
     @Test
     fun `M fail W assembleDebug { Datadog SDK not in deps }`() {
         // Given
@@ -387,6 +392,48 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .withArguments(":samples:app:assembleDebug")
             .withPluginClasspath(getTestConfigurationClasspath())
             .buildAndFail()
+    }
+
+    // TODO remove once RUMM-2344 is done
+    @Test
+    fun `M success W assembleRelease { Datadog SDK not in deps }`() {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_without_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+
+        // When
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments(":samples:app:assembleRelease")
+            .withPluginClasspath(getTestConfigurationClasspath())
+            .build()
+
+        // Then
+        assertThat(result.task(":samples:app:assembleRelease")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    // TODO remove once RUMM-2344 is done
+    @Test
+    fun `M success W assembleDebug { Datadog SDK not in deps }`() {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_without_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+
+        // When
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments(":samples:app:assembleDebug")
+            .withPluginClasspath(getTestConfigurationClasspath())
+            .build()
+
+        // Then
+        assertThat(result.task(":samples:app:assembleDebug")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -748,8 +748,9 @@ internal class DdAndroidGradlePluginTest {
 
     // region configureVariantForSdkCheck
 
+    // TODO RUMM-2344 switch back to FAIL
     @Test
-    fun `𝕄 use FAIL when configuring checkDepsTask { checkProjectDependencies not set }`(
+    fun `𝕄 use NONE when configuring checkDepsTask { checkProjectDependencies not set }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -780,15 +781,7 @@ internal class DdAndroidGradlePluginTest {
             fakeExtension
         )
 
-        val task = checkSdkDepsTaskProvider?.get()
-
-        assertThat(task).isNotNull()
-        assertThat(task?.sdkCheckLevel?.get())
-            .isEqualTo(SdkCheckLevel.FAIL)
-        assertThat(task?.configurationName?.get())
-            .isEqualTo(configurationName)
-        assertThat(task?.variantName?.get())
-            .isEqualTo(variantName)
+        assertThat(checkSdkDepsTaskProvider).isNull()
     }
 
     @Test

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_set_to_warn.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_set_to_warn.gradle
@@ -59,4 +59,3 @@ android {
 datadog {
     checkProjectDependencies = "warn"
 }
-

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -34,10 +34,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         demo {
@@ -58,6 +54,10 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -34,10 +34,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         demo {
@@ -58,4 +54,8 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -34,11 +34,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation(project(':samples:lib-module'))
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         demo {
@@ -59,4 +54,9 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation(project(':samples:lib-module'))
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -27,10 +27,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         demo {
@@ -51,4 +47,8 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -34,10 +34,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         demo {
@@ -58,6 +54,10 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -34,10 +34,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    dependencies {
-        implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
-    }
-
     flavorDimensions("version", "colour")
     productFlavors {
         pro {
@@ -53,6 +49,10 @@ android {
             dimension "colour"
         }
     }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android:1.14.0-beta1")
 }
 
 datadog {


### PR DESCRIPTION
### What does this PR do?

This change disables SDK check in the dependencies by default, to avoid false positive errors in certain setups.

We will come back to this check later in RUMM-2344.

Temporarily fixes https://github.com/DataDog/dd-sdk-android-gradle-plugin/issues/85.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

