### PR TITLE
Update to version 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.0.0-beta3"
+datadogSdk = "2.0.0"
 datadogPluginGradle = "1.10.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 2.0.0-beta3 to version 2.0.0: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.0.0-beta3...2.0.0)