### PR TITLE
RUM-8838: Register Kotlin compiler plugin to Kotlin compile options

### DIFF
--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     testImplementation(libs.kotlinPluginGradle)
     testImplementation(libs.kotlinCompilerEmbeddable)
 
+    compileOnly(libs.kotlinPluginGradle)
     compileOnly(libs.kotlinCompilerEmbeddable)
     compileOnly(libs.autoServiceAnnotation)
     kapt(libs.autoService)


### PR DESCRIPTION
### What does this PR do?

Prior to this PR, in the sample app we need to use `kotlinCompilerPluginClasspath` to make KCP work during the kotlin compilation.
```
dependencies{
      kotlinCompilerPluginClasspath("com.datadoghq:dd-sdk-android-gradle-plugin:$version")
}
```
The goal of this PR is that KCP can be automatically registered after client apply our AGP in the `plugins{}`block:
```
plugins{
     id("com.datadoghq.dd-sdk-android-gradle-plugin")
}
```
The idea of this PR is to apply compilerOptions programatically from our AGP class
```
android {
    ...
    kotlin {
      compilerOptions {
          freeCompilerArgs.add(
              "-Xplugin=/path/to/kotlin-compiler-plugin.jar"
          )
    }
}
```
The step to achieve it:
* find plugin "org.jetbrains.kotlin.android" and configure insdie.
* Retrieve the "dd-sdk-android-gradle-plugin" version declared in root gradle classpath.
* Create a custom dependency configuration called "ddCompilerPluginClassPath" dedicated for KCP dependency
* Add "dd-sdk-android-gradle-plugin" dependency with "ddCompilerPluginClassPath" into `dependencies` block
* Retrieve the jar file path of the plugin from this dependency
* Add it into `freeCompilerArgs` as "-Xplugin=/path/to/kotlin-compiler-plugin.jar"


### Motivation

RUM-8838

### Additional Notes

RUM-8838

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

