### PR TITLE
RUM-4374: Emulate upload network call for functional tests

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdFileUploadTask.kt
@@ -41,7 +41,11 @@ abstract class DdFileUploadTask @Inject constructor(
     var apiKey: String = ""
 
     private val disableGzipOption: Provider<String> =
-        providerFactory.gradleProperty(DdFileUploadTask.DISABLE_GZIP_GRADLE_PROPERTY)
+        providerFactory.gradleProperty(DISABLE_GZIP_GRADLE_PROPERTY)
+
+    // needed for functional tests, because we don't have real API key
+    private val emulateNetworkCall: Provider<String> =
+        providerFactory.gradleProperty(EMULATE_UPLOAD_NETWORK_CALL)
 
     /**
      * Source of the API key set: environment, gradle property, etc.
@@ -170,7 +174,8 @@ abstract class DdFileUploadTask @Inject constructor(
                         buildId = buildId.get()
                     ),
                     repositories.firstOrNull(),
-                    !disableGzipOption.isPresent
+                    !disableGzipOption.isPresent,
+                    emulateNetworkCall.isPresent
                 )
             } catch (e: Exception) {
                 caughtErrors.add(e)
@@ -298,7 +303,7 @@ abstract class DdFileUploadTask @Inject constructor(
         }
 
         val jsonObject = JSONObject()
-        jsonObject.put("version", RESPOSITORY_FILE_VERSION)
+        jsonObject.put("version", REPOSITORY_FILE_VERSION)
         jsonObject.put("data", data)
 
         repositoryFile.parentFile.mkdirs()
@@ -306,7 +311,7 @@ abstract class DdFileUploadTask @Inject constructor(
     }
 
     internal companion object {
-        private const val RESPOSITORY_FILE_VERSION = 1
+        private const val REPOSITORY_FILE_VERSION = 1
         private const val INDENT = 4
 
         private const val DATADOG_CI_API_KEY_PROPERTY = "apiKey"
@@ -316,6 +321,7 @@ abstract class DdFileUploadTask @Inject constructor(
         internal val LOGGER = Logging.getLogger("DdFileUploadTask")
 
         const val DISABLE_GZIP_GRADLE_PROPERTY = "dd-disable-gzip"
+        const val EMULATE_UPLOAD_NETWORK_CALL = "dd-emulate-upload-call"
 
         const val API_KEY_MISSING_ERROR = "Make sure you define an API KEY to upload your mapping files to Datadog. " +
             "Create a DD_API_KEY or DATADOG_API_KEY environment variable, gradle" +

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
@@ -56,6 +56,7 @@ internal interface Uploader {
         apiKey: String,
         identifier: DdAppIdentifier,
         repositoryInfo: RepositoryInfo?,
-        useGzip: Boolean
+        useGzip: Boolean = true,
+        emulateNetworkCall: Boolean = false
     )
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -602,10 +602,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         assertThat(result).containsInOutput("Creating request with GZIP encoding.")
@@ -663,10 +664,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 "--info",
                 "--stacktrace",
                 "-PDD_API_KEY=fakekey",
-                "-Pdd-disable-gzip"
+                "-Pdd-disable-gzip",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         assertThat(result).containsInOutput("Creating request without GZIP encoding.")
@@ -727,8 +729,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
         gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
             .build()
 
-        val result = gradleRunner { withArguments(taskName, "--info") }
-            .buildAndFail()
+        val result = gradleRunner { withArguments(taskName, "--info", "-Pdd-emulate-upload-call") }
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
@@ -783,10 +785,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
@@ -838,10 +841,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
@@ -902,10 +906,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         assertThat(result).containsInOutput(
@@ -985,10 +990,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
@@ -1033,10 +1039,11 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 taskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)
@@ -1086,20 +1093,22 @@ internal class DdAndroidGradlePluginFunctionalTest {
                 ndkSymbolUploadTaskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         val mappingResult = gradleRunner {
             withArguments(
                 mappingUploadTaskName,
                 "--info",
                 "--stacktrace",
-                "-PDD_API_KEY=fakekey"
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call"
             )
         }
-            .buildAndFail()
+            .build()
 
         // Then
         val buildIdInOriginFile = testProjectDir.findBuildIdInOriginFile(variant)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdMappingFileUploadTaskTest.kt
@@ -170,7 +170,8 @@ internal class DdMappingFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(
@@ -219,7 +220,8 @@ internal class DdMappingFileUploadTaskTest {
                     )
                 ),
                 eq(fakeRepoInfo),
-                useGzip = eq(true)
+                useGzip = eq(true),
+                emulateNetworkCall = eq(false)
             )
             assertThat(lastValue.file).hasSameTextualContentAs(
                 fileFromResourcesPath("mapping-with-aliases.txt")
@@ -270,7 +272,8 @@ internal class DdMappingFileUploadTaskTest {
                     )
                 ),
                 eq(fakeRepoInfo),
-                useGzip = eq(true)
+                useGzip = eq(true),
+                emulateNetworkCall = eq(false)
             )
             assertThat(lastValue.file.readLines()).isEqualTo(expectedLines)
         }
@@ -325,7 +328,8 @@ internal class DdMappingFileUploadTaskTest {
                     )
                 ),
                 eq(fakeRepoInfo),
-                useGzip = eq(true)
+                useGzip = eq(true),
+                emulateNetworkCall = eq(false)
             )
             assertThat(lastValue.file.readLines()).isEqualTo(expectedLines)
         }
@@ -366,7 +370,8 @@ internal class DdMappingFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(
@@ -408,7 +413,8 @@ internal class DdMappingFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             null,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
     }
 
@@ -551,7 +557,8 @@ internal class DdMappingFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
         assertThat(fakeRepositoryFile.readText())
             .isEqualTo(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTaskTest.kt
@@ -166,7 +166,8 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
     }
 
@@ -209,7 +210,8 @@ internal class DdNdkSymbolFileUploadTaskTest {
                     buildId = fakeBuildId
                 ),
                 fakeRepoInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
     }
@@ -253,7 +255,8 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
         Assertions.assertThat(fakeRepositoryFile.readText())
             .isEqualTo(
@@ -296,7 +299,8 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             null,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
     }
 
@@ -382,7 +386,6 @@ internal class DdNdkSymbolFileUploadTaskTest {
 
         // Given
         testedTask.site = siteName
-        val fakeSoFile = writeFakeSoFile("arm64-v8a")
 
         // When
         assertThrows<IllegalStateException> {
@@ -429,7 +432,8 @@ internal class DdNdkSymbolFileUploadTaskTest {
                 buildId = fakeBuildId
             ),
             fakeRepoInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
     }
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -164,7 +164,8 @@ internal class OkHttpUploaderTest {
             fakeApiKey,
             fakeIdentifier,
             fakeRepositoryInfo,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
 
         // Then
@@ -209,7 +210,8 @@ internal class OkHttpUploaderTest {
             fakeApiKey,
             fakeIdentifier,
             fakeRepositoryInfo,
-            useGzip = false
+            useGzip = false,
+            emulateNetworkCall = false
         )
 
         // Then
@@ -254,7 +256,8 @@ internal class OkHttpUploaderTest {
             fakeApiKey,
             fakeIdentifier,
             null,
-            useGzip = true
+            useGzip = true,
+            emulateNetworkCall = false
         )
 
         // Then
@@ -295,7 +298,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -348,7 +352,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -398,7 +403,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -464,7 +470,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -518,7 +525,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -571,7 +579,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
 
@@ -621,7 +630,8 @@ internal class OkHttpUploaderTest {
                 fakeApiKey,
                 fakeIdentifier,
                 fakeRepositoryInfo,
-                useGzip = true
+                useGzip = true,
+                emulateNetworkCall = false
             )
         }
         assertThat(exception.message).isEqualTo(


### PR DESCRIPTION
### What does this PR do?

Right now we are calling the real intake for the functional tests of Gradle Plugin, and since we don’t have a real API key, we get an error and we expect build failure in our tests. However, it may be some other build failures, so it is handy to emulate network call to make test expectation without any build failures.

This PR adds build parameter `dd-emulate-upload-call` which can be passed for the build script execution. If it is present, no real network call will be made and we will create a fake response.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

