### PR TITLE
RUMM-2770: Improve mapping upload flow handling

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DatadogSite.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DatadogSite.kt
@@ -57,6 +57,10 @@ enum class DatadogSite(internal val domain: String) {
         return "https://sourcemap-intake.$domain/api/v2/srcmap"
     }
 
+    internal fun apiKeyVerificationEndpoint(): String {
+        return "https://api.$domain/api/v1/validate"
+    }
+
     companion object {
         internal val validIds = DatadogSite.values().map { it.name }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -136,6 +136,12 @@ open class DdMappingFileUploadTask
         applySiteFromEnvironment()
         validateConfiguration()
 
+        if (apiKey.contains("\"") || apiKey.contains("'")) {
+            throw IllegalStateException(
+                "DD-API-KEY provided shouldn't contain quotes or apostrophes."
+            )
+        }
+
         var mappingFile = File(mappingFilePath)
         if (!validateMappingFile(mappingFile)) return
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -151,7 +151,7 @@ open class DdMappingFileUploadTask
 
         val site = DatadogSite.valueOf(site)
         uploader.upload(
-            site.uploadEndpoint(),
+            site,
             mappingFile,
             if (repositories.isEmpty()) null else repositoryFile,
             apiKey,

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.gradle.plugin.internal
 
+import com.datadog.gradle.plugin.DatadogSite
 import com.datadog.gradle.plugin.RepositoryInfo
 import java.io.File
 
@@ -13,7 +14,7 @@ internal interface Uploader {
 
     @Suppress("LongParameterList")
     fun upload(
-        url: String,
+        site: DatadogSite,
         mappingFile: File,
         repositoryFile: File?,
         apiKey: String,

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -479,7 +479,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         assertThat(result.output).contains(
             "Uploading mapping file for " +
                 "com.example.variants.$variantVersionName:1.0-$variantVersionName " +
-                "{variant:$variant}:"
+                "{variant:$variant} (site=datadoghq.com):"
         )
     }
 
@@ -526,7 +526,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         assertThat(result.output).contains(
             "Uploading mapping file for " +
                 "com.example.variants.$variantVersionName:1.0-$variantVersionName " +
-                "{variant:$variant}:"
+                "{variant:$variant} (site=datadoghq.eu):"
         )
         assertThat(result.output).contains("API key found in Datadog CI config file, using it.")
         assertThat(result.output)
@@ -565,7 +565,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         assertThat(result.output).contains(
             "Uploading mapping file for " +
                 "com.example.variants.$variantVersionName:1.0-$variantVersionName " +
-                "{variant:$variant}:"
+                "{variant:$variant} (site=datadoghq.com):"
         )
 
         assertThat(result.output).contains(
@@ -603,7 +603,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         assertThat(result.output).contains(
             "Uploading mapping file for " +
                 "com.example.variants.$variantVersionName:1.0-$variantVersionName " +
-                "{variant:$variant}:"
+                "{variant:$variant} (site=datadoghq.com):"
         )
 
         val optimizedFile = Path(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -121,7 +121,6 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.mappingFilePath = fakeMappingFile.path
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
-        val expectedUrl = fakeSite.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(listOf(fakeRepoInfo))
 
@@ -130,7 +129,7 @@ internal class DdMappingFileUploadTaskTest {
 
         // Then
         verify(mockUploader).upload(
-            expectedUrl,
+            fakeSite,
             fakeMappingFile,
             fakeRepositoryFile,
             fakeApiKey.value,
@@ -165,7 +164,6 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.mappingFilePath = fakeMappingFile.path
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
-        val expectedUrl = fakeSite.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(listOf(fakeRepoInfo))
 
@@ -175,7 +173,7 @@ internal class DdMappingFileUploadTaskTest {
         // Then
         argumentCaptor<File> {
             verify(mockUploader).upload(
-                eq(expectedUrl),
+                eq(fakeSite),
                 capture(),
                 eq(fakeRepositoryFile),
                 eq(fakeApiKey.value),
@@ -214,7 +212,6 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.mappingFilePath = fakeMappingFile.path
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
-        val expectedUrl = fakeSite.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(listOf(fakeRepoInfo))
 
@@ -224,7 +221,7 @@ internal class DdMappingFileUploadTaskTest {
         // Then
         argumentCaptor<File> {
             verify(mockUploader).upload(
-                eq(expectedUrl),
+                eq(fakeSite),
                 capture(),
                 eq(fakeRepositoryFile),
                 eq(fakeApiKey.value),
@@ -250,7 +247,6 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.remoteRepositoryUrl = fakeRemoteUrl
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
-        val expectedUrl = fakeSite.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq(fakeRemoteUrl)))
             .doReturn(listOf(fakeRepoInfo))
 
@@ -259,7 +255,7 @@ internal class DdMappingFileUploadTaskTest {
 
         // Then
         verify(mockUploader).upload(
-            expectedUrl,
+            fakeSite,
             fakeMappingFile,
             fakeRepositoryFile,
             fakeApiKey.value,
@@ -284,7 +280,6 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.mappingFilePath = fakeMappingFile.path
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
-        val expectedUrl = fakeSite.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(emptyList())
 
@@ -293,7 +288,7 @@ internal class DdMappingFileUploadTaskTest {
 
         // Then
         verify(mockUploader).upload(
-            expectedUrl,
+            fakeSite,
             fakeMappingFile,
             null,
             fakeApiKey.value,
@@ -354,7 +349,6 @@ internal class DdMappingFileUploadTaskTest {
         val fakeRepositoryFile = File(tempDir, fakeRepositoryFileName)
         testedTask.repositoryFile = fakeRepositoryFile
         testedTask.site = ""
-        val expectedUrl = DatadogSite.US1.uploadEndpoint()
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(listOf(fakeRepoInfo))
 
@@ -363,7 +357,7 @@ internal class DdMappingFileUploadTaskTest {
 
         // Then
         verify(mockUploader).upload(
-            expectedUrl,
+            DatadogSite.US1,
             fakeMappingFile,
             fakeRepositoryFile,
             fakeApiKey.value,

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -320,6 +320,31 @@ internal class DdMappingFileUploadTaskTest {
     }
 
     @Test
+    fun `𝕄 throw error 𝕎 applyTask() {api key contains quotes or apostrophes}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeMappingFile = File(tempDir, fakeMappingFileName)
+        fakeMappingFile.writeText(fakeMappingFileContent)
+        testedTask.mappingFilePath = fakeMappingFile.path
+        testedTask.apiKey = forge.anAlphaNumericalString().let {
+            val splitIndex = forge.anInt(min = 0, max = it.length) + 1
+            it.substring(0, splitIndex) +
+                forge.anElementFrom("\"", "'") +
+                it.substring(splitIndex)
+        }
+        testedTask.apiKeySource = ApiKeySource.NONE
+
+        // When
+        assertThrows<IllegalStateException> {
+            testedTask.applyTask()
+        }
+
+        // Then
+        verifyZeroInteractions(mockUploader)
+    }
+
+    @Test
     fun `𝕄 throw error 𝕎 applyTask() {invalid site}`(
         @StringForgery siteName: String
     ) {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/RecordedRequestAssert.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/RecordedRequestAssert.kt
@@ -60,6 +60,14 @@ internal class RecordedRequestAssert(actual: RecordedRequest?) :
         return this
     }
 
+    fun hasHeaderValue(header: String, expected: String): RecordedRequestAssert {
+        isNotNull
+        assertThat(actual.headers.names()).contains(header)
+        val actual = actual.getHeader(header)
+        assertThat(actual).isEqualTo(expected)
+        return this
+    }
+
     companion object {
         fun assertThat(actual: RecordedRequest?): RecordedRequestAssert {
             return RecordedRequestAssert(actual)

--- a/dd-sdk-android-gradle-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### What does this PR do?

This change improves mapping upload flow handling by doing the following:

* Additional check for the API key validity is done (using [API key validation API](https://docs.datadoghq.com/api/latest/authentication/#validate-api-key)) if server returns code 400, this is basically aligns logic with [datadog-ci](https://github.com/DataDog/datadog-ci/blob/ffc52ea6c0b0ac44004544bf84689a22ce2d4119/src/helpers/apikey.ts#L48).
* Removed a statement saying that server may already have mapping uploaded - server will never return error if there is already mapping uploaded.
* Added an additional check for quotes\apostrophes in API key, this may be useful for the error investigation on the client side (this check is quite limited to only quotes and apostrophes, because there is no public contract for the API key format).
* Added a site name to the upload info message (and to some other messages as well).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

