### PR TITLE
RUM-713 Allow customer to use non standard obfuscation

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 /**
  * Plugin adding tasks for Android projects using Datadog's SDK for Android.
  */
+@Suppress("TooManyFunctions")
 class DdAndroidGradlePlugin @Inject constructor(
     private val execOps: ExecOperations
 ) : Plugin<Project> {
@@ -40,6 +41,8 @@ class DdAndroidGradlePlugin @Inject constructor(
             val androidExtension = target.extensions.findByType(AppExtension::class.java)
             if (androidExtension == null) {
                 LOGGER.error(ERROR_NOT_ANDROID)
+            } else if (!extension.enabled) {
+                LOGGER.info("Datadog extension disabled, no upload task created")
             } else {
                 androidExtension.applicationVariants.all { variant ->
                     configureVariantForUploadTask(target, variant, apiKey, extension)
@@ -73,13 +76,13 @@ class DdAndroidGradlePlugin @Inject constructor(
         apiKey: ApiKey,
         extension: DdExtension
     ): Task? {
-        if (!variant.buildType.isMinifyEnabled) {
-            LOGGER.info("Minifying disabled for variant ${variant.name}, no upload task created")
-            return null
-        }
+        val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
+        val isDefaultObfuscationEnabled = variant.buildType.isMinifyEnabled
+        val isNonDefaultObfuscationEnabled = extensionConfiguration.nonDefaultObfuscation
+        val isObfuscationEnabled = isDefaultObfuscationEnabled || isNonDefaultObfuscationEnabled
 
-        if (!extension.enabled) {
-            LOGGER.info("Extension disabled for variant ${variant.name}, no upload task created")
+        if (!isObfuscationEnabled) {
+            LOGGER.info("Minifying disabled for variant ${variant.name}, no upload task created")
             return null
         }
 
@@ -91,13 +94,10 @@ class DdAndroidGradlePlugin @Inject constructor(
             DdMappingFileUploadTask::class.java,
             GitRepositoryDetector(execOps)
         )
-        val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
 
         configureVariantTask(uploadTask, apiKey, flavorName, extensionConfiguration, variant)
 
-        val outputsDir = File(target.buildDir, "outputs")
-        uploadTask.mappingFilePath =
-            resolveMappingFilePath(extensionConfiguration, outputsDir, variant)
+        uploadTask.mappingFilePath = resolveMappingFilePath(extensionConfiguration, target, variant)
         uploadTask.mappingFilePackagesAliases =
             filterMappingFileReplacements(
                 extensionConfiguration.mappingFilePackageAliases,
@@ -108,9 +108,7 @@ class DdAndroidGradlePlugin @Inject constructor(
             uploadTask.datadogCiFile = findDatadogCiFile(target.projectDir)
         }
 
-        val reportsDir = File(outputsDir, "reports")
-        val datadogDir = File(reportsDir, "datadog")
-        uploadTask.repositoryFile = File(datadogDir, "repository.json")
+        uploadTask.repositoryFile = resolveDatadogRepositoryFile(target)
 
         val roots = mutableListOf<File>()
         variant.sourceSets.forEach {
@@ -187,17 +185,25 @@ class DdAndroidGradlePlugin @Inject constructor(
 
     private fun resolveMappingFilePath(
         extensionConfiguration: DdExtensionConfiguration,
-        outputsDir: File,
+        target: Project,
         variant: ApplicationVariant
     ): String {
         val customPath = extensionConfiguration.mappingFilePath
         return if (customPath != null) {
             customPath
         } else {
+            val outputsDir = File(target.buildDir, "outputs")
             val mappingDir = File(outputsDir, "mapping")
             val flavorDir = File(mappingDir, variant.name)
             File(flavorDir, "mapping.txt").path
         }
+    }
+
+    private fun resolveDatadogRepositoryFile(target: Project): File {
+        val outputsDir = File(target.buildDir, "outputs")
+        val reportsDir = File(outputsDir, "reports")
+        val datadogDir = File(reportsDir, "datadog")
+        return File(datadogDir, "repository.json")
     }
 
     private fun filterMappingFileReplacements(

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -84,6 +84,13 @@ open class DdExtensionConfiguration(
     var mappingFileTrimIndents: Boolean = false
 
     /**
+     * This property declares that the obfuscation technology used is not the default
+     * R8/Proguard included in the Android toolchain (e.g.: Dexguard, …).
+     * Doing so will create an upload task for all variants and all build types
+     */
+    var nonDefaultObfuscation: Boolean = false
+
+    /**
      * Ignore the config declared in `datadog-ci.json` file if found.
      */
     var ignoreDatadogCiFileConfig: Boolean = false
@@ -98,5 +105,6 @@ open class DdExtensionConfiguration(
         mappingFilePackageAliases = config.mappingFilePackageAliases
         mappingFileTrimIndents = config.mappingFileTrimIndents
         ignoreDatadogCiFileConfig = config.ignoreDatadogCiFileConfig
+        nonDefaultObfuscation = config.nonDefaultObfuscation
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
@@ -1,0 +1,67 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("com.datadoghq.dd-sdk-android-gradle-plugin")
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion = 33
+    buildToolsVersion = "33.0.1"
+
+    defaultConfig {
+        applicationId "com.example.variants"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+        multiDexEnabled = true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile ('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    namespace = "com.example.variants"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    flavorDimensions("version", "colour")
+    productFlavors {
+        demo {
+            dimension "version"
+            applicationIdSuffix ".demo"
+            versionNameSuffix "-demo"
+        }
+        full {
+            dimension "version"
+            applicationIdSuffix ".full"
+            versionNameSuffix "-full"
+        }
+
+        green {
+            dimension "colour"
+        }
+        blue {
+            dimension "colour"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+}
+
+datadog {
+    nonDefaultObfuscation = true
+}

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
@@ -1,0 +1,67 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("com.datadoghq.dd-sdk-android-gradle-plugin")
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion = 33
+    buildToolsVersion = "33.0.1"
+
+    defaultConfig {
+        applicationId "com.example.variants"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+        multiDexEnabled = true
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile ('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    namespace = "com.example.variants"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    flavorDimensions("version", "colour")
+    productFlavors {
+        demo {
+            dimension "version"
+            applicationIdSuffix ".demo"
+            versionNameSuffix "-demo"
+        }
+        full {
+            dimension "version"
+            applicationIdSuffix ".full"
+            versionNameSuffix "-full"
+        }
+
+        green {
+            dimension "colour"
+        }
+        blue {
+            dimension "colour"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+}
+
+datadog {
+    enabled = false
+}


### PR DESCRIPTION
### What does this PR do?

Adds a `nonDefaultObfuscation` option in the extension for our plugin. This will create an uploadTask even if the Android `minifyEnabled` option is `false`


### Motivation

Among others, Dexguard users are not using Android's `minifyEnabled` which relies on the default R8/Proguard obfuscation.  For those users, the upload task wasn't created even on variants using DexGuard who needed it. 

Fixes #132 

### Usage 

```
datadog {
    nonDefaultObfuscation = true
    mappingFilePath = "custom/path/to/mapping.txt"
}
```
