### PR TITLE
Update to version 1.19.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.0.0-beta1"
+datadogSdk = "1.19.3"
 datadogPluginGradle = "1.9.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 2.0.0-beta1 to version 1.19.3: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.0.0-beta1...1.19.3)