### PR TITLE
Update to version 1.18.0

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -57,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.17.1")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -57,5 +57,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.17.0")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -58,5 +58,5 @@ android {
 
 dependencies {
     implementation(project(':samples:lib-module'))
-    implementation("com.datadoghq:dd-sdk-android:1.17.1")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.17.1")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -57,7 +57,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.17.1")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android:1.17.1")
+    implementation("com.datadoghq:dd-sdk-android:1.18.0")
 }
 
 datadog {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "1.17.2"
+datadogSdk = "1.18.0"
 datadogPluginGradle = "1.7.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.17.2 to version 1.18.0: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.17.2...1.18.0)