### PR TITLE
fix: Ensure extra attributes are placed on events

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -109,6 +109,10 @@ internal class OkHttpUploader : Uploader {
         eventJson.put("build_id", identifier.buildId)
         eventJson.put("version_code", identifier.versionCode)
         eventJson.put("type", fileInfo.fileType)
+        fileInfo.extraAttributes.forEach { (key, value) ->
+            eventJson.put(key, value)
+        }
+        LOGGER.info("  event: ${eventJson.toString(0)}")
 
         val builder = MultipartBody.Builder()
         builder.setType(MultipartBody.FORM)


### PR DESCRIPTION
### What does this PR do?

Extra attributes were printed but then ignored by the OkHttpUploader, when they should have been added to the event.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

