### PR TITLE
RUMM-3267: Remove mapping file size check

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -53,6 +53,7 @@ open class DdExtensionConfiguration(
      */
     var mappingFilePath: String? = null
 
+    // TODO RUMM-0000 Deprecate and then remove this API once all DCs support large file upload
     /**
      * Short aliases to use for package prefixes. Allows to replace, for example,
      * androidx.appcompat with something shorter, reducing the size of the mapping file. Key is
@@ -74,6 +75,7 @@ open class DdExtensionConfiguration(
      */
     var mappingFilePackageAliases: Map<String, String> = emptyMap()
 
+    // TODO RUMM-0000 Deprecate and then remove this API once all DCs support large file upload
     /**
      * This property removes indents from each line of the mapping file, reducing its size.
      *


### PR DESCRIPTION
### What does this PR do?

Requests too big will fail with status 413 and message `Request too large`, so removing mapping file size check from the plugin to rely on the status code instead. Mapping file size limits are mentioned in the docs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

