### PR TITLE
RUM-8876: Add Kotlin compilation unit test for modifier injection

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -11,6 +11,10 @@ import,org.jetbrains,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin 
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,com.google.auto.service,Apache-2.0,Copyright 2013 Google LLC
 import,org.json,JSON,Copyright (c) 2002 JSON.org
+import(test),androidx.compose,Apache-2.0,Copyright 2019 The Android Open Source Project
+import(test),androidx.compose.ui,Apache-2.0,Copyright 2019 The Android Open Source Project
+import(test),com.android.tools.build,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
+import(test),com.github.tschuchortdev,MPL-2.0,Copyright (C) 2023 Thilo Schuchort
 import(test),com.github.xgouchet.Elmyr,MIT,Copyright 2017-2019 Xavier F. Gouchet
 import(test),net.wuerl.kotlin,Apache-2.0,Copyright 2016 Andreas Würl
 import(test),org.assertj,Apache-2.0,Copyright 2012-2019 the original author or authors

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
     testImplementation(libs.androidToolsPluginGradle)
     testImplementation(libs.kotlinPluginGradle)
     testImplementation(libs.kotlinCompilerEmbeddable)
+    testImplementation(libs.kotlinCompilerTesting)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui)
 
     compileOnly(libs.kotlinPluginGradle)
     compileOnly(libs.kotlinCompilerEmbeddable)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/KotlinCompilerTest.kt
@@ -1,0 +1,341 @@
+package com.datadog.gradle.plugin
+
+import com.datadog.gradle.plugin.kcp.DatadogPluginRegistrar
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import kotlin.reflect.full.declaredFunctions
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@OptIn(ExperimentalCompilerApi::class)
+class KotlinCompilerTest {
+
+    private val datadogModifierSourceFileContent = SourceFile.kotlin(
+        DD_MODIFIER_CLASS_FILE_NAME,
+        DD_MODIFIER_SOURCE_FILE_CONTENT
+    )
+
+    @Mock
+    private lateinit var mockDataDogModifierCallback: () -> Unit
+
+    @Mock
+    private lateinit var mockCustomModifierCallback: () -> Unit
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockDataDogModifierCallback.invoke()) doReturn Unit
+        whenever(mockCustomModifierCallback.invoke()) doReturn Unit
+    }
+
+    @Test
+    fun `M not inject dd modifier W no modifier is present and plugin disabled`() {
+        // Given
+        val noModifierTestCaseSource = SourceFile.kotlin(
+            NO_MODIFIER_TEST_CASE_FILE_NAME,
+            NO_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(noModifierTestCaseSource, false)
+        executeClassFile(
+            classLoader = result.classLoader,
+            className = "com.datadog.kcp.NoModifierTestCase",
+            methodName = "NoModifierTestCase",
+            methodArgs = listOf()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verifyNoInteractions(mockDataDogModifierCallback)
+    }
+
+    @Test
+    fun `M inject dd modifier W no modifier is present and plugin enabled`() {
+        // Given
+        val noModifierTestCaseSource = SourceFile.kotlin(
+            NO_MODIFIER_TEST_CASE_FILE_NAME,
+            NO_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(noModifierTestCaseSource)
+        executeClassFile(
+            classLoader = result.classLoader,
+            className = "com.datadog.kcp.NoModifierTestCase",
+            methodName = "NoModifierTestCase",
+            methodArgs = listOf()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockDataDogModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M not inject dd modifier W default modifier is present and plugin disabled`() {
+        // Given
+        val defaultModifierTestCaseSource = SourceFile.kotlin(
+            DEFAULT_MODIFIER_TEST_CASE_FILE_NAME,
+            DEFAULT_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(defaultModifierTestCaseSource, false)
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.DefaultModifierTestCase",
+            "DefaultModifierTestCase",
+            listOf()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verifyNoInteractions(mockDataDogModifierCallback)
+    }
+
+    @Test
+    fun `M inject dd modifier W default modifier is present and plugin enabled`() {
+        // Given
+        val defaultModifierTestCaseSource = SourceFile.kotlin(
+            DEFAULT_MODIFIER_TEST_CASE_FILE_NAME,
+            DEFAULT_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(defaultModifierTestCaseSource)
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.DefaultModifierTestCase",
+            "DefaultModifierTestCase",
+            listOf()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockDataDogModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M not inject dd modifier W custom modifier is present and plugin disabled`() {
+        // Given
+        val customModifierTestCaseSource = SourceFile.kotlin(
+            CUSTOM_MODIFIER_TEST_CASE_FILE_NAME,
+            CUSTOM_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(customModifierTestCaseSource, false)
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.CustomModifierTestCase",
+            "CustomModifierTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verifyNoInteractions(mockDataDogModifierCallback)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M inject dd modifier W custom modifier is present`() {
+        // Given
+        val customModifierTestCaseSource = SourceFile.kotlin(
+            CUSTOM_MODIFIER_TEST_CASE_FILE_NAME,
+            CUSTOM_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(customModifierTestCaseSource)
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.CustomModifierTestCase",
+            "CustomModifierTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockDataDogModifierCallback).invoke()
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    private fun compileFile(
+        file: SourceFile,
+        enablePlugin: Boolean = true
+    ): KotlinCompilation.Result {
+        val pluginRegistrars = if (enablePlugin) {
+            listOf(DatadogPluginRegistrar())
+        } else {
+            listOf()
+        }
+
+        return KotlinCompilation().apply {
+            sources = listOf(datadogModifierSourceFileContent, file)
+            compilerPluginRegistrars = pluginRegistrars
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }.compile()
+    }
+
+    private fun executeClassFile(
+        classLoader: ClassLoader,
+        className: String,
+        methodName: String,
+        methodArgs: List<Any> = emptyList()
+    ) {
+        // Setup the TestCallbackContainer and the mock callback.
+        val testCallbackContainerClazz = classLoader.loadClass(TEST_CALLBACK_CONTAINER_PATH)
+        val setCallbackFunc = testCallbackContainerClazz.kotlin.declaredFunctions.find { it.name == "setCallback" }
+        val testCallbackContainerInstance = testCallbackContainerClazz.getField("INSTANCE").get(null)
+        setCallbackFunc?.call(testCallbackContainerInstance, mockDataDogModifierCallback)
+
+        // Load the target class.
+        val clazz = classLoader.loadClass(className)
+        val instance = clazz.getDeclaredConstructor().newInstance()
+        val method = clazz.kotlin.declaredFunctions.find { it.name == methodName }
+
+        // Call the function.
+        val args = methodArgs.toTypedArray()
+        method?.call(instance, *args)
+    }
+
+    companion object {
+
+        private const val DD_MODIFIER_CLASS_FILE_NAME = "DatadogModifier.kt"
+        private const val NO_MODIFIER_TEST_CASE_FILE_NAME = "NoModifierTestCase.kt"
+        private const val DEFAULT_MODIFIER_TEST_CASE_FILE_NAME = "DefaultModifierTestCase.kt"
+        private const val CUSTOM_MODIFIER_TEST_CASE_FILE_NAME = "CustomModifierTestCase.kt"
+        private const val TEST_CALLBACK_CONTAINER_PATH = "com.datadog.gradle.plugin.kcp.TestCallbackContainer"
+
+        @Language("kotlin")
+        private val DD_MODIFIER_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp.compose
+            
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.semantics.SemanticsPropertyKey
+            import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+            import androidx.compose.ui.semantics.semantics
+            import com.datadog.gradle.plugin.kcp.TestCallbackContainer
+            
+            fun Modifier.datadog(name: String): Modifier {
+                TestCallbackContainer.invokeCallback()
+                return this.semantics {
+                    this.datadog = name
+                }
+            }
+            
+            internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
+                name = "_dd_semantics",
+                mergePolicy = { parentValue, childValue ->
+                    parentValue
+                }
+            )
+
+            private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val NO_MODIFIER_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            
+            class NoModifierTestCase{
+                @Composable
+                fun NoModifierTestCase() {
+                    CustomComposable(
+                        text = "No Modifier Test Case"
+                    )
+                }
+                
+                @Composable
+                fun CustomComposable(modifier : Modifier = Modifier, text: String){
+                    // do nothing
+                }
+
+            }
+            
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val DEFAULT_MODIFIER_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            
+            class DefaultModifierTestCase{
+                @Composable
+                fun DefaultModifierTestCase() {
+                    CustomComposable(
+                        modifier = Modifier,
+                        text = "Default Modifier Test Case"
+                    )
+                }
+                
+                @Composable
+                fun CustomComposable(modifier : Modifier = Modifier, text: String){
+                    // do nothing
+                }
+
+            }
+            
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val CUSTOM_MODIFIER_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            
+            class CustomModifierTestCase{
+                @Composable
+                fun CustomModifierTestCase(customCallback : () -> Unit) {
+                    CustomComposable(
+                        modifier = Modifier.stubModifier(customCallback),
+                        text = "Custom Modifier Test Case"
+                    )
+                }
+                
+                @Composable
+                fun CustomComposable(modifier : Modifier = Modifier, text: String){
+                    // do nothing
+                }
+
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+            """.trimIndent()
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/TestCallbackContainer.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/TestCallbackContainer.kt
@@ -1,0 +1,29 @@
+package com.datadog.gradle.plugin.kcp
+
+/**
+ * A container for storing callbacks passed from the unit test environment.
+ *
+ * This object should be loaded by the same class loader that loads the test target class file.
+ * To ensure the test target function is invoked correctly, the function under test should
+ * call [TestCallbackContainer.invokeCallback], allowing external verification of the callback invocation.
+ */
+object TestCallbackContainer {
+
+    private var callback: () -> Unit = {}
+
+    /**
+     * Sets the callback function to be invoked during testing.
+     *
+     * @param callback The function to be stored and later invoked.
+     */
+    fun setCallback(callback: () -> Unit) {
+        this.callback = callback
+    }
+
+    /**
+     * Invokes the stored callback function.
+     */
+    fun invokeCallback() {
+        callback.invoke()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ datadogPluginGradle = "1.15.0"
 
 # Kotlin Compiler Plugin
 kotlinCompilerEmbeddable = "1.8.20"
+kotlinCompilerTesting = "1.6.0"
 autoService = "1.0.1"
 junitVersion = "1.2.1"
 espressoCoreVersion = "3.6.1"
@@ -105,6 +106,7 @@ datadogPluginGradle = { module = "com.datadoghq:dd-sdk-android-gradle-plugin", v
 
 # Kotlin Compiler Plugin
 kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlinCompilerEmbeddable" }
+kotlinCompilerTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompilerTesting" }
 autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 autoServiceAnnotation = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 


### PR DESCRIPTION
### What does this PR do?

In this PR, [Kotlin compile testing](https://github.com/tschuchortdev/kotlin-compile-testing) library is introduced to test the compilation result when datadog kotlin compiler plugin is applied.


The idea is to have a stub `DatadogModifier`, this stub one has the same path and function signature so that our KCP will be able to find it and inject it. 
Also for each case we have an example class with `@Composable` to verify that the injection will work in different use cases:
* No modifier is provided
* Default `Modifier` is provided
* Custom modifier is provided.

#### Testing Approach
A `TestCallbackContainer` is introduced to store the mock callback passed from the test environment. The verification process consists of the following steps:

* Load the `TestCallbackContainer` object using the compilation result’s class loader.
* Register the mock callback into `TestCallbackContainer` via reflection in the unit test function.
* Invoke the mock callback from the stub `DatadogModifier`.
* If the injection is successful, the composable function execution will trigger the mock callback.
* The unit test verifies whether the mock callback was invoked, confirming successful modifier injection.

### Motivation

RUM-8876


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

