### PR TITLE
RUMS-4053: Escape user input for mapping file packages aliases

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
@@ -129,7 +129,9 @@ abstract class MappingFileUploadTask
             // after that any possible prefix (which has a smaller length).
             .sortedByDescending { it.key.length }
             .map {
-                Regex("(?<=^|\\W)${it.key}(?=\\W)") to it.value
+                val lookup = it.key.replace(".*", "")
+                    .replace(".", "\\.")
+                Regex("(?<=^|\\W)$lookup(?=\\W)") to it.value
             }
 
         mappingFile.readLines()


### PR DESCRIPTION
### What does this PR do?

Small improvement for the [mappingFilePackageAliases](https://github.com/DataDog/dd-sdk-android-gradle-plugin/blob/ad67028439931bb4608d2a94768641f5f2c56e4e/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt#L76) configuration usage: since keys are used in the regex, `.` can be interpreted as any symbol and users may also include `.*` as a wildcard.

This PR threatens the former as a literal instead of being meta sequence and ignores the latter (since keys are supposed to be the prefixes).

This should speed up algorithm a bit on the large files.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

