### PR TITLE
RUM-1052: Delete old shrinked mapping file before writing to it

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -303,6 +303,9 @@ open class DdMappingFileUploadTask
         )
 
         val shrinkedFile = File(mappingFile.parent, MAPPING_OPTIMIZED_FILE_NAME)
+        if (shrinkedFile.exists()) {
+            shrinkedFile.delete()
+        }
         // sort is needed to have predictable replacement in the following case:
         // imagine there are 2 keys - "androidx.work" and "androidx.work.Job", and the latter
         // occurs much more often than the rest under "androidx.work.*". So for the more efficient


### PR DESCRIPTION
### What does this PR do?

There is a bug that old shrinked mapping file wasn't deleted before doing the shrinking again. This PR fixes it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

