### PR TITLE
Update Datadog SDK to version 2.3.0

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -59,5 +59,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -60,5 +60,5 @@ android {
 
 dependencies {
     implementation(project(':samples:lib-module'))
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -52,5 +52,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
@@ -59,7 +59,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.2.0")
+    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
 }
 
 datadog {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.2.0"
+datadogSdk = "2.3.0"
 datadogPluginGradle = "1.12.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog SDK from version 2.2.0 to version 2.3.0: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.2.0...2.3.0)