### PR TITLE
RUM-8952: Setup Kotlin compiling test for NavHost injection

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavController.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavController.kt
@@ -1,0 +1,6 @@
+package androidx.navigation
+
+/**
+ * This is a fake class of Android [androidx.navigation.NavController] for compilation testing purpose
+ */
+open class NavController

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavDestination.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavDestination.kt
@@ -1,0 +1,6 @@
+package androidx.navigation
+
+/**
+ * This is a fake class of Android [androidx.navigation.NavDestination] for compilation testing purpose
+ */
+class NavDestination

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavHostController.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/NavHostController.kt
@@ -1,0 +1,6 @@
+package androidx.navigation
+
+/**
+ * This is a fake class of Android [androidx.navigation.NavHostController] for compilation testing purpose
+ */
+class NavHostController : NavController()

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavGraphBuilder.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavGraphBuilder.kt
@@ -1,0 +1,17 @@
+@file:Suppress("UnusedParameter")
+
+package androidx.navigation.compose
+
+/**
+ * This is a fake class of Android [androidx.navigation.compose.NavGraphBuilder] for compilation
+ * testing purpose.
+ */
+class NavGraphBuilder
+
+/**
+ * This is a fake function of Android [androidx.navigation.compose.NavGraphBuilder.composable] for
+ * compilation testing purpose.
+ */
+public fun NavGraphBuilder.composable(route: String) {
+    // fake function
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavHost.kt
@@ -1,0 +1,21 @@
+@file:Suppress("UnusedParameter")
+
+package androidx.navigation.compose
+
+import androidx.navigation.NavHostController
+
+/**
+ * This is a fake function of Android [androidx.navigation.compose.NavHost] for compilation testing purpose
+ */
+fun NavHost(
+    navHostController: NavHostController,
+    destination: String,
+    builder: NavGraphBuilder.() -> Unit
+) {
+    // fake function
+}
+
+/**
+ * This is a fake class of Android [androidx.navigation.compose.NavHost] for compilation testing purpose
+ */
+class NavHost

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavHostController.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/navigation/compose/NavHostController.kt
@@ -1,0 +1,12 @@
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+
+/**
+ * This is a fake function of Android [androidx.navigation.compose.rememberNavController] for compilation testing purpose
+ */
+@Composable
+public fun rememberNavController(): NavHostController {
+    return NavHostController()
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
@@ -1,0 +1,126 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@OptIn(ExperimentalCompilerApi::class)
+class ComposeNavHostCompilationTest : KotlinCompilerTest() {
+
+    @Test
+    fun `M inject 'NavigationViewTrackingEffect' W found nav host`() {
+        // Given
+        val navHostTestCaseSource = SourceFile.kotlin(
+            NAV_HOST_TEST_CASE_FILE_NAME,
+            NAV_HOST_TEST_CASE_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = navHostTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.android.instrumented.NavHostTestCase",
+            "NavHostTestCase",
+            emptyList()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        // TODO RUM-8951: should be changed to 1 interaction after implementing the transformer for NavHost
+        verifyNoInteractions(mockCallback)
+    }
+
+    @Test
+    fun `M inject 'NavigationViewTrackingEffect' W found nav host with expression`() {
+        // Given
+        val navHostTestCaseSource = SourceFile.kotlin(
+            NAV_HOST_TEST_CASE_FILE_NAME,
+            NAV_HOST_TEST_CASE_WITH_EXPRESSION_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = navHostTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.android.instrumented.NavHostTestCase",
+            "NavHostTestCase",
+            emptyList()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        // TODO RUM-8951: should be changed to 1 interaction after implementing the transformer for NavHost
+        verifyNoInteractions(mockCallback)
+    }
+
+    companion object {
+
+        private const val NAV_HOST_TEST_CASE_FILE_NAME = "NavHostTestCase.kt"
+
+        @Language("kotlin")
+        private val NAV_HOST_TEST_CASE_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.android.instrumented
+
+            import androidx.compose.runtime.Composable
+            import androidx.navigation.compose.NavHost
+            import androidx.navigation.compose.composable
+            import androidx.navigation.compose.rememberNavController
+            
+            class NavHostTestCase{
+                @Composable
+                internal fun NavHostTestCase() {
+                    val navHost = rememberNavController()       
+                    NavHost(navHost,""){
+                
+                    }          
+                }
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val NAV_HOST_TEST_CASE_WITH_EXPRESSION_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.android.instrumented
+
+            import androidx.compose.runtime.Composable
+            import androidx.navigation.compose.NavHost
+            import androidx.navigation.compose.composable
+            import androidx.navigation.compose.rememberNavController
+            
+            class NavHostTestCase{
+                @Composable
+                internal fun NavHostTestCase() {
+                    val navHost = rememberNavController()       
+                    NavHost(navHost.apply{
+                        // do nothing
+                     }
+                    ,""){
+                
+                    }          
+                }
+            }
+            """.trimIndent()
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
@@ -1,0 +1,150 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import kotlin.reflect.full.declaredFunctions
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@OptIn(ExperimentalCompilerApi::class)
+open class KotlinCompilerTest {
+
+    @Mock
+    protected lateinit var mockCallback: () -> Unit
+
+    private val trackingEffectSourceFileContent = SourceFile.kotlin(
+        TRACKING_EFFECT_FILE_NAME,
+        TRACKING_EFFECT_SOURCE_FILE_CONTENT
+    )
+
+    private val datadogModifierSourceFileContent = SourceFile.kotlin(
+        DD_MODIFIER_CLASS_FILE_NAME,
+        DD_MODIFIER_SOURCE_FILE_CONTENT
+    )
+
+    // TODO RUM-8950: Dependency file should be separated in each file after the DSL configuration is introduced.
+    protected val dependencyFiles = listOf(
+        trackingEffectSourceFileContent,
+        datadogModifierSourceFileContent
+    )
+
+    protected fun compileFile(
+        target: SourceFile,
+        deps: List<SourceFile>,
+        enablePlugin: Boolean = true
+    ): KotlinCompilation.Result {
+        val pluginRegistrars = if (enablePlugin) {
+            listOf(DatadogPluginRegistrar())
+        } else {
+            listOf()
+        }
+
+        return KotlinCompilation().apply {
+            sources = deps + target
+            compilerPluginRegistrars = pluginRegistrars
+            inheritClassPath = true
+            messageOutputStream = System.out
+        }.compile()
+    }
+
+    protected fun executeClassFile(
+        classLoader: ClassLoader,
+        className: String,
+        methodName: String,
+        methodArgs: List<Any> = emptyList()
+    ) {
+        val deps = listOf(
+            NAV_HOST_BUILDER_PATH,
+            NAV_GRAPH_BUILDER_PATH,
+            NAV_HOST_CONTROLLER_PATH
+        )
+
+        deps.forEach {
+            classLoader.loadClass(it)
+        }
+
+        // Setup the TestCallbackContainer and the mock callback.
+        val testCallbackContainerClazz = classLoader.loadClass(TEST_CALLBACK_CONTAINER_PATH)
+        val setCallbackFunc = testCallbackContainerClazz.kotlin.declaredFunctions.find { it.name == "setCallback" }
+        val testCallbackContainerInstance = testCallbackContainerClazz.getField("INSTANCE").get(null)
+        setCallbackFunc?.call(testCallbackContainerInstance, mockCallback)
+
+        // Load the target class.
+        val clazz = classLoader.loadClass(className)
+        val instance = clazz.getDeclaredConstructor().newInstance()
+        val method = clazz.kotlin.declaredFunctions.find { it.name == methodName }
+
+        // Call the function.
+        val args = methodArgs.toTypedArray()
+        method?.call(instance, *args)
+    }
+
+    companion object {
+
+        private const val TEST_CALLBACK_CONTAINER_PATH = "com.datadog.gradle.plugin.kcp.TestCallbackContainer"
+        private const val NAV_GRAPH_BUILDER_PATH = "androidx.navigation.compose.NavGraphBuilder"
+        private const val NAV_HOST_BUILDER_PATH = "androidx.navigation.compose.NavHost"
+        private const val NAV_HOST_CONTROLLER_PATH = "androidx.navigation.NavHostController"
+        private const val TRACKING_EFFECT_FILE_NAME = "Navigation.kt"
+        private const val DD_MODIFIER_CLASS_FILE_NAME = "DatadogModifier.kt"
+
+        @Language("kotlin")
+        private val DD_MODIFIER_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp.compose
+            
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.semantics.SemanticsPropertyKey
+            import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+            import androidx.compose.ui.semantics.semantics
+            import com.datadog.gradle.plugin.kcp.TestCallbackContainer
+            
+            fun Modifier.datadog(name: String): Modifier {
+                TestCallbackContainer.invokeCallback()
+                return this.semantics {
+                    this.datadog = name
+                }
+            }
+            
+            internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
+                name = "_dd_semantics",
+                mergePolicy = { parentValue, childValue ->
+                    parentValue
+                }
+            )
+
+            private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val TRACKING_EFFECT_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.android.compose
+
+            import androidx.compose.runtime.Composable
+            import androidx.navigation.NavController
+            import androidx.navigation.NavDestination
+            import com.datadog.gradle.plugin.kcp.TestCallbackContainer
+            
+            
+            @Composable
+            fun NavigationViewTrackingEffect(
+                navController: NavController
+            ) {
+                TestCallbackContainer.invokeCallback()
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

According to the [task](https://datadoghq.atlassian.net/browse/RUM-8878), we are supposed to instrument `com.datadog.android.compose.NavigationViewTrackingEffect` function into `NavHost` of client code.


Before jumping into the implementation of instrumentation, this PR sets up unit tests to cover the necessary use cases.
* `KotlinCompilerTest` is used to test for compose tag instrumentation, now it becomes a base class providing compilation and execution test functions.
* `ComposeTagCompilationTest` extends from `KotlinCompilerTest` and contains the test cases of tag instrumentation migrated from old `KotlinCompilerTest` .
* `ComposeNavHostCompilationTest` extends from `KotlinCompilerTest` and contains the test case for NavHost instrumentation.
* Several fake classes are introduced, they are necessary to make the test file be compiled and executed.


### Motivation

RUM-8952


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

