### PR TITLE
RUM-592: Support new Variant API

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -25,7 +25,6 @@ object MavenConfig {
     const val PUBLICATION = "pluginMaven"
 }
 
-@Suppress("UnstableApiUsage")
 fun Project.publishingConfig(projectDescription: String) {
     val projectName = name
     val signingExtension = extensions.findByType(SigningExtension::class)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/CheckSdkDepsTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/CheckSdkDepsTask.kt
@@ -21,7 +21,7 @@ import java.util.Queue
 /**
  * A Gradle task to check the Datadog SDK throughout the variant dependencies.
  */
-abstract class DdCheckSdkDepsTask : DefaultTask() {
+abstract class CheckSdkDepsTask : DefaultTask() {
 
     /**
      * The sdkCheckLevel: NONE, WARN, FAIL.
@@ -47,7 +47,7 @@ abstract class DdCheckSdkDepsTask : DefaultTask() {
     init {
         group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
         description = "Checks for the Datadog SDK into your variant dependencies."
-        outputs.upToDateWhen { it is DdCheckSdkDepsTask && it.isLastRunSuccessful }
+        outputs.upToDateWhen { it is CheckSdkDepsTask && it.isLastRunSuccessful }
     }
 
     /**

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -6,16 +6,22 @@
 
 package com.datadog.gradle.plugin
 
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.AppExtension
-import com.android.build.gradle.api.ApplicationVariant
 import com.datadog.gradle.plugin.internal.ApiKey
 import com.datadog.gradle.plugin.internal.ApiKeySource
+import com.datadog.gradle.plugin.internal.CurrentAgpVersion
 import com.datadog.gradle.plugin.internal.GitRepositoryDetector
 import com.datadog.gradle.plugin.internal.VariantIterator
+import com.datadog.gradle.plugin.internal.lazyBuildIdProvider
+import com.datadog.gradle.plugin.internal.variant.AppVariant
+import com.datadog.gradle.plugin.internal.variant.NewApiAppVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.RegularFile
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -43,16 +49,28 @@ class DdAndroidGradlePlugin @Inject constructor(
         // need to use withPlugin instead of afterEvaluate, because otherwise generated assets
         // folder with buildId is not picked by AGP by some reason
         target.pluginManager.withPlugin("com.android.application") {
-            val androidExtension = target.androidApplicationExtension ?: return@withPlugin
-            androidExtension.applicationVariants.all { variant ->
-                if (extension.enabled) {
+            if (CurrentAgpVersion.CAN_ENABLE_NEW_VARIANT_API && !target.hasProperty(DD_FORCE_LEGACY_VARIANT_API)
+            ) {
+                val androidComponentsExtension = target.androidApplicationComponentExtension ?: return@withPlugin
+                androidComponentsExtension.onVariants { variant ->
                     configureTasksForVariant(
                         target,
-                        androidExtension,
                         extension,
-                        variant,
+                        AppVariant.create(variant, target),
                         apiKey
                     )
+                }
+            } else {
+                val androidExtension = target.androidApplicationExtension ?: return@withPlugin
+                androidExtension.applicationVariants.all { variant ->
+                    if (extension.enabled) {
+                        configureTasksForVariant(
+                            target,
+                            extension,
+                            AppVariant.create(variant, androidExtension, target),
+                            apiKey
+                        )
+                    }
                 }
             }
         }
@@ -73,17 +91,16 @@ class DdAndroidGradlePlugin @Inject constructor(
 
     internal fun configureTasksForVariant(
         target: Project,
-        androidExtension: AppExtension,
         datadogExtension: DdExtension,
-        variant: ApplicationVariant,
+        variant: AppVariant,
         apiKey: ApiKey
     ) {
         val isObfuscationEnabled = isObfuscationEnabled(variant, datadogExtension)
-        val isNativeBuildRequired = variant.externalNativeBuildProviders.isNotEmpty()
+        val isNativeBuildRequired = variant.isNativeBuildEnabled
 
         if (isObfuscationEnabled || isNativeBuildRequired) {
             val buildIdGenerationTask =
-                configureBuildIdGenerationTask(target, androidExtension, variant)
+                configureBuildIdGenerationTask(target, variant)
 
             if (isObfuscationEnabled) {
                 configureVariantForUploadTask(
@@ -112,7 +129,15 @@ class DdAndroidGradlePlugin @Inject constructor(
                 )
             }
         }
-        configureVariantForSdkCheck(target, variant, datadogExtension)
+
+        if (variant is NewApiAppVariant) {
+            // need to run this in afterEvaluate, because with new Variant API tasks won't be created yet at this point
+            target.afterEvaluate {
+                configureVariantForSdkCheck(target, variant, datadogExtension)
+            }
+        } else {
+            configureVariantForSdkCheck(target, variant, datadogExtension)
+        }
     }
 
     @Suppress("ReturnCount")
@@ -128,16 +153,16 @@ class DdAndroidGradlePlugin @Inject constructor(
         return apiKey ?: ApiKey.NONE
     }
 
-    internal fun configureNdkSymbolUploadTask(
+    private fun configureNdkSymbolUploadTask(
         target: Project,
         extension: DdExtension,
-        variant: ApplicationVariant,
+        variant: AppVariant,
         buildIdTask: TaskProvider<GenerateBuildIdTask>,
         apiKey: ApiKey
-    ): TaskProvider<DdNdkSymbolFileUploadTask> {
+    ): TaskProvider<NdkSymbolFileUploadTask> {
         val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
 
-        val uploadTask = DdNdkSymbolFileUploadTask.register(
+        val uploadTask = NdkSymbolFileUploadTask.register(
             target,
             variant,
             buildIdTask,
@@ -151,38 +176,13 @@ class DdAndroidGradlePlugin @Inject constructor(
     }
 
     @Suppress("StringLiteralDuplication")
-    internal fun configureBuildIdGenerationTask(
+    private fun configureBuildIdGenerationTask(
         target: Project,
-        appExtension: AppExtension,
-        variant: ApplicationVariant
+        variant: AppVariant
     ): TaskProvider<GenerateBuildIdTask> {
         val buildIdDirectory = target.layout.buildDirectory
             .dir(Path("generated", "datadog", "buildId", variant.name).toString())
         val buildIdGenerationTask = GenerateBuildIdTask.register(target, variant, buildIdDirectory)
-
-        // we could generate buildIdDirectory inside GenerateBuildIdTask and read it here as
-        // property using flatMap, but when Gradle sync is done inside Android Studio there is an error
-        // Querying the mapped value of provider (java.util.Set) before task ... has completed is
-        // not supported, which doesn't happen when Android Studio is not used (pure Gradle build)
-        // so applying such workaround
-        // TODO RUM-0000 use new AndroidComponents API to inject generated stuff, it is more friendly
-        appExtension.sourceSets.getByName(variant.name).assets.srcDir(buildIdDirectory)
-
-        val variantName = variant.name.capitalize()
-        listOf(
-            "package${variantName}Bundle",
-            "build${variantName}PreBundle",
-            "lintVitalAnalyze$variantName",
-            "lintVitalReport$variantName",
-            "generate${variantName}LintVitalReportModel"
-        ).forEach {
-            target.tasks.findByName(it)?.dependsOn(buildIdGenerationTask)
-        }
-
-        // don't merge these 2 into list to call forEach, because common superclass for them
-        // is different between AGP versions, which may cause ClassCastException
-        variant.mergeAssetsProvider.configure { it.dependsOn(buildIdGenerationTask) }
-        variant.packageApplicationProvider.configure { it.dependsOn(buildIdGenerationTask) }
 
         return buildIdGenerationTask
     }
@@ -190,20 +190,20 @@ class DdAndroidGradlePlugin @Inject constructor(
     @Suppress("DefaultLocale", "ReturnCount")
     internal fun configureVariantForUploadTask(
         target: Project,
-        variant: ApplicationVariant,
+        variant: AppVariant,
         buildIdGenerationTask: TaskProvider<GenerateBuildIdTask>,
         apiKey: ApiKey,
         extension: DdExtension
-    ): TaskProvider<DdMappingFileUploadTask> {
+    ): TaskProvider<MappingFileUploadTask> {
         val uploadTaskName = UPLOAD_TASK_NAME + variant.name.capitalize()
         val uploadTask = target.tasks.register(
             uploadTaskName,
-            DdMappingFileUploadTask::class.java,
+            MappingFileUploadTask::class.java,
             GitRepositoryDetector(execOps)
         ).apply {
             configure { uploadTask ->
                 @Suppress("MagicNumber")
-                if (DdTaskUtils.isGradleAbove(target, 7, 5)) {
+                if (TaskUtils.isGradleAbove(target, 7, 5)) {
                     uploadTask.notCompatibleWithConfigurationCache(
                         "Datadog Upload Mapping task is not" +
                             " compatible with configuration cache yet."
@@ -212,42 +212,18 @@ class DdAndroidGradlePlugin @Inject constructor(
                 val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
                 configureVariantTask(uploadTask, apiKey, variant.flavorName, extensionConfiguration, variant)
 
-                // upload task shouldn't depend on the build ID generation task, but only read its property,
-                // because upload task may be triggered after assemble task and we don't want to re-generate
-                // build ID, because it will be different then from the one which is already embedded in
-                // the application package
-                uploadTask.buildId = buildIdGenerationTask.flatMap {
-                    it.buildIdFile.flatMap {
-                        providerFactory.provider { it.asFile.readText().trim() }
-                    }
-                }
-                uploadTask.mappingFilePath = resolveMappingFilePath(extensionConfiguration, target, variant)
-                uploadTask.mappingFilePackagesAliases =
-                    filterMappingFileReplacements(
-                        extensionConfiguration.mappingFilePackageAliases,
-                        variant.applicationId
-                    )
+                uploadTask.buildId.set(buildIdGenerationTask.lazyBuildIdProvider(providerFactory))
+
+                uploadTask.applicationId.set(variant.applicationId)
+                uploadTask.mappingFile.set(resolveMappingFile(extensionConfiguration, target, variant))
+                uploadTask.mappingFilePackagesAliases = extensionConfiguration.mappingFilePackageAliases
                 uploadTask.mappingFileTrimIndents = extensionConfiguration.mappingFileTrimIndents
                 if (!extensionConfiguration.ignoreDatadogCiFileConfig) {
-                    uploadTask.datadogCiFile = DdTaskUtils.findDatadogCiFile(target.projectDir)
+                    uploadTask.datadogCiFile = TaskUtils.findDatadogCiFile(target.projectDir)
                 }
 
-                uploadTask.repositoryFile = DdTaskUtils.resolveDatadogRepositoryFile(target)
-
-                val roots = mutableListOf<File>()
-                variant.sourceSets.forEach {
-                    roots.addAll(it.javaDirectories)
-                    @Suppress("MagicNumber")
-                    if (DdTaskUtils.isAgpAbove(7, 0, 0)) {
-                        roots.addAll(it.kotlinDirectories)
-                    }
-                }
-
-                // it can be an overlap between java and kotlin directories and since File doesn't override
-                // equals for set comparison, we will remove duplicates manually
-                uploadTask.sourceSetRoots = roots.map { it.absolutePath }
-                    .distinct()
-                    .map { File(it) }
+                uploadTask.repositoryFile = TaskUtils.resolveDatadogRepositoryFile(target)
+                uploadTask.sourceSetRoots.set(variant.collectJavaAndKotlinSourceDirectories())
             }
         }
 
@@ -257,9 +233,9 @@ class DdAndroidGradlePlugin @Inject constructor(
     @Suppress("ReturnCount")
     internal fun configureVariantForSdkCheck(
         target: Project,
-        variant: ApplicationVariant,
+        variant: AppVariant,
         extension: DdExtension
-    ): TaskProvider<DdCheckSdkDepsTask>? {
+    ): TaskProvider<CheckSdkDepsTask>? {
         if (!extension.enabled) {
             LOGGER.info("Extension disabled for variant ${variant.name}, no sdk check task created")
             return null
@@ -289,7 +265,7 @@ class DdAndroidGradlePlugin @Inject constructor(
                 extensionConfiguration.checkProjectDependencies ?: SdkCheckLevel.FAIL
             val checkDepsTaskProvider = target.tasks.register(
                 checkDepsTaskName,
-                DdCheckSdkDepsTask::class.java
+                CheckSdkDepsTask::class.java
             ) {
                 it.configurationName.set(variant.compileConfiguration.name)
                 it.sdkCheckLevel.set(resolvedCheckDependencyFlag)
@@ -303,7 +279,7 @@ class DdAndroidGradlePlugin @Inject constructor(
     @Suppress("DefaultLocale")
     private fun findCompilationTask(
         taskContainer: TaskContainer,
-        appVariant: ApplicationVariant
+        appVariant: AppVariant
     ): Task? {
         // variants will have name like proDebug, but compile task will have a name like
         // compileProDebugSources. It can be other tasks like compileProDebugAndroidTestSources
@@ -318,69 +294,54 @@ class DdAndroidGradlePlugin @Inject constructor(
             ?: taskContainer.findByName("compile${appVariant.name.capitalize()}Sources")
     }
 
-    private fun resolveMappingFilePath(
+    private fun resolveMappingFile(
         extensionConfiguration: DdExtensionConfiguration,
         target: Project,
-        variant: ApplicationVariant
-    ): String {
+        variant: AppVariant
+    ): Provider<RegularFile> {
         val customPath = extensionConfiguration.mappingFilePath
         return if (customPath != null) {
-            customPath
+            target.objects.fileProperty().fileValue(File(customPath))
         } else {
-            val outputsDir = File(target.buildDir, "outputs")
-            val mappingDir = File(outputsDir, "mapping")
-            val flavorDir = File(mappingDir, variant.name)
-            File(flavorDir, "mapping.txt").path
-        }
-    }
-
-    private fun filterMappingFileReplacements(
-        replacements: Map<String, String>,
-        applicationId: String
-    ): Map<String, String> {
-        return replacements.filter {
-            // not necessarily applicationId == package attribute from the Manifest, but it is
-            // best and cheapest effort to avoid wrong renaming (otherwise we may loose Git
-            // integration feature).
-            if (applicationId.startsWith(it.key)) {
-                LOGGER.warn(
-                    "Renaming of package prefix=${it.key} will be skipped, because" +
-                        " it belongs to the application package."
-                )
-                false
-            } else {
-                true
-            }
+            variant.mappingFile
         }
     }
 
     private fun configureVariantTask(
-        uploadTask: DdMappingFileUploadTask,
+        uploadTask: MappingFileUploadTask,
         apiKey: ApiKey,
         flavorName: String,
         extensionConfiguration: DdExtensionConfiguration,
-        variant: ApplicationVariant
+        variant: AppVariant
     ) {
         uploadTask.apiKey = apiKey.value
         uploadTask.apiKeySource = apiKey.source
         uploadTask.variantName = flavorName
 
         uploadTask.site = extensionConfiguration.site ?: ""
-        uploadTask.versionName = extensionConfiguration.versionName ?: variant.versionName
-        uploadTask.versionCode = providerFactory.provider { variant.versionCode }
-        uploadTask.serviceName = extensionConfiguration.serviceName ?: variant.applicationId
+        if (extensionConfiguration.versionName != null) {
+            uploadTask.versionName.set(extensionConfiguration.versionName)
+        } else {
+            uploadTask.versionName.set(variant.versionName)
+        }
+        uploadTask.versionCode.set(variant.versionCode)
+        if (extensionConfiguration.serviceName != null) {
+            uploadTask.serviceName.set(extensionConfiguration.serviceName)
+        } else {
+            uploadTask.serviceName.set(variant.applicationId)
+        }
         uploadTask.remoteRepositoryUrl = extensionConfiguration.remoteRepositoryUrl ?: ""
     }
 
     internal fun resolveExtensionConfiguration(
         extension: DdExtension,
-        variant: ApplicationVariant
+        variant: AppVariant
     ): DdExtensionConfiguration {
         val configuration = DdExtensionConfiguration()
         configuration.updateWith(extension)
 
-        val flavors = variant.productFlavors.map { it.name }
-        val buildType = variant.buildType.name
+        val flavors = variant.flavors
+        val buildType = variant.buildTypeName
         val iterator = VariantIterator(flavors + buildType)
         iterator.forEach {
             val config = extension.variants.findByName(it)
@@ -396,11 +357,11 @@ class DdAndroidGradlePlugin @Inject constructor(
     }
 
     private fun isObfuscationEnabled(
-        variant: ApplicationVariant,
+        variant: AppVariant,
         extension: DdExtension
     ): Boolean {
         val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
-        val isDefaultObfuscationEnabled = variant.buildType.isMinifyEnabled
+        val isDefaultObfuscationEnabled = variant.isMinifyEnabled
         val isNonDefaultObfuscationEnabled = extensionConfiguration.nonDefaultObfuscation
         return isDefaultObfuscationEnabled || isNonDefaultObfuscationEnabled
     }
@@ -408,9 +369,14 @@ class DdAndroidGradlePlugin @Inject constructor(
     private val Project.androidApplicationExtension: AppExtension?
         get() = extensions.findByType(AppExtension::class.java)
 
+    private val Project.androidApplicationComponentExtension: ApplicationAndroidComponentsExtension?
+        get() = extensions.findByType(ApplicationAndroidComponentsExtension::class.java)
+
     // endregion
 
     companion object {
+
+        private const val DD_FORCE_LEGACY_VARIANT_API = "dd-force-legacy-variant-api"
 
         internal const val DD_API_KEY = "DD_API_KEY"
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
@@ -1,6 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
 package com.datadog.gradle.plugin
 
-import com.android.build.gradle.api.ApplicationVariant
+import com.datadog.gradle.plugin.internal.variant.AppVariant
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -57,8 +63,8 @@ abstract class GenerateBuildIdTask : DefaultTask() {
             .writeText(buildId)
     }
 
-    companion object {
-        internal const val TASK_NAME = "generateBuildId"
+    internal companion object {
+        private const val TASK_NAME = "generateBuildId"
 
         /**
          * Name of the file containing build ID information.
@@ -66,11 +72,11 @@ abstract class GenerateBuildIdTask : DefaultTask() {
         const val BUILD_ID_FILE_NAME = "datadog.buildId"
 
         /**
-         * Registers a new instance of [GenerateBuildIdTask] specific for the given [ApplicationVariant].
+         * Registers a new instance of [GenerateBuildIdTask] specific for the given [AppVariant].
          */
         fun register(
             target: Project,
-            variant: ApplicationVariant,
+            variant: AppVariant,
             buildIdDirectory: Provider<Directory>
         ): TaskProvider<GenerateBuildIdTask> {
             val generateBuildIdTask = target.tasks.register(
@@ -80,6 +86,7 @@ abstract class GenerateBuildIdTask : DefaultTask() {
                 it.buildIdDirectory.set(buildIdDirectory)
                 it.variantName.set(variant.name)
             }
+            variant.bindWith(generateBuildIdTask, buildIdDirectory)
 
             return generateBuildIdTask
         }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
@@ -1,10 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
 package com.datadog.gradle.plugin
 
 import com.android.builder.model.Version
 import org.gradle.api.Project
 import java.io.File
 
-internal object DdTaskUtils {
+internal object TaskUtils {
+
     private const val MAX_DATADOG_CI_FILE_LOOKUP_LEVELS = 4
 
     @Suppress("StringLiteralDuplication")
@@ -49,3 +56,23 @@ internal object DdTaskUtils {
         return currentMajor >= major && currentMinor >= minor && currentPatch >= patch
     }
 }
+
+@Deprecated(
+    message = "Renamed to MappingFileUploadTask",
+    replaceWith = ReplaceWith(
+        expression = "MappingFileUploadTask",
+        imports = arrayOf("com.datadog.gradle.plugin.MappingFileUploadTask")
+    )
+)
+@Suppress("unused")
+typealias DdMappingFileUploadTask = MappingFileUploadTask
+
+@Deprecated(
+    message = "Renamed to CheckSdkDepsTask",
+    replaceWith = ReplaceWith(
+        expression = "CheckSdkDepsTask",
+        imports = arrayOf("com.datadog.gradle.plugin.CheckSdkDepsTask")
+    )
+)
+@Suppress("unused")
+typealias DdCheckSdkDepsTask = CheckSdkDepsTask

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal
+
+import com.datadog.gradle.plugin.TaskUtils
+
+@Suppress("MagicNumber")
+internal object CurrentAgpVersion {
+
+    // can work probably even with lower versions, but legacy Variant API is working fine there as well
+    val CAN_ENABLE_NEW_VARIANT_API: Boolean
+        get() = TaskUtils.isAgpAbove(major = 8, minor = 4, patch = 0)
+
+    val SUPPORTS_KOTLIN_DIRECTORIES_SOURCE_PROVIDER: Boolean
+        get() = TaskUtils.isAgpAbove(major = 7, minor = 0, patch = 0)
+
+    val EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC: Boolean
+        get() = TaskUtils.isAgpAbove(major = 8, minor = 0, patch = 0)
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal
+
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.datadog.gradle.plugin.GenerateBuildIdTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import kotlin.reflect.full.memberProperties
+
+internal fun TaskProvider<ExternalNativeBuildTask>.getSearchObjDirs(providerFactory: ProviderFactory): Provider<File?> {
+    return flatMap { task -> task.getSearchObjDirs(providerFactory) }
+}
+
+internal fun ExternalNativeBuildTask.getSearchObjDirs(providerFactory: ProviderFactory): Provider<File?> {
+    return if (CurrentAgpVersion.EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC) {
+        soFolder.map { it.asFile }
+    } else {
+        val soFolder = ExternalNativeBuildTask::class.memberProperties.find {
+            it.name == "objFolder"
+        }?.get(this)
+        when (soFolder) {
+            is File -> providerFactory.provider { soFolder }
+            is DirectoryProperty -> soFolder.map { it.asFile }
+            else -> providerFactory.provider { null }
+        }
+    }
+}
+
+internal fun TaskProvider<GenerateBuildIdTask>.lazyBuildIdProvider(providerFactory: ProviderFactory): Provider<String> {
+    // upload task shouldn't depend on the build ID generation task, but only read its property,
+    // because upload task may be triggered after assemble task and we don't want to re-generate
+    // build ID, because it will be different then from the one which is already embedded in
+    // the application package
+    return flatMap {
+        it.buildIdFile.flatMap {
+            providerFactory.provider {
+                val file = it.asFile
+                if (file.exists()) {
+                    file.readText().trim()
+                } else {
+                    ""
+                }
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/AppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/AppVariant.kt
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal.variant
+
+import com.android.build.gradle.AppExtension
+import com.datadog.gradle.plugin.GenerateBuildIdTask
+import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import com.android.build.api.variant.ApplicationVariant as NewApplicationVariant
+import com.android.build.gradle.api.ApplicationVariant as LegacyApplicationVariant
+
+internal interface AppVariant {
+
+    val name: String
+
+    val applicationId: Provider<String>
+
+    val flavorName: String
+
+    val versionCode: Provider<Int>
+
+    val versionName: Provider<String>
+
+    val compileConfiguration: Configuration
+
+    val isNativeBuildEnabled: Boolean
+
+    val isMinifyEnabled: Boolean
+
+    val buildTypeName: String
+
+    val flavors: List<String>
+
+    val mappingFile: Provider<RegularFile>
+
+    fun collectJavaAndKotlinSourceDirectories(): Provider<List<File>>
+
+    fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask)
+
+    // new variant API doesn't allow to run addGeneratedSourceDirectory from inside Task#configure, thus this
+    fun bindWith(generateBuildIdTask: TaskProvider<GenerateBuildIdTask>, buildIdDirectory: Provider<Directory>)
+
+    companion object {
+        fun create(
+            variant: NewApplicationVariant,
+            target: Project
+        ): AppVariant = NewApiAppVariant(variant, target)
+
+        fun create(
+            variant: LegacyApplicationVariant,
+            appExtension: AppExtension,
+            target: Project
+        ): AppVariant = LegacyApiAppVariant(variant, appExtension, target)
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariant.kt
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal.variant
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.api.ApplicationVariant
+import com.datadog.gradle.plugin.GenerateBuildIdTask
+import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
+import com.datadog.gradle.plugin.internal.CurrentAgpVersion
+import com.datadog.gradle.plugin.internal.getSearchObjDirs
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import java.nio.file.Paths
+
+internal class LegacyApiAppVariant(
+    private val variant: ApplicationVariant,
+    private val appExtension: AppExtension,
+    private val target: Project
+) : AppVariant {
+
+    private val providerFactory = target.providers
+
+    override val name: String
+        get() = variant.name
+    override val applicationId: Provider<String>
+        get() = providerFactory.provider { variant.applicationId }
+    override val flavorName: String
+        get() = variant.flavorName
+    override val versionCode: Provider<Int>
+        get() = providerFactory.provider { variant.versionCode }
+    override val versionName: Provider<String>
+        get() = providerFactory.provider { variant.versionName.orEmpty() }
+    override val compileConfiguration: Configuration
+        get() = variant.compileConfiguration
+    override val isNativeBuildEnabled: Boolean
+        get() = variant.externalNativeBuildProviders.isNotEmpty()
+    override val isMinifyEnabled: Boolean
+        get() = variant.buildType.isMinifyEnabled
+    override val buildTypeName: String
+        get() = variant.buildType.name
+    override val flavors: List<String>
+        get() = variant.productFlavors.map { it.name }
+    override val mappingFile: Provider<RegularFile>
+        get() = target.layout.buildDirectory.file(
+            Paths.get("outputs", "mapping", variant.name, "mapping.txt").toString()
+        )
+
+    override fun collectJavaAndKotlinSourceDirectories(): Provider<List<File>> {
+        val roots = mutableListOf<File>()
+        variant.sourceSets.forEach {
+            roots.addAll(it.javaDirectories)
+            if (CurrentAgpVersion.SUPPORTS_KOTLIN_DIRECTORIES_SOURCE_PROVIDER) {
+                roots.addAll(it.kotlinDirectories)
+            }
+        }
+        return providerFactory.provider { roots }
+    }
+
+    override fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask) {
+        val nativeBuildProviders = variant.externalNativeBuildProviders
+        nativeBuildProviders.forEach { buildTask ->
+            val searchFiles = buildTask.getSearchObjDirs(providerFactory)
+
+            ndkUploadTask.searchDirectories.from(searchFiles)
+            ndkUploadTask.dependsOn(buildTask)
+        }
+    }
+
+    override fun bindWith(
+        generateBuildIdTask: TaskProvider<GenerateBuildIdTask>,
+        buildIdDirectory: Provider<Directory>
+    ) {
+        // we could generate buildIdDirectory inside GenerateBuildIdTask and read it here as
+        // property using flatMap, but when Gradle sync is done inside Android Studio there is an error
+        // Querying the mapped value of provider (java.util.Set) before task ... has completed is
+        // not supported, which doesn't happen when Android Studio is not used (pure Gradle build)
+        // so applying such workaround
+        appExtension.sourceSets.getByName(variant.name).assets.srcDir(buildIdDirectory)
+
+        val variantName = variant.name.capitalize()
+        listOf(
+            "package${variantName}Bundle",
+            "build${variantName}PreBundle",
+            "lintVitalAnalyze$variantName",
+            "lintVitalReport$variantName",
+            "generate${variantName}LintVitalReportModel"
+        ).forEach {
+            target.tasks.findByName(it)?.dependsOn(generateBuildIdTask)
+        }
+
+        // don't merge these 2 into list to call forEach, because common superclass for them
+        // is different between AGP versions, which may cause ClassCastException
+        variant.mergeAssetsProvider.configure { it.dependsOn(generateBuildIdTask) }
+        variant.packageApplicationProvider.configure { it.dependsOn(generateBuildIdTask) }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal.variant
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationVariant
+import com.android.build.api.variant.VariantOutput
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.datadog.gradle.plugin.GenerateBuildIdTask
+import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
+import com.datadog.gradle.plugin.internal.getSearchObjDirs
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+
+internal class NewApiAppVariant(
+    private val variant: ApplicationVariant,
+    private val target: Project
+) : AppVariant {
+
+    private val providerFactory = target.providers
+
+    override val name: String
+        get() = variant.name
+    override val applicationId: Provider<String>
+        get() = variant.applicationId
+    override val flavorName: String
+        get() = variant.flavorName.orEmpty()
+    override val versionCode: Provider<Int>
+        get() = providerFactory.provider { variant.mainOutput?.versionCode?.orNull ?: 1 }
+    override val versionName: Provider<String>
+        get() = providerFactory.provider { variant.mainOutput?.versionName?.orNull.orEmpty() }
+    override val compileConfiguration: Configuration
+        get() = variant.compileConfiguration
+    override val isNativeBuildEnabled: Boolean
+        get() = variant.externalNativeBuild != null
+
+    @Suppress("UnstableApiUsage")
+    override val isMinifyEnabled: Boolean
+        get() = variant.isMinifyEnabled
+    override val buildTypeName: String
+        get() = variant.buildType.orEmpty()
+    override val flavors: List<String>
+        // dimension to flavor name
+        get() = variant.productFlavors.map { it.second }
+    override val mappingFile: Provider<RegularFile>
+        get() = variant.artifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+
+    override fun collectJavaAndKotlinSourceDirectories(): Provider<List<File>> {
+        val allJava = variant.sources.java?.all
+
+        @Suppress("UnstableApiUsage")
+        val allKotlin = variant.sources.kotlin?.all
+        return if (allJava != null) {
+            if (allKotlin != null) {
+                allJava.zip(allKotlin) { java, kotlin -> java + kotlin }.asFileCollectionProvider()
+            } else {
+                allJava.asFileCollectionProvider()
+            }
+        } else {
+            allKotlin?.asFileCollectionProvider() ?: providerFactory.provider { emptyList() }
+        }
+    }
+
+    override fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask) {
+        target.tasks.withType(ExternalNativeBuildTask::class.java).forEach {
+            val searchFiles = it.getSearchObjDirs(providerFactory)
+            ndkUploadTask.searchDirectories.from(searchFiles)
+            ndkUploadTask.dependsOn(it)
+        }
+    }
+
+    override fun bindWith(
+        generateBuildIdTask: TaskProvider<GenerateBuildIdTask>,
+        buildIdDirectory: Provider<Directory>
+    ) {
+        variant.sources.assets?.addGeneratedSourceDirectory(generateBuildIdTask) {
+            it.buildIdDirectory
+        }
+    }
+
+    // region Private
+
+    private fun Provider<out Collection<Directory>>.asFileCollectionProvider() =
+        map { collection -> collection.map { it.asFile } }
+
+    // may not be precise, but we need this info only for metadata anyway
+    private val ApplicationVariant.mainOutput: VariantOutput?
+        get() = outputs.firstOrNull { it.enabled.get() && it.versionCode.orNull != null }
+
+    // endregion
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/CheckSdkDepsTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/CheckSdkDepsTaskTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.gradle.plugin
 
 import com.datadog.gradle.plugin.internal.MissingSdkException
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.datadog.gradle.plugin.utils.setStaticValue
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryException
@@ -51,8 +52,8 @@ import java.io.UncheckedIOException
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class DdCheckSdkDepsTaskTest {
-    lateinit var testedTask: DdCheckSdkDepsTask
+internal class CheckSdkDepsTaskTest {
+    lateinit var testedTask: CheckSdkDepsTask
 
     lateinit var fakeSdkCheckLevel: SdkCheckLevel
 
@@ -80,8 +81,8 @@ internal class DdCheckSdkDepsTaskTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        originalLogger = DdCheckSdkDepsTask.LOGGER
-        DdCheckSdkDepsTask::class.java.setStaticValue("LOGGER", mockLogger)
+        originalLogger = CheckSdkDepsTask.LOGGER
+        CheckSdkDepsTask::class.java.setStaticValue("LOGGER", mockLogger)
 
         whenever(mockConfiguration.name).thenReturn(fakeConfigurationName)
         whenever(mockConfiguration.resolvedConfiguration).thenReturn(mockResolvedConfiguration)
@@ -94,8 +95,8 @@ internal class DdCheckSdkDepsTaskTest {
         fakeProject.configurations.add(mockConfiguration)
 
         testedTask = fakeProject.tasks.create(
-            "DdCheckDepsTask",
-            DdCheckSdkDepsTask::class.java
+            "CheckDepsTask",
+            CheckSdkDepsTask::class.java
         ) {
             it.configurationName.set(fakeConfigurationName)
             it.sdkCheckLevel.set(fakeSdkCheckLevel)
@@ -105,7 +106,7 @@ internal class DdCheckSdkDepsTaskTest {
 
     @AfterEach
     fun `tear down`() {
-        DdCheckSdkDepsTask::class.java.setStaticValue("LOGGER", originalLogger)
+        CheckSdkDepsTask::class.java.setStaticValue("LOGGER", originalLogger)
     }
 
     // region taskAction
@@ -120,7 +121,7 @@ internal class DdCheckSdkDepsTaskTest {
 
         // THEN
         verify(mockLogger).info(
-            DdCheckSdkDepsTask.CANNOT_FIND_CONFIGURATION_MESSAGE
+            CheckSdkDepsTask.CANNOT_FIND_CONFIGURATION_MESSAGE
                 .format(fakeConfigurationName, fakeVariantName)
         )
     }
@@ -206,7 +207,7 @@ internal class DdCheckSdkDepsTaskTest {
         testedTask.applyTask()
 
         // THEN
-        verify(mockLogger).warn(DdCheckSdkDepsTask.MISSING_DD_SDK_MESSAGE.format(fakeVariantName))
+        verify(mockLogger).warn(CheckSdkDepsTask.MISSING_DD_SDK_MESSAGE.format(fakeVariantName))
         assertThat(testedTask.isLastRunSuccessful).isFalse()
     }
 

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.gradle.plugin
 
 import com.datadog.gradle.plugin.utils.assertj.BuildResultAssert.Companion.assertThat
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.datadog.gradle.plugin.utils.headHash
 import com.datadog.gradle.plugin.utils.initializeGit
 import fr.xgouchet.elmyr.Forge
@@ -37,6 +38,7 @@ import kotlin.io.path.Path
 )
 @ForgeConfiguration(value = Configurator::class)
 internal class DdAndroidGradlePluginFunctionalTest {
+
     @TempDir
     lateinit var testProjectDir: File
     private lateinit var appRootDir: File
@@ -853,7 +855,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "outputs",
             "mapping",
             "${variant}Release",
-            DdMappingFileUploadTask.MAPPING_OPTIMIZED_FILE_NAME
+            MappingFileUploadTask.MAPPING_OPTIMIZED_FILE_NAME
         ).toFile()
         assertThat(result).containsInOutput(
             "Size of optimized file is ${optimizedFile.length()} bytes"

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTest.kt
@@ -6,34 +6,30 @@
 
 package com.datadog.gradle.plugin
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.api.AndroidSourceDirectorySet
-import com.android.build.gradle.api.AndroidSourceSet
-import com.android.build.gradle.api.ApplicationVariant
-import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import com.android.builder.model.BuildType
-import com.android.builder.model.ProductFlavor
 import com.datadog.gradle.plugin.internal.ApiKey
 import com.datadog.gradle.plugin.internal.ApiKeySource
 import com.datadog.gradle.plugin.internal.GitRepositoryDetector
+import com.datadog.gradle.plugin.internal.variant.AppVariant
 import com.datadog.gradle.plugin.utils.capitalizeChar
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Transformer
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
@@ -44,14 +40,14 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.util.UUID
-import java.util.concurrent.Callable
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -66,10 +62,7 @@ internal class DdAndroidGradlePluginTest {
     lateinit var fakeProject: Project
 
     @Mock
-    lateinit var mockVariant: ApplicationVariant
-
-    @Mock
-    lateinit var mockBuildType: BuildType
+    lateinit var mockVariant: AppVariant
 
     lateinit var fakeBuildId: String
 
@@ -93,14 +86,9 @@ internal class DdAndroidGradlePluginTest {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
         fakeBuildId = forge.getForgery<UUID>().toString()
         fakeProject = ProjectBuilder.builder().build()
-        val mockProviderFactory = mock<ProviderFactory>()
-        whenever(mockProviderFactory.provider(any<Callable<*>>())) doAnswer {
-            val argument = it.getArgument<Callable<*>>(0)
-            fakeProject.provider(argument)
-        }
         testedPlugin = DdAndroidGradlePlugin(
             execOps = mock(),
-            providerFactory = mockProviderFactory
+            providerFactory = fakeProject.providers
         )
 
         setEnv(DdAndroidGradlePlugin.DD_API_KEY, "")
@@ -114,6 +102,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -123,11 +112,12 @@ internal class DdAndroidGradlePluginTest {
         whenever(mockVariant.name) doReturn
             "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -139,7 +129,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -147,11 +137,12 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(versionName)
-        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.versionName.get()).isEqualTo(versionName)
+        assertThat(task.serviceName.get()).isEqualTo(packageName)
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
-        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
+        assertThat(task.mappingFile.get().asFile)
+            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.datadogCiFile).isNull()
@@ -163,17 +154,19 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -185,7 +178,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -193,11 +186,12 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
-        assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(task.versionName.get()).isEqualTo(fakeExtension.versionName)
+        assertThat(task.serviceName.get()).isEqualTo(fakeExtension.serviceName)
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
-        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
+        assertThat(task.mappingFile.get().asFile)
+            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.mappingFileTrimIndents)
@@ -211,6 +205,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String,
         forge: Forge
     ) {
@@ -218,11 +213,12 @@ internal class DdAndroidGradlePluginTest {
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         val aliasToFilterOut =
             packageName.substring(0, forge.anInt(min = 1, max = packageName.length + 1)) to
@@ -243,7 +239,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -251,11 +247,12 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
-        assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(task.versionName.get()).isEqualTo(fakeExtension.versionName)
+        assertThat(task.serviceName.get()).isEqualTo(fakeExtension.serviceName)
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
-        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
+        assertThat(task.mappingFile.get().asFile)
+            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases.minus(aliasToFilterOut.first))
         assertThat(task.mappingFileTrimIndents)
@@ -269,6 +266,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -283,11 +281,13 @@ internal class DdAndroidGradlePluginTest {
         val fakeMappingFilePath = "${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.mappingFile) doReturn fakeMappingFilePath.asFileProvider()
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -299,7 +299,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -307,11 +307,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(versionName)
-        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.versionName.get()).isEqualTo(versionName)
+        assertThat(task.serviceName.get()).isEqualTo(packageName)
         assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo("")
-        assertThat(task.mappingFilePath).isEqualTo(fakeMappingFilePath)
+        assertThat(task.mappingFile.get().asFile.path).isEqualTo(fakeMappingFilePath)
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
@@ -323,6 +323,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -338,11 +339,13 @@ internal class DdAndroidGradlePluginTest {
         val fakeMappingFilePath = "${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.mappingFile) doReturn fakeMappingFilePath.asFileProvider()
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         val fakeDatadogCiFile = File(fakeProject.projectDir, "datadog-ci.json")
         fakeDatadogCiFile.createNewFile()
@@ -357,7 +360,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -365,11 +368,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(versionName)
-        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.versionName.get()).isEqualTo(versionName)
+        assertThat(task.serviceName.get()).isEqualTo(packageName)
         assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo("")
-        assertThat(task.mappingFilePath).isEqualTo(fakeMappingFilePath)
+        assertThat(task.mappingFile.get().asFile.path).isEqualTo(fakeMappingFilePath)
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isEqualTo(fakeDatadogCiFile)
@@ -381,6 +384,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -396,11 +400,13 @@ internal class DdAndroidGradlePluginTest {
         val fakeMappingFilePath = "${fakeProject.buildDir}/outputs/mapping/$variantName/mapping.txt"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn true
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.mappingFile) doReturn fakeMappingFilePath.asFileProvider()
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         val fakeDatadogCiFile = File(fakeProject.projectDir, "datadog-ci.json")
         fakeDatadogCiFile.createNewFile()
@@ -415,7 +421,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -423,11 +429,11 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(versionName)
-        assertThat(task.serviceName).isEqualTo(packageName)
+        assertThat(task.versionName.get()).isEqualTo(versionName)
+        assertThat(task.serviceName.get()).isEqualTo(packageName)
         assertThat(task.remoteRepositoryUrl).isEmpty()
         assertThat(task.site).isEqualTo("")
-        assertThat(task.mappingFilePath).isEqualTo(fakeMappingFilePath)
+        assertThat(task.mappingFile.get().asFile.path).isEqualTo(fakeMappingFilePath)
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
@@ -435,29 +441,21 @@ internal class DdAndroidGradlePluginTest {
     }
 
     @Test
-    fun `M not create buildId task W configureTasksForVariant() { no deobfuscation, no native build providers }`(
+    fun `M not create buildId task W configureTasksForVariant() { no deobfuscation, no native build enabled }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
-        @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
+        @StringForgery(case = Case.LOWER) buildTypeName: String
     ) {
         // Given
-        val mockAppExtension = mockAppExtension()
-
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
-        whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn false
+        whenever(mockVariant.isNativeBuildEnabled) doReturn false
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
 
         // When
         testedPlugin.configureTasksForVariant(
             fakeProject,
-            mockAppExtension,
             fakeExtension,
             mockVariant,
             fakeApiKey
@@ -466,39 +464,33 @@ internal class DdAndroidGradlePluginTest {
         // Then
         val allTasks = fakeProject.tasks.map { it.name }
         assertThat(allTasks).doesNotContain("generateBuildId${variantName.replaceFirstChar { capitalizeChar(it) }}")
+        verify(mockVariant, never()).bindWith(any<TaskProvider<GenerateBuildIdTask>>(), any<Provider<Directory>>())
     }
 
     @Test
-    fun `M create uploadSymbol task W configureTasksForVariant() { native build providers }`(
+    fun `M create uploadNdkSymbolFiles task W configureTasksForVariant() { native build providers }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
+        @IntForgery(min = 0) versionCode: Int,
         @StringForgery versionName: String,
         @StringForgery packageName: String
     ) {
         // Given
-        val mockAppExtension = mockAppExtension()
-
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.isNativeBuildEnabled) doReturn true
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
-
-        val nativeBuildProviders = listOf(
-            mock<TaskProvider<ExternalNativeBuildTask>>().apply {
-                whenever(flatMap(any<Transformer<Provider<String>, ExternalNativeBuildTask>>())) doReturn mock()
-            }
-        )
-        whenever(mockVariant.externalNativeBuildProviders) doReturn nativeBuildProviders
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         testedPlugin.configureTasksForVariant(
             fakeProject,
-            mockAppExtension,
             fakeExtension,
             mockVariant,
             fakeApiKey
@@ -507,34 +499,33 @@ internal class DdAndroidGradlePluginTest {
         // Then
         val allTasks = fakeProject.tasks.map { it.name }
         assertThat(allTasks).contains("uploadNdkSymbolFiles${variantName.replaceFirstChar { capitalizeChar(it) }}")
+        verify(mockVariant).bindWith(any<NdkSymbolFileUploadTask>())
     }
 
     @Test
-    fun `M not create uploadSymbol task W configureTasksForVariant() { no native build providers }`(
+    fun `M not create uploadNdkSymbolFiles task W configureTasksForVariant() { no native build providers }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
+        @IntForgery(min = 0) versionCode: Int,
         @StringForgery versionName: String,
         @StringForgery packageName: String
     ) {
         // Given
-        val mockAppExtension = mockAppExtension()
-
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
-
-        whenever(mockVariant.externalNativeBuildProviders) doReturn listOf()
+        whenever(mockVariant.isMinifyEnabled) doReturn true
+        whenever(mockVariant.isNativeBuildEnabled) doReturn false
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         testedPlugin.configureTasksForVariant(
             fakeProject,
-            mockAppExtension,
             fakeExtension,
             mockVariant,
             fakeApiKey
@@ -543,33 +534,30 @@ internal class DdAndroidGradlePluginTest {
         // Then
         val allTasks = fakeProject.tasks.map { it.name }
         assertThat(allTasks).allMatch { !it.startsWith("uploadNdkSymbolFiles") }
+        verify(mockVariant, never()).bindWith(any<NdkSymbolFileUploadTask>())
     }
 
     @Test
     fun `M not create mapping upload task W configureTasksForVariant() { no deobfuscation }`(
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
-        @StringForgery versionName: String,
-        @StringForgery packageName: String
+        @IntForgery(min = 0) versionCode: Int,
+        @StringForgery versionName: String
     ) {
         // Given
-        val mockAppExtension = mockAppExtension()
-
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
-        whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
-        whenever(mockVariant.mergeAssetsProvider) doReturn mock()
-        whenever(mockVariant.packageApplicationProvider) doReturn mock()
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.isMinifyEnabled) doReturn false
+        whenever(mockVariant.isNativeBuildEnabled) doReturn true
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         testedPlugin.configureTasksForVariant(
             fakeProject,
-            mockAppExtension,
             fakeExtension,
             mockVariant,
             fakeApiKey
@@ -585,6 +573,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -592,11 +581,12 @@ internal class DdAndroidGradlePluginTest {
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.isMinifyEnabled) doReturn false
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.isMinifyEnabled) doReturn false
+        whenever(mockVariant.collectJavaAndKotlinSourceDirectories()) doReturn emptyList<File>().asProvider()
 
         // When
         val task = testedPlugin.configureVariantForUploadTask(
@@ -608,7 +598,7 @@ internal class DdAndroidGradlePluginTest {
         ).get()
 
         // Then
-        check(task is DdMappingFileUploadTask)
+        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -616,11 +606,12 @@ internal class DdAndroidGradlePluginTest {
         assertThat(task.apiKey).isEqualTo(fakeApiKey.value)
         assertThat(task.apiKeySource).isEqualTo(fakeApiKey.source)
         assertThat(task.variantName).isEqualTo(flavorName)
-        assertThat(task.versionName).isEqualTo(fakeExtension.versionName)
-        assertThat(task.serviceName).isEqualTo(fakeExtension.serviceName)
+        assertThat(task.versionName.get()).isEqualTo(fakeExtension.versionName)
+        assertThat(task.serviceName.get()).isEqualTo(fakeExtension.serviceName)
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
-        assertThat(task.mappingFilePath).isEqualTo(fakeExtension.mappingFilePath)
+        assertThat(task.mappingFile.get().asFile)
+            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.mappingFileTrimIndents)
@@ -704,8 +695,11 @@ internal class DdAndroidGradlePluginTest {
 
     @Test
     fun `M return default config W resolveExtensionConfiguration() {no variant config}`() {
+        // Given
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
+
         // When
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
         val config = testedPlugin.resolveExtensionConfiguration(fakeExtension, mockVariant)
 
         // Then
@@ -728,8 +722,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return config W resolveExtensionConfiguration() { variant w full config }`(
         @Forgery variantConfig: DdExtensionConfiguration
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         whenever(fakeExtension.variants.findByName(variantName)) doReturn variantConfig
 
         // When
@@ -755,8 +751,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w version only }`(
         @StringForgery versionName: String
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.versionName = versionName
         }
@@ -782,8 +780,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w service only }`(
         @StringForgery serviceName: String
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.serviceName = serviceName
         }
@@ -809,8 +809,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w mappingPath }`(
         @StringForgery(regex = "/([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt") mappingFilePath: String
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.mappingFilePath = mappingFilePath
         }
@@ -841,8 +843,10 @@ internal class DdAndroidGradlePluginTest {
             value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
         ) mappingFilePackageAliases: Map<String, String>
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.mappingFilePackageAliases = mappingFilePackageAliases
         }
@@ -869,8 +873,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return config W resolveExtensionConfiguration() { variant+mappingFileTrimIndents }`(
         @BoolForgery mappingFileTrimIndents: Boolean
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.mappingFileTrimIndents = mappingFileTrimIndents
         }
@@ -898,8 +904,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w site only }`(
         @Forgery site: DatadogSite
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.site = site.name
         }
@@ -926,8 +934,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w sdkCheck only }`(
         @Forgery sdkCheckLevel: SdkCheckLevel
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.checkProjectDependencies = sdkCheckLevel
         }
@@ -952,8 +962,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w remoteUrl only }`(
         @Forgery fakeConfig: DdExtensionConfiguration
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.remoteRepositoryUrl = fakeConfig.remoteRepositoryUrl
         }
@@ -980,8 +992,10 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant + ignoreDdConfig }`(
         @Forgery fakeConfig: DdExtensionConfiguration
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName()
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         val incompleteConfig = DdExtensionConfiguration().apply {
             this.ignoreDatadogCiFileConfig = fakeConfig.ignoreDatadogCiFileConfig
         }
@@ -1014,6 +1028,7 @@ internal class DdAndroidGradlePluginTest {
         @Forgery variantConfigB: DdExtensionConfiguration,
         @Forgery variantConfigC: DdExtensionConfiguration
     ) {
+        // Given
         val flavorNames = listOf(flavorA, flavorB, flavorC)
         variantConfigA.apply {
             versionName = null
@@ -1024,7 +1039,8 @@ internal class DdAndroidGradlePluginTest {
             checkProjectDependencies = null
         }
         variantConfigC.apply { site = null }
-        mockVariant.mockFlavors(flavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn flavorNames
         whenever(fakeExtension.variants.findByName(flavorA)) doReturn variantConfigA
         whenever(fakeExtension.variants.findByName(flavorB)) doReturn variantConfigB
         whenever(fakeExtension.variants.findByName(flavorC)) doReturn variantConfigC
@@ -1057,12 +1073,14 @@ internal class DdAndroidGradlePluginTest {
         @Forgery variantConfigAC: DdExtensionConfiguration,
         @Forgery variantConfigBC: DdExtensionConfiguration
     ) {
+        // Given
         val flavorNames = listOf(flavorA, flavorB, flavorC)
         variantConfigAB.apply { versionName = null }
         variantConfigAC.apply { serviceName = null }
         variantConfigBC.apply { site = null }
         variantConfigBC.apply { checkProjectDependencies = null }
-        mockVariant.mockFlavors(flavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn flavorNames
         whenever(
             fakeExtension.variants.findByName(
                 flavorA + flavorB.replaceFirstChar { capitalizeChar(it) }
@@ -1105,9 +1123,11 @@ internal class DdAndroidGradlePluginTest {
     fun `M return combined config W resolveExtensionConfiguration() { variant w build type }`(
         @Forgery configuration: DdExtensionConfiguration
     ) {
+        // Given
         val variantName = fakeFlavorNames.variantName() +
             fakeBuildTypeName.replaceFirstChar { capitalizeChar(it) }
-        mockVariant.mockFlavors(fakeFlavorNames, fakeBuildTypeName)
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
+        whenever(mockVariant.flavors) doReturn fakeFlavorNames
         whenever(fakeExtension.variants.findByName(variantName)) doReturn configuration
 
         // When
@@ -1139,6 +1159,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String,
         @StringForgery configurationName: String
     ) {
@@ -1147,10 +1168,10 @@ internal class DdAndroidGradlePluginTest {
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
 
         fakeProject.task("compile${variantName.replaceFirstChar { capitalizeChar(it) }}Sources")
 
@@ -1159,13 +1180,14 @@ internal class DdAndroidGradlePluginTest {
 
         whenever(mockVariant.compileConfiguration) doReturn mockConfiguration
 
-        // When + Then
+        // When
         val checkSdkDepsTaskProvider = testedPlugin.configureVariantForSdkCheck(
             fakeProject,
             mockVariant,
             fakeExtension
         )
 
+        // Then
         assertThat(checkSdkDepsTaskProvider).isNull()
     }
 
@@ -1174,6 +1196,7 @@ internal class DdAndroidGradlePluginTest {
         @StringForgery(case = Case.LOWER) flavorName: String,
         @StringForgery(case = Case.LOWER) buildTypeName: String,
         @StringForgery versionName: String,
+        @IntForgery(min = 1) versionCode: Int,
         @StringForgery packageName: String
     ) {
         // Given
@@ -1181,10 +1204,10 @@ internal class DdAndroidGradlePluginTest {
         val variantName = "$flavorName${buildTypeName.replaceFirstChar { capitalizeChar(it) }}"
         whenever(mockVariant.name) doReturn variantName
         whenever(mockVariant.flavorName) doReturn flavorName
-        whenever(mockVariant.versionName) doReturn versionName
-        whenever(mockVariant.applicationId) doReturn packageName
-        whenever(mockVariant.buildType) doReturn mockBuildType
-        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockVariant.versionCode) doReturn versionCode.asProvider()
+        whenever(mockVariant.versionName) doReturn versionName.asProvider()
+        whenever(mockVariant.applicationId) doReturn packageName.asProvider()
+        whenever(mockVariant.buildTypeName) doReturn fakeBuildTypeName
 
         fakeProject.task("compile${variantName.replaceFirstChar { capitalizeChar(it) }}Sources")
 
@@ -1241,45 +1264,20 @@ internal class DdAndroidGradlePluginTest {
         return first() + drop(1).joinToString("") { it.replaceFirstChar { capitalizeChar(it) } }
     }
 
-    private fun ApplicationVariant.mockFlavors(
-        flavorNames: List<String>,
-        buildTypeName: String
-    ) {
-        val mockFlavors: MutableList<ProductFlavor> = mutableListOf()
-        for (flavorName in flavorNames) {
-            mockFlavors.add(
-                mock<ProductFlavor>().apply {
-                    whenever(this.name) doReturn flavorName
-                }
-            )
-        }
-        val mockBuildType: BuildType = mock()
-        whenever(mockBuildType.name) doReturn buildTypeName
-
-        whenever(productFlavors) doReturn mockFlavors
-        whenever(buildType) doReturn mockBuildType
-    }
-
     private fun mockBuildIdGenerationTask(buildId: String): TaskProvider<GenerateBuildIdTask> {
         return mock<TaskProvider<GenerateBuildIdTask>>().apply {
-            val mockBuildIdProvider = mock<Provider<String>>().apply {
-                whenever(get()) doReturn buildId
-            }
             whenever(
                 flatMap(any<Transformer<Provider<String>, GenerateBuildIdTask>>())
-            ) doReturn mockBuildIdProvider
+            ) doReturn buildId.asProvider()
         }
     }
 
-    private fun mockAppExtension(): AppExtension {
-        val mockAppExtension: AppExtension = mock()
-        val mockSoureSetsContainer: NamedDomainObjectContainer<AndroidSourceSet> = mock()
-        val mockSoureSets: AndroidSourceSet = mock()
-        val mockAssets: AndroidSourceDirectorySet = mock()
-        whenever(mockAppExtension.sourceSets).thenReturn(mockSoureSetsContainer)
-        whenever(mockSoureSetsContainer.getByName(any())).thenReturn(mockSoureSets)
-        whenever(mockSoureSets.assets).thenReturn(mockAssets)
-        return mockAppExtension
+    private fun <T> T.asProvider(): Provider<T> {
+        return fakeProject.provider { this }
+    }
+
+    private fun String.asFileProvider(): Provider<RegularFile> {
+        return fakeProject.objects.fileProperty().value { File(this) }
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/RepositoryInfoTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/RepositoryInfoTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.gradle.plugin
 
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/TaskUtilsTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/TaskUtilsTest.kt
@@ -1,5 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
 package com.datadog.gradle.plugin
 
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -14,7 +21,8 @@ import java.io.File
     ExtendWith(ForgeExtension::class)
 )
 @ForgeConfiguration(Configurator::class)
-class DdTaskUtilsTest {
+class TaskUtilsTest {
+
     @Test
     fun `M find datadog-ci file W findDatadogCiFile()`(
         @TempDir rootDir: File,
@@ -26,7 +34,7 @@ class DdTaskUtilsTest {
         File(tree[forge.anInt(0, tree.size)], "datadog-ci.json").createNewFile()
 
         // When
-        val ciFile = DdTaskUtils.findDatadogCiFile(tree.last())
+        val ciFile = TaskUtils.findDatadogCiFile(tree.last())
 
         // Then
         Assertions.assertThat(ciFile).isNotNull()
@@ -41,7 +49,7 @@ class DdTaskUtilsTest {
         val tree = buildDirectoryTree(rootDir, maxDepth = 3, forge = forge)
 
         // When
-        val ciFile = DdTaskUtils.findDatadogCiFile(tree.last())
+        val ciFile = TaskUtils.findDatadogCiFile(tree.last())
 
         // Then
         Assertions.assertThat(ciFile).isNull()
@@ -56,7 +64,7 @@ class DdTaskUtilsTest {
         val tree = buildDirectoryTree(rootDir, minDepth = 4, maxDepth = 7, forge = forge)
 
         // When
-        val ciFile = DdTaskUtils.findDatadogCiFile(tree.last())
+        val ciFile = TaskUtils.findDatadogCiFile(tree.last())
 
         // Then
         Assertions.assertThat(ciFile).isNull()

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/GitRepositoryDetectorTest.kt
@@ -6,9 +6,9 @@
 
 package com.datadog.gradle.plugin.internal
 
-import com.datadog.gradle.plugin.Configurator
 import com.datadog.gradle.plugin.RepositoryDetector
 import com.datadog.gradle.plugin.internal.sanitizer.UrlSanitizer
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.datadog.gradle.plugin.utils.initializeGit
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -6,10 +6,10 @@
 
 package com.datadog.gradle.plugin.internal
 
-import com.datadog.gradle.plugin.Configurator
 import com.datadog.gradle.plugin.DatadogSite
-import com.datadog.gradle.plugin.RecordedRequestAssert.Companion.assertThat
 import com.datadog.gradle.plugin.RepositoryInfo
+import com.datadog.gradle.plugin.utils.assertj.RecordedRequestAssert.Companion.assertThat
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/VariantIteratorTest.kt
@@ -6,8 +6,8 @@
 
 package com.datadog.gradle.plugin.internal
 
-import com.datadog.gradle.plugin.Configurator
 import com.datadog.gradle.plugin.utils.capitalizeChar
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/sanitizer/GitRemoteUrlSanitizerTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.gradle.plugin.internal.sanitizer
 
-import com.datadog.gradle.plugin.Configurator
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariantTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariantTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal.variant
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.tasks.ExternalNativeBuildTask
+import com.android.builder.model.BuildType
+import com.android.builder.model.ProductFlavor
+import com.android.builder.model.SourceProvider
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.File
+import java.nio.file.Paths
+
+@Extensions(
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(MockitoExtension::class)
+)
+@ForgeConfiguration(value = Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class LegacyApiAppVariantTest {
+
+    private lateinit var testedAppVariant: LegacyApiAppVariant
+
+    private val fakeProject = ProjectBuilder.builder().build()
+
+    @Mock
+    lateinit var mockAppExtension: AppExtension
+
+    @Mock
+    lateinit var mockAndroidVariant: ApplicationVariant
+
+    @BeforeEach
+    fun `set up`() {
+        testedAppVariant = LegacyApiAppVariant(
+            mockAndroidVariant,
+            mockAppExtension,
+            fakeProject
+        )
+    }
+
+    @Test
+    fun `M return variant name W name`(
+        @StringForgery fakeName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.name) doReturn fakeName
+
+        // When
+        val name = testedAppVariant.name
+
+        // Then
+        assertThat(name).isEqualTo(fakeName)
+    }
+
+    @Test
+    fun `M return application ID W applicationId`(
+        @StringForgery fakeApplicationId: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.applicationId) doReturn fakeApplicationId
+
+        // When
+        val applicationId = testedAppVariant.applicationId.get()
+
+        // Then
+        assertThat(applicationId).isEqualTo(fakeApplicationId)
+    }
+
+    @Test
+    fun `M return flavor name W flavorName`(
+        @StringForgery fakeFlavorName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.flavorName) doReturn fakeFlavorName
+
+        // When
+        val flavorName = testedAppVariant.flavorName
+
+        // Then
+        assertThat(flavorName).isEqualTo(fakeFlavorName)
+    }
+
+    @Test
+    fun `M return version name W versionName`(
+        @StringForgery fakeVersionName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.versionName) doReturn fakeVersionName
+
+        // When
+        val versionName = testedAppVariant.versionName.get()
+
+        // Then
+        assertThat(versionName).isEqualTo(fakeVersionName)
+    }
+
+    @Test
+    fun `M return empty version name W versionName { missing version name }`() {
+        // Given
+        whenever(mockAndroidVariant.versionName) doReturn null
+
+        // When
+        val versionName = testedAppVariant.versionName.get()
+
+        // Then
+        assertThat(versionName).isEmpty()
+    }
+
+    @Test
+    fun `M return version code W versionCode`(
+        @IntForgery(min = 1) fakeVersionCode: Int
+    ) {
+        // Given
+        whenever(mockAndroidVariant.versionCode) doReturn fakeVersionCode
+
+        // When
+        val versionCode = testedAppVariant.versionCode.get()
+
+        // Then
+        assertThat(versionCode).isEqualTo(fakeVersionCode)
+    }
+
+    @Test
+    fun `M return compile configuration W compileConfiguration`() {
+        // Given
+        val mockCompileConfiguration = mock<Configuration>()
+        whenever(mockAndroidVariant.compileConfiguration) doReturn mockCompileConfiguration
+
+        // When
+        val compileConfiguration = testedAppVariant.compileConfiguration
+
+        // Then
+        assertThat(compileConfiguration).isSameAs(mockCompileConfiguration)
+    }
+
+    @Test
+    fun `M return true W isNativeBuildEnabled { native build providers registered }`(
+        forge: Forge
+    ) {
+        // Given
+        val externalNativeBuildProviders = forge.aList { mock<TaskProvider<ExternalNativeBuildTask>>() }
+        whenever(mockAndroidVariant.externalNativeBuildProviders) doReturn externalNativeBuildProviders
+
+        // When
+        val isNativeBuildEnabled = testedAppVariant.isNativeBuildEnabled
+
+        // Then
+        assertThat(isNativeBuildEnabled).isTrue()
+    }
+
+    @Test
+    fun `M return false W isNativeBuildEnabled { native build providers not registered }`() {
+        // Given
+        whenever(mockAndroidVariant.externalNativeBuildProviders) doReturn emptyList()
+
+        // When
+        val isNativeBuildEnabled = testedAppVariant.isNativeBuildEnabled
+
+        // Then
+        assertThat(isNativeBuildEnabled).isFalse()
+    }
+
+    @Test
+    fun `M return if minification is enabled or not W isMinifyEnabled`(
+        @BoolForgery fakeMinifyEnabled: Boolean
+    ) {
+        // Given
+        val mockBuildType = mock<BuildType>()
+        whenever(mockBuildType.isMinifyEnabled) doReturn fakeMinifyEnabled
+        whenever(mockAndroidVariant.buildType) doReturn mockBuildType
+
+        // When
+        val isMinifyEnabled = testedAppVariant.isMinifyEnabled
+
+        // Then
+        assertThat(isMinifyEnabled).isEqualTo(fakeMinifyEnabled)
+    }
+
+    @Test
+    fun `M return build type name W buildTypeName`(
+        @StringForgery fakeBuildTypeName: String
+    ) {
+        // Given
+        val mockBuildType = mock<BuildType>()
+        whenever(mockBuildType.name) doReturn fakeBuildTypeName
+        whenever(mockAndroidVariant.buildType) doReturn mockBuildType
+
+        // When
+        val buildTypeName = testedAppVariant.buildTypeName
+
+        // Then
+        assertThat(buildTypeName).isEqualTo(fakeBuildTypeName)
+    }
+
+    @Test
+    fun `M return flavor names W flavors`(
+        @StringForgery fakeFlavorNames: List<String>
+    ) {
+        // Given
+        val mockFlavors = fakeFlavorNames.map {
+            val mockFlavor = mock<ProductFlavor>()
+            whenever(mockFlavor.name) doReturn it
+            mockFlavor
+        }
+        whenever(mockAndroidVariant.productFlavors) doReturn mockFlavors
+
+        // When
+        val flavors = testedAppVariant.flavors
+
+        // Then
+        assertThat(flavors).isEqualTo(fakeFlavorNames)
+    }
+
+    @Test
+    fun `M return mapping file W mappingFile`(
+        @StringForgery fakeVariantName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.name) doReturn fakeVariantName
+
+        // When
+        val mappingFile = testedAppVariant.mappingFile
+
+        // Then
+        assertThat(mappingFile.get().asFile.path).endsWith(
+            Paths.get("outputs", "mapping", fakeVariantName, "mapping.txt").toString()
+        )
+    }
+
+    @Test
+    fun `M collect java and kotlin source dirs W collectJavaAndKotlinSourceDirectories`(
+        @TempDir tempDir: File,
+        forge: Forge
+    ) {
+        // Given
+        val expectedSourceDirectories = mutableListOf<File>()
+        val mockSourceSets = forge.aList {
+            val mockSourceProvider = mock<SourceProvider>()
+            val fakeJavaDirectories = aList { File(tempDir, anAlphaNumericalString()) }
+            val fakeKotlinDirectories = aList { File(tempDir, anAlphaNumericalString()) }
+            expectedSourceDirectories += fakeJavaDirectories
+            expectedSourceDirectories += fakeKotlinDirectories
+            whenever(mockSourceProvider.javaDirectories) doReturn fakeJavaDirectories
+            whenever(mockSourceProvider.kotlinDirectories) doReturn fakeKotlinDirectories
+            mockSourceProvider
+        }
+        whenever(mockAndroidVariant.sourceSets) doReturn mockSourceSets
+
+        // When
+        val sourceDirectories = testedAppVariant.collectJavaAndKotlinSourceDirectories()
+
+        // Then
+        assertThat(sourceDirectories.get())
+            .isEqualTo(expectedSourceDirectories)
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariantTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariantTest.kt
@@ -1,0 +1,375 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.internal.variant
+
+import com.android.build.api.artifact.Artifacts
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationVariant
+import com.android.build.api.variant.ExternalNativeBuild
+import com.android.build.api.variant.SourceDirectories
+import com.android.build.api.variant.Sources
+import com.android.build.api.variant.VariantOutput
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.File
+import java.util.Random
+
+@Extensions(
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(MockitoExtension::class)
+)
+@ForgeConfiguration(value = Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class NewApiAppVariantTest {
+
+    private lateinit var testedAppVariant: NewApiAppVariant
+
+    private val fakeProject = ProjectBuilder.builder().build()
+
+    @Mock
+    lateinit var mockAndroidVariant: ApplicationVariant
+
+    @BeforeEach
+    fun `set up`() {
+        testedAppVariant = NewApiAppVariant(
+            mockAndroidVariant,
+            fakeProject
+        )
+    }
+
+    @Test
+    fun `M return variant name W name`(
+        @StringForgery fakeName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.name) doReturn fakeName
+
+        // When
+        val name = testedAppVariant.name
+
+        // Then
+        assertThat(name).isEqualTo(fakeName)
+    }
+
+    @Test
+    fun `M return application ID W applicationId`(
+        @StringForgery fakeApplicationId: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.applicationId) doReturn fakeApplicationId.asProperty()
+
+        // When
+        val applicationId = testedAppVariant.applicationId.get()
+
+        // Then
+        assertThat(applicationId).isEqualTo(fakeApplicationId)
+    }
+
+    @Test
+    fun `M return flavor name W flavorName`(
+        @StringForgery fakeFlavorName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.flavorName) doReturn fakeFlavorName
+
+        // When
+        val flavorName = testedAppVariant.flavorName
+
+        // Then
+        assertThat(flavorName).isEqualTo(fakeFlavorName)
+    }
+
+    @Test
+    fun `M return version name W versionName`(
+        @IntForgery(min = 1) fakeVersionCode: Int,
+        @StringForgery fakeVersionName: String,
+        forge: Forge
+    ) {
+        // Given
+        val validOutput = mock<VariantOutput>()
+        whenever(validOutput.enabled) doReturn true.asProperty()
+        whenever(validOutput.versionCode) doReturn fakeVersionCode.asProperty()
+        whenever(validOutput.versionName) doReturn fakeVersionName.asProperty()
+        val fakeNonValidOutputs = forge.aList {
+            val nonValidOutput = mock<VariantOutput>()
+            if (forge.aBool()) {
+                whenever(nonValidOutput.enabled) doReturn false.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn fakeVersionCode.asProperty()
+            } else {
+                whenever(nonValidOutput.enabled) doReturn true.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn null.asProperty()
+            }
+            nonValidOutput
+        }
+        val fakeVariantOutputs = (fakeNonValidOutputs + validOutput).shuffled(Random(forge.seed))
+        whenever(mockAndroidVariant.outputs) doReturn fakeVariantOutputs
+
+        // When
+        val versionName = testedAppVariant.versionName.get()
+
+        // Then
+        assertThat(versionName).isEqualTo(fakeVersionName)
+    }
+
+    @Test
+    fun `M return empty version name W versionName { missing version name }`(
+        @IntForgery(min = 1) fakeVersionCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        val validOutput = mock<VariantOutput>()
+        whenever(validOutput.enabled) doReturn true.asProperty()
+        whenever(validOutput.versionCode) doReturn fakeVersionCode.asProperty()
+        whenever(validOutput.versionName) doReturn null.asProperty()
+        val fakeNonValidOutputs = forge.aList {
+            val nonValidOutput = mock<VariantOutput>()
+            if (forge.aBool()) {
+                whenever(nonValidOutput.enabled) doReturn false.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn fakeVersionCode.asProperty()
+            } else {
+                whenever(nonValidOutput.enabled) doReturn true.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn null.asProperty()
+            }
+            nonValidOutput
+        }
+        val fakeVariantOutputs = (fakeNonValidOutputs + validOutput).shuffled(Random(forge.seed))
+        whenever(mockAndroidVariant.outputs) doReturn fakeVariantOutputs
+
+        // When
+        val versionName = testedAppVariant.versionName.get()
+
+        // Then
+        assertThat(versionName).isEmpty()
+    }
+
+    @Test
+    fun `M return version code W versionCode`(
+        @IntForgery(min = 1) fakeVersionCode: Int,
+        forge: Forge
+    ) {
+        val validOutput = mock<VariantOutput>()
+        whenever(validOutput.enabled) doReturn true.asProperty()
+        whenever(validOutput.versionCode) doReturn fakeVersionCode.asProperty()
+        val fakeNonValidOutputs = forge.aList {
+            val nonValidOutput = mock<VariantOutput>()
+            if (forge.aBool()) {
+                whenever(nonValidOutput.enabled) doReturn false.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn fakeVersionCode.asProperty()
+            } else {
+                whenever(nonValidOutput.enabled) doReturn true.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn null.asProperty()
+            }
+            nonValidOutput
+        }
+        val fakeVariantOutputs = (fakeNonValidOutputs + validOutput).shuffled(Random(forge.seed))
+        whenever(mockAndroidVariant.outputs) doReturn fakeVariantOutputs
+
+        // When
+        val versionCode = testedAppVariant.versionCode.get()
+
+        // Then
+        assertThat(versionCode).isEqualTo(fakeVersionCode)
+    }
+
+    @Test
+    fun `M return default version code W versionCode { no valid variant output }`(
+        @IntForgery(min = 1) fakeVersionCode: Int,
+        forge: Forge
+    ) {
+        val fakeNonValidOutputs = forge.aList {
+            val nonValidOutput = mock<VariantOutput>()
+            if (forge.aBool()) {
+                whenever(nonValidOutput.enabled) doReturn false.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn fakeVersionCode.asProperty()
+            } else {
+                whenever(nonValidOutput.enabled) doReturn true.asProperty()
+                whenever(nonValidOutput.versionCode) doReturn null.asProperty()
+            }
+            nonValidOutput
+        }
+        whenever(mockAndroidVariant.outputs) doReturn fakeNonValidOutputs
+
+        // When
+        val versionCode = testedAppVariant.versionCode.get()
+
+        // Then
+        assertThat(versionCode).isEqualTo(1)
+    }
+
+    @Test
+    fun `M return compile configuration W compileConfiguration`() {
+        // Given
+        val mockCompileConfiguration = mock<Configuration>()
+        whenever(mockAndroidVariant.compileConfiguration) doReturn mockCompileConfiguration
+
+        // When
+        val compileConfiguration = testedAppVariant.compileConfiguration
+
+        // Then
+        assertThat(compileConfiguration).isSameAs(mockCompileConfiguration)
+    }
+
+    @Test
+    fun `M return if native build is enabled W isNativeBuildEnabled`(
+        @BoolForgery fakeEnabled: Boolean
+    ) {
+        // Given
+        whenever(
+            mockAndroidVariant.externalNativeBuild
+        ) doReturn if (fakeEnabled) mock<ExternalNativeBuild>() else null
+
+        // When
+        val isNativeBuildEnabled = testedAppVariant.isNativeBuildEnabled
+
+        // Then
+        assertThat(isNativeBuildEnabled).isEqualTo(fakeEnabled)
+    }
+
+    @Test
+    fun `M return if minification is enabled W isMinifyEnabled`(
+        @BoolForgery fakeMinifyEnabled: Boolean
+    ) {
+        // Given
+        @Suppress("UnstableApiUsage")
+        whenever(mockAndroidVariant.isMinifyEnabled) doReturn fakeMinifyEnabled
+
+        // When
+        val isMinifyEnabled = testedAppVariant.isMinifyEnabled
+
+        // Then
+        assertThat(isMinifyEnabled).isEqualTo(fakeMinifyEnabled)
+    }
+
+    @Test
+    fun `M return build type name W buildTypeName`(
+        @StringForgery fakeBuildTypeName: String
+    ) {
+        // Given
+        whenever(mockAndroidVariant.buildType) doReturn fakeBuildTypeName
+
+        // When
+        val buildTypeName = testedAppVariant.buildTypeName
+
+        // Then
+        assertThat(buildTypeName).isEqualTo(fakeBuildTypeName)
+    }
+
+    @Test
+    fun `M return flavor names W flavors`(
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) fakeFlavors: Map<String, String>
+    ) {
+        // Given
+        whenever(mockAndroidVariant.productFlavors) doReturn fakeFlavors.toList()
+
+        // When
+        val flavors = testedAppVariant.flavors
+
+        // Then
+        assertThat(flavors).isEqualTo(fakeFlavors.values.toList())
+    }
+
+    @Test
+    fun `M return mapping file W mappingFile`(
+        @StringForgery fakeMappingFileName: String
+    ) {
+        // Given
+        val fakeMappingFile = File(fakeProject.layout.buildDirectory.get().asFile, fakeMappingFileName)
+        val mockArtifacts = mock<Artifacts>()
+        whenever(
+            mockArtifacts.get(SingleArtifact.OBFUSCATION_MAPPING_FILE)
+        ) doReturn fakeProject.layout.buildDirectory.file(fakeMappingFile.path)
+        whenever(mockAndroidVariant.artifacts) doReturn mockArtifacts
+
+        // When
+        val mappingFile = testedAppVariant.mappingFile
+
+        // Then
+        assertThat(mappingFile.get().asFile).isEqualTo(fakeMappingFile)
+    }
+
+    @RepeatedTest(4)
+    fun `M collect java and kotlin source dirs W collectJavaAndKotlinSourceDirectories`(
+        @TempDir tempDir: File,
+        @BoolForgery includeJava: Boolean,
+        @BoolForgery includeKotlin: Boolean,
+        forge: Forge
+    ) {
+        // Given
+        val expectedSourceDirectories = mutableListOf<File>()
+        val mockSources = mock<Sources>()
+        if (includeJava) {
+            val mockJavaSources = mock<SourceDirectories.Flat>()
+            val fakeJavaDirectories = forge.aList { File(tempDir, anAlphaNumericalString()) }
+            whenever(
+                mockJavaSources.all
+            ) doReturn fakeJavaDirectories.map { it.asDirectory() }.asListProperty()
+            whenever(mockSources.java) doReturn mockJavaSources
+            expectedSourceDirectories += fakeJavaDirectories
+        }
+        if (includeKotlin) {
+            val mockKotlinSources = mock<SourceDirectories.Flat>()
+            val fakeKotlinDirectories = forge.aList { File(tempDir, anAlphaNumericalString()) }
+            whenever(
+                mockKotlinSources.all
+            ) doReturn fakeKotlinDirectories.map { it.asDirectory() }.asListProperty()
+            @Suppress("UnstableApiUsage")
+            whenever(mockSources.kotlin) doReturn mockKotlinSources
+            expectedSourceDirectories += fakeKotlinDirectories
+        }
+        whenever(mockAndroidVariant.sources) doReturn mockSources
+
+        // When
+        val sourceDirectories = testedAppVariant.collectJavaAndKotlinSourceDirectories()
+
+        // Then
+        assertThat(sourceDirectories.get())
+            .isEqualTo(expectedSourceDirectories)
+    }
+
+    // region private
+
+    private inline fun <reified T> T.asProperty(): Property<T> =
+        fakeProject.objects.property(T::class.java).value(this)
+
+    private inline fun <reified T> Collection<T>.asListProperty(): ListProperty<T> =
+        fakeProject.objects.listProperty(T::class.java).value(this)
+
+    private fun File.asDirectory(): Directory =
+        fakeProject.objects.directoryProperty().fileValue(this).get()
+
+    // endregion
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/BuildResultAssert.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/BuildResultAssert.kt
@@ -1,7 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
 package com.datadog.gradle.plugin.utils.assertj
 
 import com.datadog.gradle.plugin.DdAndroidGradlePlugin
-import com.datadog.gradle.plugin.DdNdkSymbolFileUploadTask
+import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
@@ -39,14 +45,14 @@ internal class BuildResultAssert(actual: BuildResult) :
             it.path.contains(DdAndroidGradlePlugin.UPLOAD_TASK_NAME)
         }
         assertThat(actual.tasks).noneMatch {
-            it.path.contains(DdNdkSymbolFileUploadTask.TASK_NAME)
+            it.path.contains(NdkSymbolFileUploadTask.TASK_NAME)
         }
         return this
     }
 
     fun hasNoNdkSymbolUploadTasks(): BuildResultAssert {
         assertThat(actual.tasks).noneMatch {
-            it.path.contains(DdNdkSymbolFileUploadTask.TASK_NAME)
+            it.path.contains(NdkSymbolFileUploadTask.TASK_NAME)
         }
         return this
     }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/RecordedRequestAssert.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/RecordedRequestAssert.kt
@@ -4,7 +4,7 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.assertj
 
 import okhttp3.mockwebserver.RecordedRequest
 import okio.GzipSource

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
@@ -4,7 +4,7 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.forge
 
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeConfigurator

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/DdExtensionConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/DdExtensionConfigurationForgeryFactory.kt
@@ -4,30 +4,24 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.forge
 
+import com.datadog.gradle.plugin.DatadogSite
+import com.datadog.gradle.plugin.DdExtensionConfiguration
+import com.datadog.gradle.plugin.SdkCheckLevel
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
-import org.gradle.api.model.ObjectFactory
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
-internal class DdExtensionForgeryFactory : ForgeryFactory<DdExtension> {
-    override fun getForgery(forge: Forge): DdExtension {
-        val objectFactory: ObjectFactory = mock()
-
-        whenever(objectFactory.domainObjectContainer<Any>(any())) doReturn mock()
-
-        return DdExtension(objectFactory).apply {
+internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensionConfiguration> {
+    override fun getForgery(forge: Forge): DdExtensionConfiguration {
+        return DdExtensionConfiguration().apply {
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}")
             versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
             site = forge.aValueFrom(DatadogSite::class.java).name
-            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
             remoteRepositoryUrl = forge.aStringMatching(
                 "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git"
             )
+            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
             mappingFilePath = forge.aStringMatching(
                 "([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt"
             )

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/DdExtensionForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/DdExtensionForgeryFactory.kt
@@ -4,21 +4,33 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.forge
 
+import com.datadog.gradle.plugin.DatadogSite
+import com.datadog.gradle.plugin.DdExtension
+import com.datadog.gradle.plugin.SdkCheckLevel
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
+import org.gradle.api.model.ObjectFactory
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
-internal class DdExtensionConfigurationForgeryFactory : ForgeryFactory<DdExtensionConfiguration> {
-    override fun getForgery(forge: Forge): DdExtensionConfiguration {
-        return DdExtensionConfiguration().apply {
+internal class DdExtensionForgeryFactory : ForgeryFactory<DdExtension> {
+    override fun getForgery(forge: Forge): DdExtension {
+        val objectFactory: ObjectFactory = mock()
+
+        whenever(objectFactory.domainObjectContainer<Any>(any())) doReturn mock()
+
+        return DdExtension(objectFactory).apply {
             serviceName = forge.aStringMatching("[a-z]{3}(\\.[a-z]{5,10}){2,4}")
             versionName = forge.aStringMatching("\\d\\.\\d{1,2}\\.\\d{1,3}")
             site = forge.aValueFrom(DatadogSite::class.java).name
+            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
             remoteRepositoryUrl = forge.aStringMatching(
                 "https://[a-z]{4,10}\\.[com|org]/[a-z]{4,10}/[a-z]{4,10}\\.git"
             )
-            checkProjectDependencies = forge.aValueFrom(SdkCheckLevel::class.java)
             mappingFilePath = forge.aStringMatching(
                 "([a-z]+)/([a-z]+)/([a-z]+)/mapping.txt"
             )

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/IdentifierForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/IdentifierForgeryFactory.kt
@@ -4,7 +4,7 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.forge
 
 import com.datadog.gradle.plugin.internal.DdAppIdentifier
 import fr.xgouchet.elmyr.Forge

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/RepositoryInfoForgeryFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/RepositoryInfoForgeryFactory.kt
@@ -4,8 +4,9 @@
  * Copyright 2020-Present Datadog, Inc.
  */
 
-package com.datadog.gradle.plugin
+package com.datadog.gradle.plugin.utils.forge
 
+import com.datadog.gradle.plugin.RepositoryInfo
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory

--- a/samples/basic/src/main/AndroidManifest.xml
+++ b/samples/basic/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
   ~ Copyright 2020-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.datadog.example.basic">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/samples/variants-kotlin/build.gradle.kts
+++ b/samples/variants-kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
 
-    namespace = "com.datadog.example.variants.kotlin"
+    namespace = "com.datadog.example.variants"
     defaultConfig {
         applicationId = "com.datadog.example.variants.kotlin"
 

--- a/samples/variants-kotlin/src/main/AndroidManifest.xml
+++ b/samples/variants-kotlin/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
   ~ Copyright 2020-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.datadog.example.variants">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/samples/variants/src/main/AndroidManifest.xml
+++ b/samples/variants/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
   ~ Copyright 2020-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.datadog.example.variants">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
### What does this PR do?

This PR brings support of [new Variant API](https://medium.com/androiddevelopers/new-apis-in-the-android-gradle-plugin-f5325742e614). It was [originally added in AGP 7](https://developer.android.com/build/releases/past-releases/agp-7-0-0-release-notes#variant-api-stable), but we didn't use it because it was missing some APIs from old Variant API.

Now we will use new Variant API for AGP 8.4.0 and above (because for the older AGP versions old Variant API works fine, but AGP 8.4.0 has a regression mentioned [here](https://issuetracker.google.com/issues/342428022)).

Timeline of migration from old Variant API to the new one is [here](https://developer.android.com/build/releases/gradle-plugin-roadmap) (new Variant API is completely stable with AGP 9, old Variant API is removed with AGP 10, mid-2025).

This PR should fix #242 and #257.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

