### PR TITLE
RUM-4292: Mark upload task as not compatible with configuration cache

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -188,6 +188,13 @@ class DdAndroidGradlePlugin @Inject constructor(
             GitRepositoryDetector(execOps)
         ).apply {
             configure { uploadTask ->
+                @Suppress("MagicNumber")
+                if (DdTaskUtils.isGradleAbove(target, 7, 5)) {
+                    uploadTask.notCompatibleWithConfigurationCache(
+                        "Datadog Upload Mapping task is not" +
+                            " compatible with configuration cache yet."
+                    )
+                }
                 val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
                 configureVariantTask(uploadTask, apiKey, variant.flavorName, extensionConfiguration, variant)
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdTaskUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdTaskUtils.kt
@@ -29,15 +29,23 @@ internal object DdTaskUtils {
         return null
     }
 
-    @Suppress("MagicNumber", "ReturnCount")
     fun isAgpAbove(major: Int, minor: Int, patch: Int): Boolean {
-        val version = Version.ANDROID_GRADLE_PLUGIN_VERSION
-        val groups = version.split(".")
-        if (groups.size < 3) return false
-        val currentMajor = groups[0].toIntOrNull()
-        val currentMinor = groups[1].toIntOrNull()
-        val currentPatch = groups[2].substringBefore("-").toIntOrNull()
-        if (currentMajor == null || currentMinor == null || currentPatch == null) return false
+        return isVersionAbove(Version.ANDROID_GRADLE_PLUGIN_VERSION, major, minor, patch)
+    }
+
+    // Gradle version may not have patch version
+    fun isGradleAbove(project: Project, major: Int, minor: Int, patch: Int = 0): Boolean {
+        return isVersionAbove(project.gradle.gradleVersion, major, minor, patch)
+    }
+
+    @Suppress("MagicNumber", "ReturnCount")
+    private fun isVersionAbove(refVersion: String, major: Int, minor: Int, patch: Int): Boolean {
+        val groups = refVersion.split(".")
+        // should be at least major and minor versions
+        if (groups.size < 2) return false
+        val currentMajor = groups[0].toIntOrNull() ?: 0
+        val currentMinor = groups[1].toIntOrNull() ?: 0
+        val currentPatch = groups.getOrNull(2)?.substringBefore("-")?.toIntOrNull() ?: 0
         return currentMajor >= major && currentMinor >= minor && currentPatch >= patch
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR will mark upload task as not compatible with configuration cache, meaning it won't be recorded for the configuration cache.

This fixes the issue #251.

Note, that we may come back to the configuration cache support for this task in the future, but for now the issue is that task input expects build ID file to be present, and it will be present only after build run, not at the configuration phase. Complete configuration cache support thus will require major logic changes, which may be not worth it, considering that configuration for this task is very fast.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

