### PR TITLE
Overwrite gradle.properties with CI configs for test plugin task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ test:plugin:
   stage: test
   timeout: 1h
   script:
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
     - git fetch --depth=1 origin main
     - rm -rf ~/.gradle/daemon/
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?

`test:plugin` keeps failing on CI with this error:
```
> Task :dd-sdk-android-gradle-plugin:test
DdAndroidGradlePluginFunctionalTest > M success W assembleRelease() FAILED
    java.lang.IllegalStateException at DdAndroidGradlePluginFunctionalTest.kt:142
        Caused by: org.gradle.tooling.GradleConnectionException at DdAndroidGradlePluginFunctionalTest.kt:142
            Caused by: org.gradle.launcher.daemon.client.DaemonDisappearedException at DaemonClient.java:283
DdAndroidGradlePluginFunctionalTest > M not try to upload the symbol file W no cmake dependencies { using a fake API_KEY }() FAILED
    java.lang.IllegalStateException at DdAndroidGradlePluginFunctionalTest.kt:1022
        Caused by: org.gradle.tooling.GradleConnectionException at DdAndroidGradlePluginFunctionalTest.kt:1022
            Caused by: org.gradle.launcher.daemon.client.DaemonDisappearedException at DaemonClient.java:283
```
For CI it's useless to have daemons, so we copy the CI gradle properties to the overwrite the project gradle properties with following options:
```
org.gradle.daemon=false
org.gradle.parallel=false
org.gradle.caching=false
```



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

