### PR TITLE
Update to version 2.0.0-beta3

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -59,5 +59,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -60,5 +60,5 @@ android {
 
 dependencies {
     implementation(project(':samples:lib-module'))
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -52,5 +52,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta2")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.0.0-beta3")
 }
 
 datadog {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.0.0-beta2"
+datadogSdk = "2.0.0-beta3"
 datadogPluginGradle = "1.10.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 2.0.0-beta2 to version 2.0.0-beta3: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.0.0-beta2...2.0.0-beta3)