### PR TITLE
RUM-1822: Inject build ID into mapping file upload and SDK host application as well

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -17,18 +17,21 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.process.ExecOperations
 import java.io.File
 import javax.inject.Inject
+import kotlin.io.path.Path
 
 /**
  * Plugin adding tasks for Android projects using Datadog's SDK for Android.
  */
 @Suppress("TooManyFunctions")
 class DdAndroidGradlePlugin @Inject constructor(
-    private val execOps: ExecOperations
+    private val execOps: ExecOperations,
+    private val providerFactory: ProviderFactory
 ) : Plugin<Project> {
 
     // region Plugin
@@ -38,16 +41,29 @@ class DdAndroidGradlePlugin @Inject constructor(
         val extension = target.extensions.create(EXT_NAME, DdExtension::class.java)
         val apiKey = resolveApiKey(target)
 
+        // need to use withPlugin instead of afterEvaluate, because otherwise generated assets
+        // folder with buildId is not picked by AGP by some reason
+        target.pluginManager.withPlugin("com.android.application") {
+            val androidExtension = target.androidApplicationExtension ?: return@withPlugin
+            androidExtension.applicationVariants.all { variant ->
+                if (extension.enabled) {
+                    configureTasksForVariant(
+                        target,
+                        androidExtension,
+                        extension,
+                        variant,
+                        apiKey
+                    )
+                }
+            }
+        }
+
         target.afterEvaluate {
-            val androidExtension = target.extensions.findByType(AppExtension::class.java)
+            val androidExtension = target.androidApplicationExtension
             if (androidExtension == null) {
                 LOGGER.error(ERROR_NOT_ANDROID)
             } else if (!extension.enabled) {
                 LOGGER.info("Datadog extension disabled, no upload task created")
-            } else {
-                androidExtension.applicationVariants.all { variant ->
-                    configureTasksForVariant(target, androidExtension, extension, variant, apiKey)
-                }
             }
         }
     }
@@ -93,17 +109,23 @@ class DdAndroidGradlePlugin @Inject constructor(
         return apiKey ?: ApiKey.NONE
     }
 
+    @Suppress("StringLiteralDuplication")
     internal fun configureBuildIdGenerationTask(
         target: Project,
         appExtension: AppExtension,
         variant: ApplicationVariant
     ): TaskProvider<GenerateBuildIdTask> {
-        val buildIdGenerationTask = GenerateBuildIdTask.register(target, variant)
+        val buildIdDirectory = target.layout.buildDirectory
+            .dir(Path("generated", "datadog", "buildId", variant.name).toString())
+        val buildIdGenerationTask = GenerateBuildIdTask.register(target, variant, buildIdDirectory)
 
-        val buildIdDirectoryProvider = buildIdGenerationTask.flatMap { it.buildIdDirectory }
-        appExtension.sourceSets.getByName(variant.name).assets.srcDir(
-            buildIdDirectoryProvider
-        )
+        // we could generate buildIdDirectory inside GenerateBuildIdTask and read it here as
+        // property using flatMap, but when Gradle sync is done inside Android Studio there is an error
+        // Querying the mapped value of provider (java.util.Set) before task ... has completed is
+        // not supported, which doesn't happen when Android Studio is not used (pure Gradle build)
+        // so applying such workaround
+        // TODO RUM-0000 use new AndroidComponents API to inject generated stuff, it is more friendly
+        appExtension.sourceSets.getByName(variant.name).assets.srcDir(buildIdDirectory)
 
         val variantName = variant.name.capitalize()
         listOf(
@@ -144,9 +166,13 @@ class DdAndroidGradlePlugin @Inject constructor(
 
         configureVariantTask(uploadTask, apiKey, flavorName, extensionConfiguration, variant)
 
+        // upload task shouldn't depend on the build ID generation task, but only read its property,
+        // because upload task may be triggered after assemble task and we don't want to re-generate
+        // build ID, because it will be different then from the one which is already embedded in
+        // the application package
         uploadTask.buildId = buildIdGenerationTask.flatMap {
-            it.buildIdFile.map {
-                it.asFile.readText().trim()
+            it.buildIdFile.flatMap {
+                providerFactory.provider { it.asFile.readText().trim() }
             }
         }
         uploadTask.mappingFilePath = resolveMappingFilePath(extensionConfiguration, target, variant)
@@ -167,7 +193,6 @@ class DdAndroidGradlePlugin @Inject constructor(
             roots.addAll(it.javaDirectories)
         }
         uploadTask.sourceSetRoots = roots
-        uploadTask.dependsOn(buildIdGenerationTask)
 
         return uploadTask
     }
@@ -344,6 +369,9 @@ class DdAndroidGradlePlugin @Inject constructor(
         val isNonDefaultObfuscationEnabled = extensionConfiguration.nonDefaultObfuscation
         return isDefaultObfuscationEnabled || isNonDefaultObfuscationEnabled
     }
+
+    private val Project.androidApplicationExtension: AppExtension?
+        get() = extensions.findByType(AppExtension::class.java)
 
     // endregion
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -293,6 +293,7 @@ class DdAndroidGradlePlugin @Inject constructor(
 
         uploadTask.site = extensionConfiguration.site ?: ""
         uploadTask.versionName = extensionConfiguration.versionName ?: variant.versionName
+        uploadTask.versionCode = variant.versionCode
         uploadTask.serviceName = extensionConfiguration.serviceName ?: variant.applicationId
         uploadTask.remoteRepositoryUrl = extensionConfiguration.remoteRepositoryUrl ?: ""
     }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdCheckSdkDepsTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdCheckSdkDepsTask.kt
@@ -45,7 +45,7 @@ abstract class DdCheckSdkDepsTask : DefaultTask() {
     internal var isLastRunSuccessful: Boolean = true
 
     init {
-        group = "datadog"
+        group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
         description = "Checks for the Datadog SDK into your variant dependencies."
         outputs.upToDateWhen { it is DdCheckSdkDepsTask && it.isLastRunSuccessful }
     }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -155,7 +155,11 @@ open class DdMappingFileUploadTask
         validateConfiguration()
 
         check(!(apiKey.contains("\"") || apiKey.contains("'"))) {
-            "DD_API_KEY provided shouldn't contain quotes or apostrophes."
+            INVALID_API_KEY_FORMAT_ERROR
+        }
+
+        check(buildId.isPresent && buildId.get().isNotEmpty()) {
+            MISSING_BUILD_ID_ERROR
         }
 
         var mappingFile = File(mappingFilePath)
@@ -261,11 +265,7 @@ open class DdMappingFileUploadTask
 
     @Suppress("CheckInternal")
     private fun validateConfiguration() {
-        check(apiKey.isNotBlank()) {
-            "Make sure you define an API KEY to upload your mapping files to Datadog. " +
-                "Create a DD_API_KEY or DATADOG_API_KEY environment variable, gradle" +
-                " property or define it in datadog-ci.json file."
-        }
+        check(apiKey.isNotBlank()) { API_KEY_MISSING_ERROR }
 
         if (site.isBlank()) {
             site = DatadogSite.US1.name
@@ -389,5 +389,13 @@ open class DdMappingFileUploadTask
         private const val DATADOG_CI_SITE_PROPERTY = "datadogSite"
         const val DATADOG_SITE = "DATADOG_SITE"
         const val DISABLE_GZIP_GRADLE_PROPERTY = "dd-disable-gzip"
+
+        const val API_KEY_MISSING_ERROR = "Make sure you define an API KEY to upload your mapping files to Datadog. " +
+            "Create a DD_API_KEY or DATADOG_API_KEY environment variable, gradle" +
+            " property or define it in datadog-ci.json file."
+        const val INVALID_API_KEY_FORMAT_ERROR =
+            "DD_API_KEY provided shouldn't contain quotes or apostrophes."
+        const val MISSING_BUILD_ID_ERROR =
+            "Build ID is missing, you need to run upload task only after APK/AAB file is generated."
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -68,6 +68,12 @@ open class DdMappingFileUploadTask
     var versionName: String = ""
 
     /**
+     * The version code of the application.
+     */
+    @get:Input
+    var versionCode: Int = 0
+
+    /**
      * The service name of the application (by default, it is your app's package name).
      */
     @get:Input
@@ -174,6 +180,7 @@ open class DdMappingFileUploadTask
             DdAppIdentifier(
                 serviceName = serviceName,
                 version = versionName,
+                versionCode = versionCode,
                 variant = variantName,
                 buildId = buildId.get()
             ),

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTask.kt
@@ -86,6 +86,12 @@ open class DdMappingFileUploadTask
     var remoteRepositoryUrl: String = ""
 
     /**
+     * Build ID which will be used for mapping file matching.
+     */
+    @get:Input
+    var buildId: Provider<String> = providerFactory.provider { "" }
+
+    /**
      * The path to the mapping file to upload.
      */
     @get:Input
@@ -123,7 +129,7 @@ open class DdMappingFileUploadTask
     var repositoryFile: File = File("")
 
     init {
-        group = "datadog"
+        group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
         description = "Uploads the Proguard/R8 mapping file to Datadog"
         // it is never up-to-date, because request may fail
         outputs.upToDateWhen { false }
@@ -168,7 +174,8 @@ open class DdMappingFileUploadTask
             DdAppIdentifier(
                 serviceName = serviceName,
                 version = versionName,
-                variant = variantName
+                variant = variantName,
+                buildId = buildId.get()
             ),
             repositories.firstOrNull(),
             !disableGzipOption.isPresent

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
@@ -1,0 +1,80 @@
+package com.datadog.gradle.plugin
+
+import com.android.build.gradle.api.ApplicationVariant
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import java.util.UUID
+import kotlin.io.path.Path
+
+/**
+ * This task generates unique Build ID which is later used to match error and mapping file.
+ */
+abstract class GenerateBuildIdTask : DefaultTask() {
+
+    /**
+     * Directory to store build ID file.
+     */
+    @get:OutputDirectory
+    abstract val buildIdDirectory: DirectoryProperty
+
+    /**
+     * File containing build ID.
+     */
+    @get:OutputFile
+    val buildIdFile: Provider<RegularFile> = buildIdDirectory.file(BUILD_ID_FILE_NAME)
+
+    init {
+        outputs.upToDateWhen { false }
+        group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
+        description = "Generates a unique build ID to associate mapping file and application."
+    }
+
+    /**
+     * Generates unique build ID and saves it to a file.
+     */
+    @TaskAction
+    fun generateBuildId() {
+        val buildIdDirectory = buildIdDirectory.get().asFile
+        buildIdDirectory.mkdirs()
+
+        val buildId = UUID.randomUUID().toString()
+        buildIdFile.get().asFile
+            .writeText(buildId)
+    }
+
+    companion object {
+        internal const val TASK_NAME = "generateBuildId"
+
+        /**
+         * Name of the file containing build ID information.
+         */
+        const val BUILD_ID_FILE_NAME = "datadog.buildId"
+
+        /**
+         * Registers a new instance of [GenerateBuildIdTask] specific for the given [ApplicationVariant].
+         */
+        fun register(
+            target: Project,
+            variant: ApplicationVariant
+        ): TaskProvider<GenerateBuildIdTask> {
+            val variantName = variant.name.capitalize()
+            val buildIdDirectory = target.layout.buildDirectory
+                .dir(Path("generated", "datadog", "buildId", variant.name).toString())
+            val generateBuildIdTask = target.tasks.register(
+                TASK_NAME + variantName,
+                GenerateBuildIdTask::class.java
+            ) {
+                it.buildIdDirectory.set(buildIdDirectory)
+            }
+
+            return generateBuildIdTask
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/DdAppIdentifier.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/DdAppIdentifier.kt
@@ -9,11 +9,13 @@ package com.datadog.gradle.plugin.internal
 internal data class DdAppIdentifier(
     val serviceName: String,
     val version: String,
+    val versionCode: Int,
     val variant: String,
     val buildId: String
 ) {
 
     override fun toString(): String {
-        return "`service:$serviceName`, `version:$version`, `variant:$variant`, `buildId:$buildId`"
+        return "`service:$serviceName`, `version:$version`, `versionCode:$versionCode`," +
+            " `variant:$variant`, `buildId:$buildId`"
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/DdAppIdentifier.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/DdAppIdentifier.kt
@@ -9,10 +9,11 @@ package com.datadog.gradle.plugin.internal
 internal data class DdAppIdentifier(
     val serviceName: String,
     val version: String,
-    val variant: String
+    val variant: String,
+    val buildId: String
 ) {
 
     override fun toString(): String {
-        return "`service:$serviceName`, `version:$version`, `variant:$variant`"
+        return "`service:$serviceName`, `version:$version`, `variant:$variant`, `buildId:$buildId`"
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -104,6 +104,7 @@ internal class OkHttpUploader : Uploader {
         eventJson.put("service", identifier.serviceName)
         eventJson.put("variant", identifier.variant)
         eventJson.put("buildId", identifier.buildId)
+        eventJson.put("versionCode", identifier.versionCode)
         eventJson.put("type", TYPE_JVM_MAPPING_FILE)
 
         val builder = MultipartBody.Builder()

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -103,6 +103,7 @@ internal class OkHttpUploader : Uploader {
         eventJson.put("version", identifier.version)
         eventJson.put("service", identifier.serviceName)
         eventJson.put("variant", identifier.variant)
+        eventJson.put("buildId", identifier.buildId)
         eventJson.put("type", TYPE_JVM_MAPPING_FILE)
 
         val builder = MultipartBody.Builder()

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -592,6 +592,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
+                "`versionCode:1`, " +
                 "`variant:$variant`, " +
                 "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
@@ -634,6 +635,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
+                "`versionCode:1`, " +
                 "`variant:$variant`, " +
                 "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
@@ -676,6 +678,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
+                "`versionCode:1`, " +
                 "`variant:$variant`, " +
                 "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.eu):"
         )
@@ -716,6 +719,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
+                "`versionCode:1`, " +
                 "`variant:$variant`, " +
                 "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
@@ -756,6 +760,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
+                "`versionCode:1`, " +
                 "`variant:$variant`, " +
                 "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.util.Locale
 import java.util.Properties
+import java.util.UUID
+import java.util.zip.ZipFile
 import kotlin.io.path.Path
 
 @Extensions(
@@ -118,10 +120,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
         // Then
@@ -137,11 +136,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result =
+            gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleRelease")?.outcome)
@@ -157,11 +153,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--build-cache", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result =
+            gradleRunner { withArguments("--build-cache", ":samples:app:assembleRelease") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleRelease")?.outcome)
@@ -176,11 +169,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -195,11 +184,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -214,11 +199,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -233,11 +214,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             appBuildGradleFile
         )
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -254,11 +231,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--build-cache", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result =
+            gradleRunner { withArguments("--build-cache", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -283,11 +257,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--configuration-cache", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner {
+            withArguments(
+                "--configuration-cache",
+                ":samples:app:assembleRelease"
+            )
+        }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleRelease")?.outcome)
@@ -311,11 +286,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--configuration-cache", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner {
+            withArguments(
+                "--configuration-cache",
+                ":samples:app:assembleDebug"
+            )
+        }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -331,11 +307,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--configuration-cache", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner {
+            withArguments(
+                "--configuration-cache",
+                ":samples:app:assembleDebug"
+            )
+        }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -360,11 +337,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--configuration-cache", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner {
+            withArguments(
+                "--configuration-cache",
+                ":samples:app:assembleRelease"
+            )
+        }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleRelease")?.outcome)
@@ -380,11 +358,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result =
+            gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleRelease")?.outcome)
@@ -406,11 +381,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
-            .build()
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }.build()
 
         // Then
         assertThat(result.task(":samples:app:assembleDebug")?.outcome)
@@ -433,10 +404,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .buildAndFail()
     }
 
@@ -450,10 +418,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }
             .buildAndFail()
     }
 
@@ -467,10 +432,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
         // Then
@@ -488,10 +450,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleDebug")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner { withArguments("--info", ":samples:app:assembleDebug") }
             .build()
 
         // Then
@@ -500,6 +459,100 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     // endregion
+
+    // region BuildId
+
+    @Test
+    fun `M inject build ID W assembleRelease`() {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_with_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+        // When
+        val result = gradleRunner {
+            withArguments(
+                "--info",
+                "--configuration-cache",
+                ":samples:app:assembleRelease"
+            )
+        }
+            .build()
+
+        // Then
+        assertThat(result.task(":samples:app:assembleRelease")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val apks = testProjectDir.walk()
+            .filter { it.isFile && it.extension == "apk" }
+            .map { ZipFile(it) }
+            .toList()
+
+        assertThat(apks).isNotEmpty
+
+        val buildIdFiles = apks.mapNotNull { it.getEntry(BUILD_ID_FILE_PATH_APK) }
+
+        // each apk should contain one build ID file
+        assertThat(apks.size).isEqualTo(buildIdFiles.size)
+
+        val buildIds = apks.map {
+            it.getInputStream(it.getEntry(BUILD_ID_FILE_PATH_APK))
+                .bufferedReader()
+                .use { it.readText().trim() }
+                .let { UUID.fromString(it) }
+        }
+
+        // all build IDs should be unique
+        assertThat(buildIds.toSet()).hasSize(apks.size)
+    }
+
+    @Test
+    fun `M inject buildId W bundleRelease`() {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_with_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+        // When
+        val result = gradleRunner {
+            withArguments(
+                "--info",
+                "--configuration-cache",
+                ":samples:app:bundleRelease"
+            )
+        }
+            .build()
+
+        // Then
+        assertThat(result.task(":samples:app:bundleRelease")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val bundles = testProjectDir.walk()
+            .filter {
+                it.isFile &&
+                    !it.name.contains("intermediary") &&
+                    it.extension == "aab"
+            }
+            .map { ZipFile(it) }
+            .toList()
+
+        assertThat(bundles).isNotEmpty
+
+        val buildIdFiles = bundles.mapNotNull { it.getEntry(BUILD_ID_FILE_PATH_AAB) }
+
+        // each bundle should contain one build ID file
+        assertThat(bundles.size).isEqualTo(buildIdFiles.size)
+
+        val buildIds = bundles.map {
+            it.getInputStream(it.getEntry(BUILD_ID_FILE_PATH_AAB))
+                .bufferedReader()
+                .use { it.readText().trim() }
+                .let { UUID.fromString(it) }
+        }
+
+        // all build IDs should be unique
+        assertThat(buildIds.toSet()).hasSize(bundles.size)
+    }
 
     // region Upload
 
@@ -520,16 +573,17 @@ internal class DdAndroidGradlePluginFunctionalTest {
         // since there is no explicit dependency between assemble and upload tasks, Gradle may
         // optimize the execution and run them in parallel, ignoring the order in the command
         // line, so we do the explicit split
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info", "--stacktrace", "-PDD_API_KEY=fakekey")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey"
+            )
+        }
             .buildAndFail()
 
         // Then
@@ -538,7 +592,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
-                "`variant:$variant` (site=datadoghq.com):"
+                "`variant:$variant`, " +
+                "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
     }
 
@@ -559,16 +614,18 @@ internal class DdAndroidGradlePluginFunctionalTest {
         // since there is no explicit dependency between assemble and upload tasks, Gradle may
         // optimize the execution and run them in parallel, ignoring the order in the command
         // line, so we do the explicit split
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info", "--stacktrace", "-PDD_API_KEY=fakekey", "-Pdd-disable-gzip")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-disable-gzip"
+            )
+        }
             .buildAndFail()
 
         // Then
@@ -577,7 +634,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
-                "`variant:$variant` (site=datadoghq.com):"
+                "`variant:$variant`, " +
+                "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
     }
 
@@ -607,16 +665,10 @@ internal class DdAndroidGradlePluginFunctionalTest {
         // since there is no explicit dependency between assemble and upload tasks, Gradle may
         // optimize the execution and run them in parallel, ignoring the order in the command
         // line, so we do the explicit split
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner { withArguments(taskName, "--info") }
             .buildAndFail()
 
         // Then
@@ -624,7 +676,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
-                "`variant:$variant` (site=datadoghq.eu):"
+                "`variant:$variant`, " +
+                "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.eu):"
         )
         assertThat(result.output).contains("API key found in Datadog CI config file, using it.")
         assertThat(result.output)
@@ -645,16 +698,17 @@ internal class DdAndroidGradlePluginFunctionalTest {
         val taskName = resolveUploadTask(variant)
 
         // When
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info", "--stacktrace", "-PDD_API_KEY=fakekey")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey"
+            )
+        }
             .buildAndFail()
 
         // Then
@@ -662,7 +716,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
-                "`variant:$variant` (site=datadoghq.com):"
+                "`variant:$variant`, " +
+                "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
         assertThat(result.output).contains(
             "http://github.com:fakeapp/repository.git"
@@ -683,16 +738,17 @@ internal class DdAndroidGradlePluginFunctionalTest {
         val taskName = resolveUploadTask(variant)
 
         // When
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info", "--stacktrace", "-PDD_API_KEY=fakekey")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey"
+            )
+        }
             .buildAndFail()
 
         // Then
@@ -700,7 +756,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "Uploading mapping file with tags " +
                 "`service:com.example.variants.$variantVersionName`, " +
                 "`version:1.0-$variantVersionName`, " +
-                "`variant:$variant` (site=datadoghq.com):"
+                "`variant:$variant`, " +
+                "`buildId:${testProjectDir.findBuildId(variant)}` (site=datadoghq.com):"
         )
         val optimizedFile = Path(
             appRootDir.path,
@@ -727,16 +784,17 @@ internal class DdAndroidGradlePluginFunctionalTest {
         val taskName = resolveUploadTask(variant)
 
         // When
-        GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:assembleRelease")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments(taskName, "--info", "--stacktrace", "-PDD_API_KEY=fakekey")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey"
+            )
+        }
             .buildAndFail()
 
         // Then
@@ -752,10 +810,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
 
         // When
-        val result = GradleRunner.create()
-            .withProjectDir(testProjectDir)
-            .withArguments("--info", ":samples:app:tasks")
-            .withPluginClasspath(getTestConfigurationClasspath())
+        val result = gradleRunner { withArguments("--info", ":samples:app:tasks") }
             .build()
 
         // Then
@@ -792,6 +847,27 @@ internal class DdAndroidGradlePluginFunctionalTest {
         properties["implementation-classpath"] = System.getProperty("java.class.path")
         return PluginUnderTestMetadataReading
             .readImplementationClasspath("gradle-runner-classpath", properties)
+    }
+
+    private fun gradleRunner(configure: GradleRunner.() -> Unit): GradleRunner {
+        return GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withPluginClasspath(getTestConfigurationClasspath())
+            .apply {
+                configure(this)
+            }
+    }
+
+    private fun File.findBuildId(variantName: String): String {
+        return walk()
+            .filter {
+                it.name == GenerateBuildIdTask.BUILD_ID_FILE_NAME &&
+                    it.path.contains(variantName)
+            }
+            .map {
+                it.readText()
+            }
+            .first()
     }
 
     // endregion
@@ -871,5 +947,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
 
         const val OLD_AGP_VERSION = "7.1.2"
         const val LATEST_AGP_VERSION = "8.1.0"
+
+        const val BUILD_ID_FILE_PATH_APK = "assets/datadog.buildId"
+        const val BUILD_ID_FILE_PATH_AAB = "base/assets/datadog.buildId"
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -86,7 +86,7 @@ internal class DdAndroidGradlePluginTest {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
         fakeBuildId = forge.getForgery<UUID>().toString()
         fakeProject = ProjectBuilder.builder().build()
-        testedPlugin = DdAndroidGradlePlugin(mock())
+        testedPlugin = DdAndroidGradlePlugin(mock(), mock())
         setEnv(DdAndroidGradlePlugin.DD_API_KEY, "")
         setEnv(DdAndroidGradlePlugin.DATADOG_API_KEY, "")
     }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -25,7 +25,10 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.api.Project
+import org.gradle.api.Transformer
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,11 +38,13 @@ import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -59,6 +64,8 @@ internal class DdAndroidGradlePluginTest {
     @Mock
     lateinit var mockBuildType: BuildType
 
+    lateinit var fakeBuildId: String
+
     @Forgery
     lateinit var fakeExtension: DdExtension
 
@@ -77,16 +84,17 @@ internal class DdAndroidGradlePluginTest {
             source = forge.aValueFrom(ApiKeySource::class.java)
         )
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
+        fakeBuildId = forge.getForgery<UUID>().toString()
         fakeProject = ProjectBuilder.builder().build()
         testedPlugin = DdAndroidGradlePlugin(mock())
         setEnv(DdAndroidGradlePlugin.DD_API_KEY, "")
         setEnv(DdAndroidGradlePlugin.DATADOG_API_KEY, "")
     }
 
-    // region configureVariant()
+    // region configureVariantForUploadTask()
 
     @Test
-    fun `𝕄 configure the upload task with the variant info 𝕎 configureVariant()`(
+    fun `𝕄 configure the upload task with the variant info 𝕎 configureVariantForUploadTask()`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -109,6 +117,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -130,10 +139,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 configure the upload task with the extension info 𝕎 configureVariant()`(
+    fun `𝕄 configure the upload task with the extension info 𝕎 configureVariantForUploadTask()`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -153,6 +163,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -176,10 +187,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 configure the upload task with sanitized mapping aliases 𝕎 configureVariant()`(
+    fun `𝕄 configure the upload task with sanitized mapping aliases 𝕎 configureVariantForUploadTask()`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -209,6 +221,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -232,10 +245,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 use sensible defaults 𝕎 configureVariant() { empty config }`(
+    fun `𝕄 use sensible defaults 𝕎 configureVariantForUploadTask() { empty config }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -263,6 +277,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -284,10 +299,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 apply datadog CI file 𝕎 configureVariant()`(
+    fun `𝕄 apply datadog CI file 𝕎 configureVariantForUploadTask()`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -319,6 +335,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -340,10 +357,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isEqualTo(fakeDatadogCiFile)
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 not apply datadog CI file 𝕎 configureVariant() { ignoreDatadogCiFileConfig }`(
+    fun `𝕄 not apply datadog CI file 𝕎 configureVariantForUploadTask() { ignoreDatadogCiFileConfig }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -375,6 +393,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -396,10 +415,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     @Test
-    fun `𝕄 do nothing 𝕎 configureVariant() { no deobfuscation }`(
+    fun `𝕄 not create upload and buildId tasks 𝕎 configureTasksForVariant() { no deobfuscation }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -415,19 +435,22 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockBuildType.name) doReturn fakeBuildTypeName
 
         // When
-        val task = testedPlugin.configureVariantForUploadTask(
+        testedPlugin.configureTasksForVariant(
             fakeProject,
+            mock(),
+            fakeExtension,
             mockVariant,
-            fakeApiKey,
-            fakeExtension
+            fakeApiKey
         )
 
         // Then
-        assertThat(task).isNull()
+        val allTasks = fakeProject.tasks.map { it.name }
+        assertThat(allTasks).allMatch { !it.startsWith(DdAndroidGradlePlugin.UPLOAD_TASK_NAME) }
+        assertThat(allTasks).allMatch { !it.startsWith(GenerateBuildIdTask.TASK_NAME) }
     }
 
     @Test
-    fun `𝕄 configure the upload task 𝕎 configureVariant() { non default obfuscation }`(
+    fun `𝕄 configure the upload task 𝕎 configureVariantForUploadTask() { non default obfuscation }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -448,6 +471,7 @@ internal class DdAndroidGradlePluginTest {
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
+            mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
         )
@@ -471,6 +495,7 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
+        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
     }
 
     // endregion
@@ -1174,6 +1199,17 @@ internal class DdAndroidGradlePluginTest {
         tree.last().mkdirs()
 
         return tree
+    }
+
+    private fun mockBuildIdGenerationTask(buildId: String): TaskProvider<GenerateBuildIdTask> {
+        return mock<TaskProvider<GenerateBuildIdTask>>().apply {
+            val mockBuildIdProvider = mock<Provider<String>>().apply {
+                whenever(get()) doReturn buildId
+            }
+            whenever(
+                flatMap(any<Transformer<Provider<String>, GenerateBuildIdTask>>())
+            ) doReturn mockBuildIdProvider
+        }
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -16,6 +16,7 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
 import org.json.JSONArray
 import org.json.JSONObject
@@ -34,11 +35,13 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -61,6 +64,8 @@ internal class DdMappingFileUploadTaskTest {
 
     @StringForgery
     lateinit var fakeVariant: String
+
+    lateinit var fakeBuildId: String
 
     @StringForgery
     lateinit var fakeVersion: String
@@ -105,12 +110,14 @@ internal class DdMappingFileUploadTaskTest {
             value = forge.anHexadecimalString(),
             source = forge.aValueFrom(ApiKeySource::class.java)
         )
+        fakeBuildId = forge.getForgery<UUID>().toString()
         testedTask.apiKey = fakeApiKey.value
         testedTask.apiKeySource = fakeApiKey.source
         testedTask.variantName = fakeVariant
         testedTask.versionName = fakeVersion
         testedTask.serviceName = fakeService
         testedTask.site = fakeSite.name
+        testedTask.buildId = mock<Provider<String>>().apply { whenever(get()) doReturn fakeBuildId }
         setEnv(DdMappingFileUploadTask.DATADOG_SITE, "")
     }
 
@@ -142,7 +149,8 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
-                variant = fakeVariant
+                variant = fakeVariant,
+                buildId = fakeBuildId
             ),
             fakeRepoInfo,
             useGzip = true
@@ -188,7 +196,8 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
-                        variant = fakeVariant
+                        variant = fakeVariant,
+                        buildId = fakeBuildId
                     )
                 ),
                 eq(fakeRepoInfo),
@@ -237,7 +246,8 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
-                        variant = fakeVariant
+                        variant = fakeVariant,
+                        buildId = fakeBuildId
                     )
                 ),
                 eq(fakeRepoInfo),
@@ -290,7 +300,8 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
-                        variant = fakeVariant
+                        variant = fakeVariant,
+                        buildId = fakeBuildId
                     )
                 ),
                 eq(fakeRepoInfo),
@@ -324,7 +335,8 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
-                variant = fakeVariant
+                variant = fakeVariant,
+                buildId = fakeBuildId
             ),
             fakeRepoInfo,
             useGzip = true
@@ -358,7 +370,8 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
-                variant = fakeVariant
+                variant = fakeVariant,
+                buildId = fakeBuildId
             ),
             null,
             useGzip = true
@@ -453,7 +466,8 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
-                variant = fakeVariant
+                variant = fakeVariant,
+                buildId = fakeBuildId
             ),
             fakeRepoInfo,
             useGzip = true

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -12,6 +12,7 @@ import com.datadog.gradle.plugin.internal.DdAppIdentifier
 import com.datadog.gradle.plugin.internal.Uploader
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -70,6 +71,9 @@ internal class DdMappingFileUploadTaskTest {
     @StringForgery
     lateinit var fakeVersion: String
 
+    @IntForgery(min = 0)
+    var fakeVersionCode: Int = 0
+
     @StringForgery
     lateinit var fakeService: String
 
@@ -115,6 +119,7 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.apiKeySource = fakeApiKey.source
         testedTask.variantName = fakeVariant
         testedTask.versionName = fakeVersion
+        testedTask.versionCode = fakeVersionCode
         testedTask.serviceName = fakeService
         testedTask.site = fakeSite.name
         testedTask.buildId = mock<Provider<String>>().apply { whenever(get()) doReturn fakeBuildId }
@@ -149,6 +154,7 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
+                versionCode = fakeVersionCode,
                 variant = fakeVariant,
                 buildId = fakeBuildId
             ),
@@ -196,6 +202,7 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
+                        versionCode = fakeVersionCode,
                         variant = fakeVariant,
                         buildId = fakeBuildId
                     )
@@ -246,6 +253,7 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
+                        versionCode = fakeVersionCode,
                         variant = fakeVariant,
                         buildId = fakeBuildId
                     )
@@ -300,6 +308,7 @@ internal class DdMappingFileUploadTaskTest {
                     DdAppIdentifier(
                         serviceName = fakeService,
                         version = fakeVersion,
+                        versionCode = fakeVersionCode,
                         variant = fakeVariant,
                         buildId = fakeBuildId
                     )
@@ -335,6 +344,7 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
+                versionCode = fakeVersionCode,
                 variant = fakeVariant,
                 buildId = fakeBuildId
             ),
@@ -370,6 +380,7 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
+                versionCode = fakeVersionCode,
                 variant = fakeVariant,
                 buildId = fakeBuildId
             ),
@@ -466,6 +477,7 @@ internal class DdMappingFileUploadTaskTest {
             DdAppIdentifier(
                 serviceName = fakeService,
                 version = fakeVersion,
+                versionCode = fakeVersionCode,
                 variant = fakeVariant,
                 buildId = fakeBuildId
             ),

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/IdentifierForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/IdentifierForgeryFactory.kt
@@ -16,6 +16,7 @@ internal class IdentifierForgeryFactory : ForgeryFactory<DdAppIdentifier> {
         return DdAppIdentifier(
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}"),
             version = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}"),
+            versionCode = forge.aPositiveInt(),
             variant = forge.anAlphabeticalString(),
             buildId = forge.getForgery<UUID>().toString()
         )

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/IdentifierForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/IdentifierForgeryFactory.kt
@@ -9,13 +9,15 @@ package com.datadog.gradle.plugin
 import com.datadog.gradle.plugin.internal.DdAppIdentifier
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
 
 internal class IdentifierForgeryFactory : ForgeryFactory<DdAppIdentifier> {
     override fun getForgery(forge: Forge): DdAppIdentifier {
         return DdAppIdentifier(
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}"),
             version = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}"),
-            variant = forge.anAlphabeticalString()
+            variant = forge.anAlphabeticalString(),
+            buildId = forge.getForgery<UUID>().toString()
         )
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -171,6 +171,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -219,6 +220,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -265,6 +267,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -312,6 +315,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -368,6 +372,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -421,6 +426,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -490,6 +496,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -547,6 +554,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"
@@ -603,6 +611,7 @@ internal class OkHttpUploaderTest {
                 "event",
                 "{\"service\":\"${fakeIdentifier.serviceName}\"," +
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
+                    "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
                     "\"version\":\"${fakeIdentifier.version}\"}",
                 "application/json; charset=utf-8"

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -173,7 +173,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -222,7 +223,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -269,7 +271,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -317,7 +320,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -374,7 +378,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -428,7 +433,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -498,7 +504,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -556,7 +563,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(
@@ -613,7 +621,8 @@ internal class OkHttpUploaderTest {
                     "\"variant\":\"${fakeIdentifier.variant}\"," +
                     "\"buildId\":\"${fakeIdentifier.buildId}\"," +
                     "\"type\":\"${OkHttpUploader.TYPE_JVM_MAPPING_FILE}\"," +
-                    "\"version\":\"${fakeIdentifier.version}\"}",
+                    "\"version\":\"${fakeIdentifier.version}\"," +
+                    "\"versionCode\":${fakeIdentifier.versionCode}}",
                 "application/json; charset=utf-8"
             )
             .containsMultipartFile(


### PR DESCRIPTION
### What does this PR do?

This PR brings support of so-called build ID, which will allow us to precisely match stacktrace sent to Datadog with a mapping file.

This is achieved by generating build ID with each build, so that it can be added to the mapping file upload metadata and also stored as a file in the `assets` folder of the application which is going to be built, so that it can be later read by the SDK in runtime and added to the RUM/Logs errors. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

