### PR TITLE
[RUM-4594] Increase upload timeout to 120s to match EvP limits

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -283,7 +283,7 @@ internal class OkHttpUploader : Uploader {
         internal const val KEY_EVENT = "event"
         internal const val KEY_REPOSITORY = "repository"
 
-        internal val NETWORK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60)
+        internal val NETWORK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(120)
         internal val MEDIA_TYPE_JSON = "application/json".toMediaTypeOrNull()
 
         internal const val MAX_MAP_SIZE_EXCEEDED_ERROR =


### PR DESCRIPTION
### What does this PR do?

This PR increases the upload timeout limit from 60s to 120s in all DCs. This change was made in order to support customers with slower upload speeds. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

