### PR TITLE
Prepare release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 1.13.0 / 2024-04-09
+
+* [FEATURE] Inject build ID into mapping file upload and SDK host application as well. See [#211](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/211)
+* [BUGFIX] Add files under kotlin source set to the repository information. See [#212](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/212)
+* [MAINTENANCE] Remove use of deprecated env variables. See [#188](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/188)
+* [MAINTENANCE] Next dev version. See [#201](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/201)
+* [MAINTENANCE] Merge `release/1.12.0` branch into `develop` branch. See [#202](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/202)
+* [MAINTENANCE] Use version 1.12.0 of plugin for sample apps. See [#204](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/204)
+* [MAINTENANCE] Update Datadog SDK to version 2.3.0. See [#207](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/207)
+* [MAINTENANCE] Update build tooling to target API 34. See [#208](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/208)
+* [MAINTENANCE] Fix CI visibility integration. See [#209](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/209)
+* [MAINTENANCE] Run functional tests against different AGP versions. See [#214](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/214)
+* [MAINTENANCE] Update `CODEOWNERS` to include `rum-mobile-android`. See [#213](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/213)
+* [MAINTENANCE] Update Datadog SDK to version 2.4.0. See [#215](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/215)
+* [MAINTENANCE] Use snake case for properties in mapping file event. See [#217](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/217)
+* [MAINTENANCE] Update Datadog SDK to version 2.5.0. See [#218](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/218)
+* [MAINTENANCE] Update Datadog SDK to version 2.5.1. See [#219](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/219)
+* [MAINTENANCE] Update CMAKE to 3.22.1 for gitlab builds.. See [#221](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/221)
+* [MAINTENANCE] Update Datadog SDK to version 2.6.0. See [#223](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/223)
+* [MAINTENANCE] Update Datadog SDK to version 2.6.1. See [#224](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/224)
+* [MAINTENANCE] Update Datadog SDK to version 2.6.2. See [#225](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/225)
+* [MAINTENANCE] Remove non-ASCII characters from test names. See [#226](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/226)
+* [MAINTENANCE] Tooling update. See [#227](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/227)
+* [MAINTENANCE] Update AGP to 8.3.1. See [#229](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/229)
+* [MAINTENANCE] Update Datadog SDK to version 2.7.0. See [#230](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/230)
+* [MAINTENANCE] Update Datadog SDK to version 2.7.1. See [#231](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/231)
+
 # 1.12.0 / 2023-10-30
 
 * [IMPROVEMENT] Make plugin compatible with Kotlin Script. See [#197](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/197)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -20,7 +20,7 @@ import java.net.URI
 
 object MavenConfig {
 
-    val VERSION = Version(1, 13, 0, Version.Type.Dev)
+    val VERSION = Version(1, 13, 0, Version.Type.Release)
     const val GROUP_ID = "com.datadoghq"
     const val PUBLICATION = "pluginMaven"
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -93,12 +93,12 @@ class DdAndroidGradlePlugin @Inject constructor(
         } else {
             LOGGER.info("Minifying disabled for variant ${variant.name}, no upload task created")
         }
-        configureNdkSymbolUploadTask(
-            target,
-            datadogExtension,
-            variant,
-            buildIdGenerationTask
-        )
+//        configureNdkSymbolUploadTask(
+//            target,
+//            datadogExtension,
+//            variant,
+//            buildIdGenerationTask
+//        )
         configureVariantForSdkCheck(target, variant, datadogExtension)
     }
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -944,123 +944,6 @@ internal class DdAndroidGradlePluginFunctionalTest {
 
     // endregion
 
-    // region NDK Symbol Upload
-
-    @Test
-    fun `M not try to upload the symbol file W no cmake dependencies { using a fake API_KEY }`() {
-        // Given
-        stubGradleBuildFromResourceFile(
-            "build_with_datadog_dep.gradle",
-            appBuildGradleFile
-        )
-        stubNativeFiles()
-
-        val result = gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
-            .build()
-
-        // Then
-        assertThat(result).hasNoNdkSymbolUploadTasks()
-    }
-
-    @Test
-    fun `M try to upload the symbol file W upload { using a fake API_KEY }`(forge: Forge) {
-        // Given
-        stubGradleBuildFromResourceFile(
-            "native_gradle_files/build_with_native_and_datadog_dep.gradle",
-            appBuildGradleFile
-        )
-        stubNativeFiles()
-
-        val color = forge.anElementFrom(colors)
-        val version = forge.anElementFrom(versions)
-        val variantVersionName = version.lowercase()
-        val variant = "${version.lowercase()}$color"
-        val taskName = resolveNdkSymbolUploadTask(variant)
-
-        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
-            .build()
-
-        val result = gradleRunner {
-            withArguments(
-                taskName,
-                "--info",
-                "--stacktrace",
-                "-PDD_API_KEY=fakekey"
-            )
-        }
-            .buildAndFail()
-
-        // Then
-        val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
-
-        assertThat(result).containsInOutput("Creating request with GZIP encoding.")
-
-        assertThat(result).containsInOutput("Uploading ndk_symbol_file file: ")
-
-        assertThat(result).containsInOutput(
-            "Uploading file libplaceholder.so with tags " +
-                "`service:com.example.variants.$variantVersionName`, " +
-                "`version:1.0-$variantVersionName`, " +
-                "`version_code:1`, " +
-                "`variant:$variant`, " +
-                "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
-        )
-
-        for (arch in SUPPORTED_ABIS) {
-            assertThat(result).containsInOutput("extra attributes: {arch=$arch}")
-        }
-    }
-
-    fun `M try to upload the symbol file W upload { using a fake API_KEY, gzip disabled }`(forge: Forge) {
-        // Given
-        stubGradleBuildFromResourceFile(
-            "native_gradle_files/build_with_native_and_datadog_dep.gradle",
-            appBuildGradleFile
-        )
-        stubNativeFiles()
-
-        val color = forge.anElementFrom(colors)
-        val version = forge.anElementFrom(versions)
-        val variantVersionName = version.lowercase()
-        val variant = "${version.lowercase()}$color"
-        val taskName = resolveNdkSymbolUploadTask(variant)
-
-        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
-            .build()
-
-        val result = gradleRunner {
-            withArguments(
-                taskName,
-                "--info",
-                "--stacktrace",
-                "-PDD_API_KEY=fakekey"
-            )
-        }
-            .buildAndFail()
-
-        // Then
-        val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
-
-        assertThat(result).containsInOutput("Creating request without GZIP encoding.")
-
-        assertThat(result).containsInOutput("Uploading ndk_symbol_file file: ")
-
-        assertThat(result).containsInOutput(
-            "Uploading file libplaceholder.so with tags " +
-                "`service:com.example.variants.$variantVersionName`, " +
-                "`version:1.0-$variantVersionName`, " +
-                "`version_code:1`, " +
-                "`variant:$variant`, " +
-                "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
-        )
-
-        for (arch in SUPPORTED_ABIS) {
-            assertThat(result).containsInOutput("extra attributes: {arch=$arch}")
-        }
-    }
-
-    // endregion
-
     @Test
     fun `M try to upload the symbol file and mapping file W upload { using a fake API_KEY }`(forge: Forge) {
         // Given
@@ -1074,22 +957,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
         val version = forge.anElementFrom(versions)
         val variantVersionName = version.lowercase()
         val variant = "${version.lowercase()}$color"
-        val ndkSymbolUploadTaskName = resolveNdkSymbolUploadTask(variant)
         val mappingUploadTaskName = resolveMappingUploadTask(variant)
 
         // When
         gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
-
-        val nativeResult = gradleRunner {
-            withArguments(
-                ndkSymbolUploadTaskName,
-                "--info",
-                "--stacktrace",
-                "-PDD_API_KEY=fakekey"
-            )
-        }
-            .buildAndFail()
 
         val mappingResult = gradleRunner {
             withArguments(
@@ -1106,23 +978,6 @@ internal class DdAndroidGradlePluginFunctionalTest {
         val buildIdInApk = testProjectDir.findBuildIdInApk(variant)
         assertThat(buildIdInApk).isEqualTo(buildIdInOriginFile)
 
-        assertThat(nativeResult).containsInOutput("Creating request with GZIP encoding.")
-
-        assertThat(nativeResult).containsInOutput("Uploading ndk_symbol_file file: ")
-
-        assertThat(nativeResult).containsInOutput(
-            "Uploading file libplaceholder.so with tags " +
-                "`service:com.example.variants.$variantVersionName`, " +
-                "`version:1.0-$variantVersionName`, " +
-                "`version_code:1`, " +
-                "`variant:$variant`, " +
-                "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
-        )
-
-        for (arch in SUPPORTED_ABIS) {
-            assertThat(nativeResult).containsInOutput("extra attributes: {arch=$arch}")
-        }
-
         assertThat(mappingResult).containsInOutput("Creating request with GZIP encoding.")
 
         assertThat(mappingResult).containsInOutput(
@@ -1138,7 +993,6 @@ internal class DdAndroidGradlePluginFunctionalTest {
     // region Internal
 
     private fun resolveMappingUploadTask(variantName: String) = "uploadMapping${variantName}Release"
-    private fun resolveNdkSymbolUploadTask(variantName: String) = "uploadNdkSymbolFiles${variantName}Release"
 
     private fun stubFile(destination: File, content: String) {
         with(destination.outputStream()) {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -10,7 +10,6 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.AndroidSourceDirectorySet
 import com.android.build.gradle.api.AndroidSourceSet
 import com.android.build.gradle.api.ApplicationVariant
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.android.builder.model.BuildType
 import com.android.builder.model.ProductFlavor
 import com.datadog.gradle.plugin.internal.ApiKey
@@ -454,83 +453,6 @@ internal class DdAndroidGradlePluginTest {
         // Then
         val allTasks = fakeProject.tasks.map { it.name }
         assertThat(allTasks).contains("generateBuildId${variantName.replaceFirstChar { capitalizeChar(it) }}")
-    }
-
-    @Test
-    fun `M create uploadSymbol task W configureTasksForVariant() { native build providers }`(
-        @StringForgery(case = Case.LOWER) flavorName: String,
-        @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
-    ) {
-        // Given
-        val mockAppExtension = mockAppExtension()
-
-        val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
-        whenever(mockVariant.name) doReturn variantName
-        whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
-
-        val nativeBuildProviders = listOf(
-            mock<TaskProvider<ExternalNativeBuildTask>>().apply {
-                whenever(flatMap(any<Transformer<Provider<String>, ExternalNativeBuildTask>>())) doReturn mock()
-            }
-        )
-        whenever(mockVariant.externalNativeBuildProviders) doReturn nativeBuildProviders
-
-        // When
-        testedPlugin.configureTasksForVariant(
-            fakeProject,
-            mockAppExtension,
-            fakeExtension,
-            mockVariant,
-            fakeApiKey
-        )
-
-        // Then
-        val allTasks = fakeProject.tasks.map { it.name }
-        assertThat(allTasks).contains("uploadNdkSymbolFiles${variantName.replaceFirstChar { capitalizeChar(it) }}")
-    }
-
-    @Test
-    fun `M not create uploadSymbol task W configureTasksForVariant() { no native build providers }`(
-        @StringForgery(case = Case.LOWER) flavorName: String,
-        @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
-    ) {
-        // Given
-        val mockAppExtension = mockAppExtension()
-
-        val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
-        whenever(mockVariant.name) doReturn variantName
-        whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
-
-        whenever(mockVariant.externalNativeBuildProviders) doReturn listOf()
-
-        // When
-        testedPlugin.configureTasksForVariant(
-            fakeProject,
-            mockAppExtension,
-            fakeExtension,
-            mockVariant,
-            fakeApiKey
-        )
-
-        // Then
-        val allTasks = fakeProject.tasks.map { it.name }
-        assertThat(allTasks).allMatch { !it.startsWith("uploadNdkSymbolFiles") }
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This PR prepares release 1.13.0. It includes commit to skip NDK symbol files upload task creation, because this functionality is not yet completely ready on the backend side, so shouldn't be a part of the release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

