### PR TITLE
Increase CI kubernetes memory limit to 20Gi to avoid OOM

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_COMMON_AGENT_CONFIG: "dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false"
 
   KUBERNETES_MEMORY_REQUEST: "8Gi"
-  KUBERNETES_MEMORY_LIMIT: "16Gi"
+  KUBERNETES_MEMORY_LIMIT: "20Gi"
 
 stages:
   - ci-image
@@ -90,7 +90,6 @@ test:plugin:
   stage: test
   timeout: 1h
   script:
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
     - git fetch --depth=1 origin main
     - rm -rf ~/.gradle/daemon/
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?

Increase CI kubernetes memory limit to 20Gi .

### Motivation

To avoid `test:plugin` task triggering OOM on CI

### Additional Notes

The previous fix of adding the override of gradle.properties is revoked.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

