### PR TITLE
Update to version 1.16.0-beta1

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -57,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -57,5 +57,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -58,5 +58,5 @@ android {
 
 dependencies {
     implementation(project(':samples:lib-module'))
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -57,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.15.0")
+    implementation("com.datadoghq:dd-sdk-android:1.16.0-beta1")
 }
 
 datadog {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ nexusPublishPluginGradle = "1.1.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "1.15.0"
+datadogSdk = "1.16.0-beta1"
 datadogPluginGradle = "1.5.1"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.15.0 to version 1.16.0-beta1: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.15.0...1.16.0-beta1)