### PR TITLE
RUMM-2345: Read config properties from datadog-ci.json

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DatadogSite.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DatadogSite.kt
@@ -3,61 +3,59 @@ package com.datadog.gradle.plugin
 /**
  * Defines the Datadog sites you can send tracked data to.
  */
-enum class DatadogSite {
+enum class DatadogSite(internal val domain: String) {
     /**
      *  The US1 site: [app.datadoghq.com](https://app.datadoghq.com) (legacy name).
      */
-    US,
+    US("datadoghq.com"),
 
     /**
      *  The US1 site: [app.datadoghq.com](https://app.datadoghq.com).
      */
-    US1,
+    US1("datadoghq.com"),
 
     /**
      *  The US3 site: [us3.datadoghq.com](https://us3.datadoghq.com).
      */
-    US3,
+    US3("us3.datadoghq.com"),
 
     /**
      *  The US5 site: [us5.datadoghq.com](https://us5.datadoghq.com).
      */
-    US5,
+    US5("us5.datadoghq.com"),
 
     /**
      *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com) (legacy name).
      */
-    GOV,
+    GOV("ddog-gov.com"),
 
     /**
      *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com).
      */
-    US1_FED,
+    US1_FED("ddog-gov.com"),
 
     /**
      *  The EU1 site: [app.datadoghq.eu](https://app.datadoghq.eu) (legacy name).
      */
-    EU,
+    EU("datadoghq.eu"),
 
     /**
      *  The EU1 site: [app.datadoghq.eu](https://app.datadoghq.eu).
      */
-    EU1;
+    EU1("datadoghq.eu");
 
     /**
      * Returns the endpoint to use to upload sourcemap to this site.
      */
     internal fun uploadEndpoint(): String {
-        return when (this) {
-            US, US1 -> "https://sourcemap-intake.datadoghq.com/api/v2/srcmap"
-            US3 -> "https://sourcemap-intake.us3.datadoghq.com/api/v2/srcmap"
-            US5 -> "https://sourcemap-intake.us5.datadoghq.com/api/v2/srcmap"
-            GOV, US1_FED -> "https://sourcemap-intake.ddog-gov.com/api/v2/srcmap"
-            EU, EU1 -> "https://sourcemap-intake.datadoghq.eu/api/v2/srcmap"
-        }
+        return "https://sourcemap-intake.$domain/api/v2/srcmap"
     }
 
     companion object {
         internal val validIds = DatadogSite.values().map { it.name }
+
+        internal fun fromDomain(domain: String): DatadogSite? {
+            return DatadogSite.values().firstOrNull { it.domain == domain }
+        }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -75,6 +75,11 @@ open class DdExtensionConfiguration(
      */
     var mappingFileTrimIndents: Boolean = false
 
+    /**
+     * Ignore the config declared in `datadog-ci.json` file if found.
+     */
+    var ignoreDatadogCiFileConfig: Boolean = false
+
     internal fun updateWith(config: DdExtensionConfiguration) {
         config.versionName?.let { versionName = it }
         config.serviceName?.let { serviceName = it }
@@ -84,5 +89,6 @@ open class DdExtensionConfiguration(
         config.mappingFilePath?.let { mappingFilePath = it }
         mappingFilePackageAliases = config.mappingFilePackageAliases
         mappingFileTrimIndents = config.mappingFileTrimIndents
+        ignoreDatadogCiFileConfig = config.ignoreDatadogCiFileConfig
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/ApiKey.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/ApiKey.kt
@@ -1,0 +1,17 @@
+package com.datadog.gradle.plugin.internal
+
+internal data class ApiKey(val value: String, val source: ApiKeySource) {
+    companion object {
+        val NONE = ApiKey("", ApiKeySource.NONE)
+    }
+}
+
+/**
+ * Source of API key.
+ */
+enum class ApiKeySource {
+    GRADLE_PROPERTY,
+    ENVIRONMENT,
+    DATADOG_CI_CONFIG_FILE,
+    NONE
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionConfigurationForgeryFactory.kt
@@ -27,6 +27,7 @@ internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensi
                     forge.anAlphabeticalString()
             }
             mappingFileTrimIndents = forge.aBool()
+            ignoreDatadogCiFileConfig = forge.aBool()
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdExtensionForgeryFactory.kt
@@ -36,6 +36,7 @@ internal class DdExtensionForgeryFactory : ForgeryFactory<DdExtension> {
                     forge.anAlphabeticalString()
             }
             mappingFileTrimIndents = forge.aBool()
+            ignoreDatadogCiFileConfig = forge.aBool()
         }
     }
 }

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -34,7 +34,7 @@ For any given error, you can access the file path, line number, and a code snipp
    }
    ```
 
-2. [Create a dedicated Datadog API key][2] and export it as an environment variable named `DD_API_KEY` (alternatively, pass it as a task property).
+2. [Create a dedicated Datadog API key][2] and export it as an environment variable named `DD_API_KEY` (alternatively, pass it as a task property or if you have `datadog-ci.json` file in the root of your project, it can be taken from `apiKey` property there).
 3. Optionally, configure the plugin to upload files to the EU region by configuring the plugin in your `build.gradle` script:
    
    ```
@@ -65,7 +65,7 @@ For any given error, you can access the file path, line number, and a code snipp
    }
    ```
 
-2. [Create a dedicated Datadog API key][2] and export it as an environment variable named `DD_API_KEY` (alternatively, pass it as a task property).
+2. [Create a dedicated Datadog API key][2] and export it as an environment variable named `DD_API_KEY` (alternatively, pass it as a task property or if you have `datadog-ci.json` file in the root of your project, it can be taken from `apiKey` property there).
 3. Configure the plugin to use the EU region by adding the following snippet in your app's `build.gradle` script file:
 
    ```groovy


### PR DESCRIPTION
### What does this PR do?

This change supports parsing some properties from `datadog-ci.json`, namely `datadogSite` and `apiKey` properties.

This file may be located in the root of the project (but since the definition of the root may vary between the different setups, we try to find `datadog-ci.json` file by doing upward traversal).

The order of API key lookup is like the following:

* Gradle property
* `datadog-ci.json` file
* Environment property

The order of site lookup is like the following:

* Gradle extension configuration
* `datadog-ci.json` file

`datadog-ci.json` file is included as an input of upload task so that it can be watched by the Gradle for the changes, otherwise it won't be checked and any changes there won't be reflected when running upload task, which may be confusing for the user.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

