### PR TITLE
Update Datadog SDK to version 2.16.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.15.1"
+datadogSdk = "2.16.0"
 datadogPluginGradle = "1.14.0"
 
 [libraries]


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog SDK from version 2.15.1 to version 2.16.0: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.15.1...2.16.0)