### PR TITLE
Prepare 1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.8.0 / 2023-03-22
+
+* [FEATURE] Add support to AP1. See [#150](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/150)
+* [FEATURE] Add support for Staging upload. See [#151](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/151)
+* [IMPROVEMENT] Minor improvements. See [#155](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/155)
+* [MAINTENANCE] Next dev version 1.8.0. See [#145](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/145)
+* [MAINTENANCE] Update Gradle to version 8.0, update Kotlin, AGP, OkHttp versions as well. See [#148](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/148)
+* [MAINTENANCE] Update to version 1.17.1. See [#149](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/149)
+* [MAINTENANCE] Fix CI warnings and issues. See [#152](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/152)
+* [MAINTENANCE] Update to version 1.17.2. See [#153](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/153)
+* [MAINTENANCE] Update to version 1.18.0. See [#156](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/156)
+* [DOCS] Improve the documentation for 50Mb limit. See [#141](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/141)
+
 # 1.7.0 / 2023-02-08
 
 - [FEATURE] Add Gzip support for mapping file upload. See [#143](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/143)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -20,7 +20,7 @@ import java.net.URI
 
 object MavenConfig {
 
-    val VERSION = Version(1, 8, 0, Version.Type.Dev)
+    val VERSION = Version(1, 8, 0, Version.Type.Release)
     const val GROUP_ID = "com.datadoghq"
     const val PUBLICATION = "pluginMaven"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
 datadogSdk = "1.18.0"
-datadogPluginGradle = "1.7.0"
+datadogPluginGradle = "1.8.0"
 
 [libraries]
 


### PR DESCRIPTION
### What does this PR do?

This PR prepares release of version 1.8.0, which needs to be done to be consistent with release 1.18.0 of Android SDK in terms of AP1 endpoint support.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

