### PR TITLE
RUM-7461: supporting custom ndk symbols path

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -98,8 +98,10 @@ class DdAndroidGradlePlugin @Inject constructor(
     ) {
         val isObfuscationEnabled = isObfuscationEnabled(variant, datadogExtension)
         val isNativeBuildRequired = variant.isNativeBuildEnabled
+        val isNativeSymbolsTaskRequired =
+            isNativeBuildRequired || datadogExtension.additionalSymbolFilesLocations?.isNotEmpty() == true
 
-        if (isObfuscationEnabled || isNativeBuildRequired) {
+        if (isObfuscationEnabled || isNativeBuildRequired || isNativeSymbolsTaskRequired) {
             val buildIdGenerationTask =
                 configureBuildIdGenerationTask(target, variant)
 
@@ -115,7 +117,7 @@ class DdAndroidGradlePlugin @Inject constructor(
                 LOGGER.info("Minifying disabled for variant ${variant.name}, no mapping file upload task created")
             }
 
-            if (isNativeBuildRequired) {
+            if (isNativeSymbolsTaskRequired) {
                 configureNdkSymbolUploadTask(
                     target,
                     datadogExtension,
@@ -126,6 +128,7 @@ class DdAndroidGradlePlugin @Inject constructor(
             } else {
                 LOGGER.info(
                     "No native build tasks found for variant ${variant.name}," +
+                        " no additionalSymbolFilesLocations provided, " +
                         " no NDK symbol file upload task created."
                 )
             }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -95,6 +95,22 @@ open class DdExtensionConfiguration(
      */
     var ignoreDatadogCiFileConfig: Boolean = false
 
+    /**
+     * Additional locations that Gradle plugin will check for `.so` files during `uploadNdkSymbolFiles` task.
+     * Directory structure should follow pattern: `/path/to/location/obj/{arch}/libname.so`.
+     *
+     * In case of above `additionalSymbolFilesLocations` should be equal to:
+     *
+     * ```
+     * datadog {
+     *      additionalSymbolFilesLocations = listOf("/path/to/location/obj")
+     * }
+     * ```
+     *
+     * Note that each `.so` file should be placed inside the directory with architecture name (e.g. x86).
+     */
+    var additionalSymbolFilesLocations: List<String>? = null
+
     internal fun updateWith(config: DdExtensionConfiguration) {
         config.versionName?.let { versionName = it }
         config.serviceName?.let { serviceName = it }
@@ -102,6 +118,7 @@ open class DdExtensionConfiguration(
         config.remoteRepositoryUrl?.let { remoteRepositoryUrl = it }
         config.checkProjectDependencies?.let { checkProjectDependencies = it }
         config.mappingFilePath?.let { mappingFilePath = it }
+        config.additionalSymbolFilesLocations?.let { additionalSymbolFilesLocations = it }
         mappingFilePackageAliases = config.mappingFilePackageAliases
         mappingFileTrimIndents = config.mappingFileTrimIndents
         ignoreDatadogCiFileConfig = config.ignoreDatadogCiFileConfig

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTask.kt
@@ -113,6 +113,9 @@ internal abstract class NdkSymbolFileUploadTask @Inject constructor(
 
                     task.datadogCiFile = TaskUtils.findDatadogCiFile(project.rootDir)
                     task.repositoryFile = TaskUtils.resolveDatadogRepositoryFile(project)
+                    extensionConfiguration.additionalSymbolFilesLocations?.let {
+                        task.searchDirectories.from(it.toTypedArray())
+                    }
                     task.configureWith(
                         apiKey,
                         extensionConfiguration,

--- a/dd-sdk-android-gradle-plugin/src/test/resources/native_gradle_files/build_with_custom_ndk.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/native_gradle_files/build_with_custom_ndk.gradle
@@ -1,0 +1,72 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("com.datadoghq.dd-sdk-android-gradle-plugin")
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        applicationId "com.example.variants"
+        minSdkVersion 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+        multiDexEnabled = true
+    }
+
+    namespace = "com.example.variants"
+
+    compileOptions {
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
+    }
+    externalNativeBuild {
+        cmake {
+            path file('src/main/cpp/CMakeLists.txt')
+            version '3.22.1'
+        }
+    }
+
+    flavorDimensions("version", "colour")
+    productFlavors {
+        demo {
+            dimension "version"
+            applicationIdSuffix ".demo"
+            versionNameSuffix "-demo"
+        }
+        full {
+            dimension "version"
+            applicationIdSuffix ".full"
+            versionNameSuffix "-full"
+        }
+
+        green {
+            dimension "colour"
+        }
+        blue {
+            dimension "colour"
+        }
+    }
+}
+
+dependencies {
+    implementation(rootProject.ext.datadogSdkDependency)
+}
+
+datadog {
+    additionalSymbolFilesLocations = [
+            "custom"
+    ]
+}

--- a/dd-sdk-android-gradle-plugin/src/test/resources/native_gradle_files/build_with_custom_ndk_no_externalNativeBuild.gradle
+++ b/dd-sdk-android-gradle-plugin/src/test/resources/native_gradle_files/build_with_custom_ndk_no_externalNativeBuild.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("com.datadoghq.dd-sdk-android-gradle-plugin")
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion = rootProject.ext.targetSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        applicationId "com.example.variants"
+        minSdkVersion 21
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+        multiDexEnabled = true
+    }
+
+    namespace = "com.example.variants"
+
+    compileOptions {
+        sourceCompatibility = rootProject.ext.jvmTarget
+        targetCompatibility = rootProject.ext.jvmTarget
+    }
+
+    kotlinOptions {
+        jvmTarget = rootProject.ext.jvmTarget
+    }
+
+    flavorDimensions("version", "colour")
+    productFlavors {
+        demo {
+            dimension "version"
+            applicationIdSuffix ".demo"
+            versionNameSuffix "-demo"
+        }
+        full {
+            dimension "version"
+            applicationIdSuffix ".full"
+            versionNameSuffix "-full"
+        }
+
+        green {
+            dimension "colour"
+        }
+        blue {
+            dimension "colour"
+        }
+    }
+}
+
+dependencies {
+    implementation(rootProject.ext.datadogSdkDependency)
+}
+
+datadog {
+    additionalSymbolFilesLocations = [
+            "custom"
+    ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds a property `additionalSymbolsFilesLocations ` which allows to specify custom .so files location in order to upload them with **uploadNdkSymbolFiles** task

### Motivation

This is the response to customer [request](https://github.com/DataDog/dd-sdk-android-gradle-plugin/issues/296)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

