### PR TITLE
fix: Standardize architectures

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTask.kt
@@ -42,7 +42,8 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
             .toSet()
             .forEach { file ->
                 val arch = file.parentFile.name
-                require(SUPPORTED_ARCHS.contains(arch))
+                val archMapping = SUPPORTED_ARCHS.firstOrNull { it.arch == arch }
+                require(archMapping != null)
                 files.add(
                     Uploader.UploadFileInfo(
                         KEY_NDK_SYMBOL_FILE,
@@ -51,7 +52,7 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
                         TYPE_NDK_SYMBOL_FILE,
                         file.name,
                         mapOf(
-                            "arch" to arch
+                            "arch" to archMapping.uploadArch
                         )
                     )
                 )
@@ -70,12 +71,23 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
         }
     }
 
+    // Map of Android architecture names to the architecture names recognized by the symbolication service
+    data class SupportedArchitectureMapping(
+        val arch: String,
+        val uploadArch: String
+    )
+
     companion object {
         internal const val TASK_NAME = "uploadNdkSymbolFiles"
         internal const val KEY_NDK_SYMBOL_FILE = "ndk_symbol_file"
         internal const val TYPE_NDK_SYMBOL_FILE = "ndk_symbol_file"
         internal const val ENCODING = "application/octet-stream"
-        internal val SUPPORTED_ARCHS = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+        internal val SUPPORTED_ARCHS = setOf(
+            SupportedArchitectureMapping("armeabi-v7a", "arm"),
+            SupportedArchitectureMapping("arm64-v8a", "arm64"),
+            SupportedArchitectureMapping("x86", "x86"),
+            SupportedArchitectureMapping("x86_64", "x64")
+        )
 
         internal val LOGGER = Logging.getLogger("DdSymbolFileUploadTask")
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -1006,7 +1006,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
         )
 
-        for (arch in SUPPORTED_ABIS) {
+        for (arch in SUPPORTED_ABIS.values) {
             assertThat(result).containsInOutput("extra attributes: {arch=$arch}")
         }
     }
@@ -1054,7 +1054,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
         )
 
-        for (arch in SUPPORTED_ABIS) {
+        for (arch in SUPPORTED_ABIS.values) {
             assertThat(result).containsInOutput("extra attributes: {arch=$arch}")
         }
     }
@@ -1119,7 +1119,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 "`build_id:$buildIdInOriginFile` (site=datadoghq.com):"
         )
 
-        for (arch in SUPPORTED_ABIS) {
+        for (arch in SUPPORTED_ABIS.values) {
             assertThat(nativeResult).containsInOutput("extra attributes: {arch=$arch}")
         }
 
@@ -1228,7 +1228,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
             val jvmTarget: String
         )
 
-        val SUPPORTED_ABIS = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+        val SUPPORTED_ABIS = mapOf(
+            "armeabi-v7a" to "arm",
+            "arm64-v8a" to "arm64",
+            "x86" to "x86",
+            "x86_64" to "x64"
+        )
 
         val APPLICATION_CLASS_CONTENT = """
             package com.datadog.android.sample

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTaskTest.kt
@@ -153,7 +153,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 fileType = DdNdkSymbolFileUploadTask.TYPE_NDK_SYMBOL_FILE,
                 fileName = "libfake.so",
                 extraAttributes = mapOf(
-                    "arch" to "arm64-v8a"
+                    "arch" to "arm64"
                 )
             ),
             fakeRepositoryFile,
@@ -178,7 +178,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
         whenever(mockRepositoryDetector.detectRepositories(any(), eq("")))
             .doReturn(listOf(fakeRepoInfo))
         val fakeSoFiles = mapOf(
-            "arm64-v8a" to writeFakeSoFile("arm64-v8a"),
+            "arm64" to writeFakeSoFile("arm64-v8a"),
             "x86" to writeFakeSoFile("x86")
         )
 
@@ -240,7 +240,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 fileType = DdNdkSymbolFileUploadTask.TYPE_NDK_SYMBOL_FILE,
                 fileName = "libfake.so",
                 extraAttributes = mapOf(
-                    "arch" to "arm64-v8a"
+                    "arch" to "arm64"
                 )
             ),
             fakeRepositoryFile,
@@ -283,7 +283,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 fileType = DdNdkSymbolFileUploadTask.TYPE_NDK_SYMBOL_FILE,
                 fileName = "libfake.so",
                 extraAttributes = mapOf(
-                    "arch" to "arm64-v8a"
+                    "arch" to "arm64"
                 )
             ),
             null,
@@ -328,7 +328,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 forge.anElementFrom("\"", "'") +
                 it.substring(splitIndex)
         }
-        writeFakeSoFile("arm64-v8a")
+        writeFakeSoFile("arm64")
 
         // When
         val exception = assertThrows<IllegalStateException> {
@@ -416,7 +416,7 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 fileType = DdNdkSymbolFileUploadTask.TYPE_NDK_SYMBOL_FILE,
                 fileName = "libfake.so",
                 extraAttributes = mapOf(
-                    "arch" to "arm64-v8a"
+                    "arch" to "arm64"
                 )
             ),
             fakeRepositoryFile,


### PR DESCRIPTION
### What does this PR do?

The symbolication service currently understands `arm`, `arm64`, `x86` and `x64` as valid symbol file architectures. Instead of adding the Android ABIs, we map them to those architectures instead.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

