### PR TITLE
RUM-4406: Avoid BuildId task creation if there is no obfuscation or native build providers registered

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdNdkSymbolFileUploadTask.kt
@@ -7,7 +7,6 @@ import com.datadog.gradle.plugin.internal.Uploader
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
@@ -89,8 +88,6 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
             SupportedArchitectureMapping("x86_64", "x64")
         )
 
-        internal val LOGGER = Logging.getLogger("DdSymbolFileUploadTask")
-
         private fun getSearchDirs(
             buildTask: TaskProvider<ExternalNativeBuildTask>,
             providerFactory: ProviderFactory
@@ -122,13 +119,7 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
             apiKey: ApiKey,
             extensionConfiguration: DdExtensionConfiguration,
             repositoryDetector: RepositoryDetector
-        ): TaskProvider<DdNdkSymbolFileUploadTask>? {
-            val nativeBuildProviders = variant.externalNativeBuildProviders
-            if (nativeBuildProviders.isEmpty()) {
-                LOGGER.info("No native build tasks found for variant ${variant.name}, skipping NDK symbol file upload.")
-                return null
-            }
-
+        ): TaskProvider<DdNdkSymbolFileUploadTask> {
             return project.tasks.register(
                 TASK_NAME + variant.name.capitalize(),
                 DdNdkSymbolFileUploadTask::class.java,
@@ -145,6 +136,7 @@ internal abstract class DdNdkSymbolFileUploadTask @Inject constructor(
                     }
                     task.sourceSetRoots = roots
 
+                    val nativeBuildProviders = variant.externalNativeBuildProviders
                     nativeBuildProviders.forEach { buildTask ->
                         val searchFiles = getSearchDirs(buildTask, providerFactory)
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -435,7 +435,7 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
-    fun `M create buildId task W configureTasksForVariant() { no deobfuscation }`(
+    fun `M not create buildId task W configureTasksForVariant() { no deobfuscation, no native build providers }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
@@ -465,7 +465,7 @@ internal class DdAndroidGradlePluginTest {
 
         // Then
         val allTasks = fakeProject.tasks.map { it.name }
-        assertThat(allTasks).contains("generateBuildId${variantName.replaceFirstChar { capitalizeChar(it) }}")
+        assertThat(allTasks).doesNotContain("generateBuildId${variantName.replaceFirstChar { capitalizeChar(it) }}")
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This PR will make build ID generation task to be created only if there is obfuscation enabled or there are native build providers.

Partially addresses #258.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

