### PR TITLE
Remove the statement from `README` that logs are not deobfuscated

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ datadog {
 }
 ```
 
-**Note**: Only stacktraces in errors/crashes reported through RUM will be deobfuscated; errors in Datadog Logs won't be deobfuscated. 
-
 For more information, see [Android Crash Reporting and Error Tracking](https://docs.datadoghq.com/real_user_monitoring/error_tracking/android/).
 
 ## Troubleshooting


### PR DESCRIPTION
### What does this PR do?

We support deobfuscation for logs for a long time already, so removing false statement.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

