### PR TITLE
RUM-4031: Avoid eager fetching of Variant values

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdFileUploadTask.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
  * Proguard/R8 files, etc.)..
  */
 abstract class DdFileUploadTask @Inject constructor(
-    providerFactory: ProviderFactory,
+    private val providerFactory: ProviderFactory,
     @get:Internal internal val repositoryDetector: RepositoryDetector
 ) : DefaultTask() {
     @get:Internal
@@ -62,10 +62,11 @@ abstract class DdFileUploadTask @Inject constructor(
     var versionName: String = ""
 
     /**
-     * The version code of the application.
+     * The version code of the application. Need to be a provider, because resolution during
+     * configuration phase may cause incompatibility with other plugins if legacy Variant API is used.
      */
     @get:Input
-    var versionCode: Int = 0
+    var versionCode: Provider<Int> = providerFactory.provider { 0 }
 
     /**
      * The service name of the application (by default, it is your app's package name).
@@ -164,7 +165,7 @@ abstract class DdFileUploadTask @Inject constructor(
                     DdAppIdentifier(
                         serviceName = serviceName,
                         version = versionName,
-                        versionCode = versionCode,
+                        versionCode = versionCode.get(),
                         variant = variantName,
                         buildId = buildId.get()
                     ),
@@ -199,7 +200,7 @@ abstract class DdFileUploadTask @Inject constructor(
         site = extensionConfiguration.site ?: ""
 
         versionName = variant.versionName ?: ""
-        versionCode = variant.versionCode
+        versionCode = providerFactory.provider { variant.versionCode }
         serviceName = extensionConfiguration.serviceName ?: variant.applicationId
         variantName = variant.flavorName
         remoteRepositoryUrl = extensionConfiguration.remoteRepositoryUrl ?: ""

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -32,6 +32,7 @@ import org.gradle.api.Project
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
@@ -42,12 +43,14 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.Callable
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -89,7 +92,16 @@ internal class DdAndroidGradlePluginTest {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
         fakeBuildId = forge.getForgery<UUID>().toString()
         fakeProject = ProjectBuilder.builder().build()
-        testedPlugin = DdAndroidGradlePlugin(mock(), mock())
+        val mockProviderFactory = mock<ProviderFactory>()
+        whenever(mockProviderFactory.provider(any<Callable<*>>())) doAnswer {
+            val argument = it.getArgument<Callable<*>>(0)
+            fakeProject.provider(argument)
+        }
+        testedPlugin = DdAndroidGradlePlugin(
+            execOps = mock(),
+            providerFactory = mockProviderFactory
+        )
+
         setEnv(DdAndroidGradlePlugin.DD_API_KEY, "")
         setEnv(DdAndroidGradlePlugin.DATADOG_API_KEY, "")
     }
@@ -123,7 +135,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -169,7 +181,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -227,7 +239,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -283,7 +295,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -341,7 +353,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -399,7 +411,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)
@@ -515,7 +527,7 @@ internal class DdAndroidGradlePluginTest {
             mockBuildIdGenerationTask(fakeBuildId),
             fakeApiKey,
             fakeExtension
-        )
+        ).get()
 
         // Then
         check(task is DdMappingFileUploadTask)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -119,7 +119,9 @@ internal class DdMappingFileUploadTaskTest {
         testedTask.apiKeySource = fakeApiKey.source
         testedTask.variantName = fakeVariant
         testedTask.versionName = fakeVersion
-        testedTask.versionCode = fakeVersionCode
+        testedTask.versionCode = mock<Provider<Int>>().apply {
+            whenever(get()) doReturn fakeVersionCode
+        }
         testedTask.serviceName = fakeService
         testedTask.site = fakeSite.name
         testedTask.buildId = mock<Provider<String>>().apply {


### PR DESCRIPTION
### What does this PR do?

This PR switches to the lazy configuration of upload task by using `TaskContainer#register` API instead of `TaskContainer#create`. This solves the problem of compatibility with https://github.com/Triple-T/gradle-play-publisher plugin which is similar to what described here https://github.com/Triple-T/gradle-play-publisher/issues/940.

Long-term solution will be to switch from the legacy Variant API to the new Variant API.

**Note**: This is a partial fix, because if both tasks try to configure themselves in the same build execution, the problem will still occur. But it is not clear if it should be fixed on our side or problem is on the `gradle-play-publisher` plugin side.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

