### PR TITLE
Update Datadog SDK to version 2.11.0-debug

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.11.0"
+datadogSdk = "2.11.0-debug"
 datadogPluginGradle = "1.14.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog SDK from version 2.11.0 to version 2.11.0-debug: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.11.0...2.11.0-debug)