### PR TITLE
Use mapping file provider in case of legacy Variant API

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
@@ -20,4 +20,7 @@ internal object CurrentAgpVersion {
 
     val EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC: Boolean
         get() = TaskUtils.isAgpAbove(major = 8, minor = 0, patch = 0)
+
+    val CAN_QUERY_MAPPING_FILE_PROVIDER: Boolean
+        get() = TaskUtils.isAgpAbove(major = 7, minor = 0, patch = 0)
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/AppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/AppVariant.kt
@@ -8,6 +8,7 @@ package com.datadog.gradle.plugin.internal.variant
 
 import com.android.build.gradle.AppExtension
 import com.datadog.gradle.plugin.GenerateBuildIdTask
+import com.datadog.gradle.plugin.MappingFileUploadTask
 import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -46,6 +47,8 @@ internal interface AppVariant {
     fun collectJavaAndKotlinSourceDirectories(): Provider<List<File>>
 
     fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask)
+
+    fun bindWith(mappingFileUploadTask: MappingFileUploadTask)
 
     // new variant API doesn't allow to run addGeneratedSourceDirectory from inside Task#configure, thus this
     fun bindWith(generateBuildIdTask: TaskProvider<GenerateBuildIdTask>, buildIdDirectory: Provider<Directory>)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
@@ -11,6 +11,7 @@ import com.android.build.api.variant.ApplicationVariant
 import com.android.build.api.variant.VariantOutput
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
 import com.datadog.gradle.plugin.GenerateBuildIdTask
+import com.datadog.gradle.plugin.MappingFileUploadTask
 import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
 import com.datadog.gradle.plugin.internal.getSearchObjDirs
 import org.gradle.api.Project
@@ -76,6 +77,10 @@ internal class NewApiAppVariant(
             ndkUploadTask.searchDirectories.from(searchFiles)
             ndkUploadTask.dependsOn(it)
         }
+    }
+
+    override fun bindWith(mappingFileUploadTask: MappingFileUploadTask) {
+        // nothing is needed, dependency on minification task is created by mapping file provider
     }
 
     override fun bindWith(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariantTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariantTest.kt
@@ -240,9 +240,56 @@ internal class LegacyApiAppVariantTest {
 
     @Test
     fun `M return mapping file W mappingFile`(
+        @TempDir fakeMappingDirectory: File,
+        @StringForgery fakeVariantName: String,
+        @StringForgery fakeMappingFileName: String
+    ) {
+        // Given
+        val fakeMappingFile = File(fakeMappingDirectory, fakeMappingFileName)
+        whenever(
+            mockAndroidVariant.mappingFileProvider
+        ) doReturn fakeProject.provider { fakeProject.files(fakeMappingFile) }
+        whenever(mockAndroidVariant.name) doReturn fakeVariantName
+
+        // When
+        val mappingFile = testedAppVariant.mappingFile
+
+        // Then
+        assertThat(mappingFile.get().asFile).isEqualTo(fakeMappingFile)
+    }
+
+    @Test
+    fun `M return mapping file W mappingFile { fallback to legacy, no mapping files in provider }`(
         @StringForgery fakeVariantName: String
     ) {
         // Given
+        whenever(
+            mockAndroidVariant.mappingFileProvider
+        ) doReturn fakeProject.provider { fakeProject.files() }
+        whenever(mockAndroidVariant.name) doReturn fakeVariantName
+
+        // When
+        val mappingFile = testedAppVariant.mappingFile
+
+        // Then
+        assertThat(mappingFile.get().asFile.path).endsWith(
+            Paths.get("outputs", "mapping", fakeVariantName, "mapping.txt").toString()
+        )
+    }
+
+    @Test
+    fun `M return mapping file W mappingFile { fallback to legacy, multiple files in provider }`(
+        @TempDir fakeMappingDirectory: File,
+        @StringForgery fakeVariantName: String,
+        @StringForgery fakeMappingFileNameA: String,
+        @StringForgery fakeMappingFileNameB: String
+    ) {
+        // Given
+        val fileA = File(fakeMappingDirectory, fakeMappingFileNameA)
+        val fileB = File(fakeMappingDirectory, fakeMappingFileNameB)
+        whenever(
+            mockAndroidVariant.mappingFileProvider
+        ) doReturn fakeProject.provider { fakeProject.files(fileA, fileB) }
         whenever(mockAndroidVariant.name) doReturn fakeVariantName
 
         // When


### PR DESCRIPTION
### What does this PR do?

This PR makes to use `Variant.mappingFileProvider` in case of legacy API usage. This brings more reliable way to get a mapping file.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

