### PR TITLE
RUMM-2952: Add Gzip support for mapping file upload

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -12,6 +12,8 @@ import com.datadog.gradle.plugin.internal.DdAppIdentifier
 import com.datadog.gradle.plugin.internal.OkHttpUploader
 import com.datadog.gradle.plugin.internal.Uploader
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -30,6 +32,7 @@ import javax.inject.Inject
  */
 open class DdMappingFileUploadTask
 @Inject constructor(
+    providerFactory: ProviderFactory,
     @get:Internal internal val repositoryDetector: RepositoryDetector
 ) : DefaultTask() {
 
@@ -42,6 +45,9 @@ open class DdMappingFileUploadTask
      */
     @get:Input
     var apiKey: String = ""
+
+    private val disableGzipOption: Provider<String> =
+        providerFactory.gradleProperty(DISABLE_GZIP_GRADLE_PROPERTY)
 
     /**
      * Source of the API key set: environment, gradle property, etc.
@@ -166,7 +172,8 @@ open class DdMappingFileUploadTask
                 version = versionName,
                 variant = variantName
             ),
-            repositories.firstOrNull()
+            repositories.firstOrNull(),
+            !disableGzipOption.isPresent
         )
     }
 
@@ -364,5 +371,6 @@ open class DdMappingFileUploadTask
         private const val DATADOG_CI_API_KEY_PROPERTY = "apiKey"
         private const val DATADOG_CI_SITE_PROPERTY = "datadogSite"
         const val DATADOG_SITE = "DATADOG_SITE"
+        const val DISABLE_GZIP_GRADLE_PROPERTY = "dd-disable-gzip"
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
@@ -19,6 +19,7 @@ internal interface Uploader {
         repositoryFile: File?,
         apiKey: String,
         identifier: DdAppIdentifier,
-        repositoryInfo: RepositoryInfo?
+        repositoryInfo: RepositoryInfo?,
+        useGzip: Boolean
     )
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -47,7 +47,7 @@ import java.io.File
 @ForgeConfiguration(Configurator::class)
 internal class DdMappingFileUploadTaskTest {
 
-    lateinit var testedTask: DdMappingFileUploadTask
+    private lateinit var testedTask: DdMappingFileUploadTask
 
     @TempDir
     lateinit var tempDir: File
@@ -138,7 +138,8 @@ internal class DdMappingFileUploadTaskTest {
                 version = fakeVersion,
                 variant = fakeVariant
             ),
-            fakeRepoInfo
+            fakeRepoInfo,
+            useGzip = true
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(
@@ -184,7 +185,8 @@ internal class DdMappingFileUploadTaskTest {
                         variant = fakeVariant
                     )
                 ),
-                eq(fakeRepoInfo)
+                eq(fakeRepoInfo),
+                useGzip = eq(true)
             )
             assertThat(lastValue).hasSameTextualContentAs(
                 fileFromResourcesPath("mapping-with-aliases.txt")
@@ -232,7 +234,8 @@ internal class DdMappingFileUploadTaskTest {
                         variant = fakeVariant
                     )
                 ),
-                eq(fakeRepoInfo)
+                eq(fakeRepoInfo),
+                useGzip = eq(true)
             )
             assertThat(lastValue.readLines()).isEqualTo(expectedLines)
         }
@@ -264,7 +267,8 @@ internal class DdMappingFileUploadTaskTest {
                 version = fakeVersion,
                 variant = fakeVariant
             ),
-            fakeRepoInfo
+            fakeRepoInfo,
+            useGzip = true
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(
@@ -297,7 +301,8 @@ internal class DdMappingFileUploadTaskTest {
                 version = fakeVersion,
                 variant = fakeVariant
             ),
-            null
+            null,
+            useGzip = true
         )
     }
 
@@ -391,7 +396,8 @@ internal class DdMappingFileUploadTaskTest {
                 version = fakeVersion,
                 variant = fakeVariant
             ),
-            fakeRepoInfo
+            fakeRepoInfo,
+            useGzip = true
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -156,13 +156,63 @@ internal class OkHttpUploaderTest {
             fakeRepositoryFile,
             fakeApiKey,
             fakeIdentifier,
-            fakeRepositoryInfo
+            fakeRepositoryInfo,
+            useGzip = true
         )
 
         // Then
         assertThat(mockWebServer.requestCount).isEqualTo(1)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
+            .containsFormData("git_repository_url", fakeRepositoryInfo.url)
+            .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
+            .containsMultipartFile(
+                "event",
+                "event",
+                "{\"service\":\"${fakeIdentifier.serviceName}\"," +
+                    "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
+                    "\"version\":\"${fakeIdentifier.version}\"}",
+                "application/json; charset=utf-8"
+            )
+            .containsMultipartFile(
+                "jvm_mapping_file",
+                "jvm_mapping",
+                fakeMappingFileContent,
+                "text/plain"
+            )
+            .containsMultipartFile(
+                "repository",
+                "repository",
+                fakeRepositoryFileContent,
+                "application/json"
+            )
+    }
+
+    @Test
+    fun `𝕄 upload proper request 𝕎 upload() { without gzip }`() {
+        // Given
+        mockUploadResponse = MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+            .setBody("{}")
+
+        // When
+        testedUploader.upload(
+            mockSite,
+            fakeMappingFile,
+            fakeRepositoryFile,
+            fakeApiKey,
+            fakeIdentifier,
+            fakeRepositoryInfo,
+            useGzip = false
+        )
+
+        // Then
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+        assertThat(dispatchedUploadRequest)
+            .hasMethod("POST")
+            .doesNotHaveHeader("Content-Encoding")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -202,13 +252,15 @@ internal class OkHttpUploaderTest {
             null,
             fakeApiKey,
             fakeIdentifier,
-            null
+            null,
+            useGzip = true
         )
 
         // Then
         assertThat(mockWebServer.requestCount).isEqualTo(1)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsMultipartFile(
                 "event",
                 "event",
@@ -244,7 +296,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -252,6 +305,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(1)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -298,7 +352,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -306,6 +361,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(1)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -349,7 +405,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -357,6 +414,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(2)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -416,7 +474,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -424,6 +483,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(2)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -471,7 +531,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -479,6 +540,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(2)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -525,7 +587,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
 
@@ -533,6 +596,7 @@ internal class OkHttpUploaderTest {
         assertThat(mockWebServer.requestCount).isEqualTo(2)
         assertThat(dispatchedUploadRequest)
             .hasMethod("POST")
+            .hasHeaderValue("Content-Encoding", "gzip")
             .containsFormData("git_repository_url", fakeRepositoryInfo.url)
             .containsFormData("git_commit_sha", fakeRepositoryInfo.hash)
             .containsMultipartFile(
@@ -580,7 +644,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
         assertThat(exception.message).isEqualTo(
@@ -614,7 +679,8 @@ internal class OkHttpUploaderTest {
                 fakeRepositoryFile,
                 fakeApiKey,
                 fakeIdentifier,
-                fakeRepositoryInfo
+                fakeRepositoryInfo,
+                useGzip = true
             )
         }
         assertThat(exception.message).isEqualTo(
@@ -648,7 +714,8 @@ internal class OkHttpUploaderTest {
             fakeRepositoryFile,
             fakeApiKey,
             fakeIdentifier,
-            fakeRepositoryInfo
+            fakeRepositoryInfo,
+            useGzip = true
         )
 
         // Then
@@ -678,7 +745,8 @@ internal class OkHttpUploaderTest {
             fakeRepositoryFile,
             fakeApiKey,
             fakeIdentifier,
-            fakeRepositoryInfo
+            fakeRepositoryInfo,
+            useGzip = true
         )
 
         // Then
@@ -704,7 +772,8 @@ internal class OkHttpUploaderTest {
             fakeRepositoryFile,
             fakeApiKey,
             fakeIdentifier,
-            fakeRepositoryInfo
+            fakeRepositoryInfo,
+            useGzip = true
         )
 
         // Then


### PR DESCRIPTION
### What does this PR do?

This change add Gzip support for mapping file upload by optionally (enabled by default) adding gzip encoding to the `srcmap` endpoint request.

There is a way to disable this behavior by using `dd-disable-gzip` Gradle property. This property is accessed using `ProviderFactory#gradleProperty`, which is available since Gradle 6.2 (but we are using already `ExecOperations` interface for a long time which is available since Gradle 6.0, so it should be ok to bump min Gradle version a bit).

Unfortunately it is not possible to test this property using unit tests (because `org.gradle.testfixtures.ProjectBuilder` used in the `DdMappingFileUploadTaskTest` is not capable of reading/setting Gradle properties), so I had to rely on the functional tests instead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

