### PR TITLE
Improve the documentation for 50Mb limit

### DIFF
--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -146,7 +146,7 @@ than 50Mb, you can try several options to reduce the file size and be able to up
 
 ```
 datadog {
-    mappingFileTrimIndents = false
+    mappingFileTrimIndents = true
     mappingFilePackageAliases = mapOf(
         "kotlinx.coroutines" to "kx.cor",
         "com.google.android.material" to "material",

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -136,6 +136,26 @@ For example:
 tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 ```
 
+## Limitations
+
+For now, we can only upload mapping files with a size smaller than 50 Mb. If your project has a mapping file larger
+than 50Mb, you can try several options to reduce the file size and be able to upload it.
+
+- set the `mappingFileTrimIndents` option to true, this will reduce your file size by 5% on average
+- set a map of `mappingFilePackagesAliases`: this will replace package names by shorter alias. The main caveat is that the stacktrace in Datadog will use the same alias instead of the original package name, so it's better to use it for third party dependencies.
+
+```
+datadog {
+    mappingFileTrimIndents = false
+    mappingFilePackageAliases = mapOf(
+        "kotlinx.coroutines" to "kx.cor",
+        "com.google.android.material" to "material",
+        "com.google.gson" to "gson",
+        "com.squareup.picasso" to "picasso"
+    )
+}
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -138,7 +138,7 @@ tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 
 ## Limitations
 
-Mapping files are limited to 50 Mb. If your project has a mapping file larger than 50 Mb, use one of the following options to reduce the file size:
+Mapping files are limited to 100 Mb when targeting our US1 site, and 50 Mb for other sites. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 
 - Set the `mappingFileTrimIndents` option to `true`. This reduces your file size by 5%, on average.
 - Set a map of `mappingFilePackagesAliases`: This replaces package names with shorter aliases. **Note**: Datadog's stacktrace uses the same alias instead of the original package name, so it's better to use this option for third party dependencies.

--- a/docs/upload_mapping_file.md
+++ b/docs/upload_mapping_file.md
@@ -138,11 +138,10 @@ tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 
 ## Limitations
 
-For now, we can only upload mapping files with a size smaller than 50 Mb. If your project has a mapping file larger
-than 50Mb, you can try several options to reduce the file size and be able to upload it.
+Mapping files are limited to 50 Mb. If your project has a mapping file larger than 50 Mb, use one of the following options to reduce the file size:
 
-- set the `mappingFileTrimIndents` option to true, this will reduce your file size by 5% on average
-- set a map of `mappingFilePackagesAliases`: this will replace package names by shorter alias. The main caveat is that the stacktrace in Datadog will use the same alias instead of the original package name, so it's better to use it for third party dependencies.
+- Set the `mappingFileTrimIndents` option to `true`. This reduces your file size by 5%, on average.
+- Set a map of `mappingFilePackagesAliases`: This replaces package names with shorter aliases. **Note**: Datadog's stacktrace uses the same alias instead of the original package name, so it's better to use this option for third party dependencies.
 
 ```
 datadog {


### PR DESCRIPTION
### What does this PR do?

Improve the documentation to give workarounds when the mapping file is above 50 Mb