### PR TITLE
RUM-2451: Run functional tests against different AGP versions

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JUnitConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JUnitConfig.kt
@@ -9,12 +9,14 @@ package com.datadog.gradle.config
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 
-@Suppress("UnstableApiUsage")
 fun Project.junitConfig() {
     tasks.withType(Test::class.java) {
         jvmArgs(
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
             "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+            "--add-opens=java.base/java.net=ALL-UNNAMED",
             "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
             "--add-opens=java.base/java.util=ALL-UNNAMED"
         )
         useJUnitPlatform {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -132,17 +132,17 @@ class DdAndroidGradlePlugin @Inject constructor(
         listOf(
             "package${variantName}Bundle",
             "build${variantName}PreBundle",
-            "lintVitalAnalyze$variantName"
+            "lintVitalAnalyze$variantName",
+            "lintVitalReport$variantName",
+            "generate${variantName}LintVitalReportModel"
         ).forEach {
             target.tasks.findByName(it)?.dependsOn(buildIdGenerationTask)
         }
 
-        listOf(
-            variant.packageApplicationProvider,
-            variant.mergeAssetsProvider
-        ).forEach {
-            it.configure { it.dependsOn(buildIdGenerationTask) }
-        }
+        // don't merge these 2 into list to call forEach, because common superclass for them
+        // is different between AGP versions, which may cause ClassCastException
+        variant.mergeAssetsProvider.configure { it.dependsOn(buildIdGenerationTask) }
+        variant.packageApplicationProvider.configure { it.dependsOn(buildIdGenerationTask) }
 
         return buildIdGenerationTask
     }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_disabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_disabled.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_set_to_warn.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_check_deps_set_to_warn.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_custom_remote_repos_url.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -59,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_datadog_dep.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -59,5 +63,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_lib_module_attached.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -60,5 +64,5 @@ android {
 
 dependencies {
     implementation(project(':samples:lib-module'))
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_minify_not_enabled.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -25,8 +25,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -52,5 +56,5 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_non_default_obfuscation.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -59,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_optimized_mapping.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -59,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_plugin_disabled.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     namespace = "com.example.variants"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -59,7 +63,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_with_variant_override.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")
@@ -54,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation("com.datadoghq:dd-sdk-android-rum:2.3.0")
+    implementation(rootProject.ext.datadogSdkDependency)
 }
 
 datadog {

--- a/dd-sdk-android-gradle-plugin/src/test/resources/build_without_datadog_dep.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/build_without_datadog_dep.gradle
@@ -10,13 +10,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.variants"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -32,8 +32,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
     }
 
     flavorDimensions("version", "colour")

--- a/dd-sdk-android-gradle-plugin/src/test/resources/lib_module_build.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/lib_module_build.gradle
@@ -9,12 +9,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion = 34
-    buildToolsVersion = "34.0.0"
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionName "1.0"
         versionCode 1
         multiDexEnabled = true
@@ -23,11 +23,11 @@ android {
     namespace = "com.example.lib"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = rootProject.ext.jvmTarget
     }
 }


### PR DESCRIPTION
### What does this PR do?

Because of the way [GradleRunner#withPluginClasspath](https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html#withPluginClasspath--) works we were actually running E2E tests always with the AGP version plugin was compiled against.

This PR fixes it, now we will run tests for AGP 7.0.4 and AGP 8.2.0.

Also few issues were discovered thanks to the proper test runs, and they are fixed with this PR as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

