### PR TITLE
Update Datadog SDK to version 2.4.0

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -1080,7 +1080,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
                     buildToolsVersion = buildToolsVersion
                     // some AndroidX dependencies in recent SDK versions require compileSdk >= 33, so downgrading
                     datadogSdkDependency = targetSdkVersion >= 33 ?
-                       "com.datadoghq:dd-sdk-android-rum:2.3.0" : "com.datadoghq:dd-sdk-android:1.15.0"
+                       "com.datadoghq:dd-sdk-android-rum:2.4.0" : "com.datadoghq:dd-sdk-android:1.15.0"
                     jvmTarget = jvmTarget
                 }
                 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.3.0"
+datadogSdk = "2.4.0"
 datadogPluginGradle = "1.12.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog SDK from version 2.3.0 to version 2.4.0: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.3.0...2.4.0)