### PR TITLE
RUMM-2469: Fix a possible NPE in the datadog-ci.json file lookup

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -260,10 +260,9 @@ class DdAndroidGradlePlugin @Inject constructor(
         return configuration
     }
 
-    private fun findDatadogCiFile(projectDir: File): File? {
-        var currentDir = projectDir
+    internal fun findDatadogCiFile(projectDir: File): File? {
+        var currentDir: File? = projectDir
         var levelsUp = 0
-        @Suppress("SENSELESS_COMPARISON") // parentFile can return null, Kotlin is wrong here
         while (currentDir != null && levelsUp < MAX_DATADOG_CI_FILE_LOOKUP_LEVELS) {
             val datadogCiFile = File(currentDir, "datadog-ci.json")
             if (datadogCiFile.exists()) {

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -2,8 +2,8 @@ Dependencies List
 
 com.squareup.okhttp3:okhttp:4.9.3                               :  773 Kb
 com.squareup.okio:okio:2.8.0                                    :  237 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.5.21                :  193 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.5.21                       : 1462 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.6.10                :  195 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.6.10                       : 1472 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20180813                                          :   63 Kb
 


### PR DESCRIPTION
### What does this PR do?

Fixes #111. `currentDir` had an implicit type `File` inherited from the `projectDir` argument, but because `parentFile` can return `null`, conversion to `File` failed.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

