### PR TITLE
RUM-8950: Implement Kotlin compiler plugin DSL configuration

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdExtensionConfiguration.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.gradle.plugin
 
+import com.datadog.gradle.plugin.kcp.InstrumentationConfiguration
+
 /**
  * Base extension used to configure the `dd-android-gradle-plugin`.
  * @param name Name of the given configuration.
@@ -111,6 +113,17 @@ open class DdExtensionConfiguration(
      */
     var additionalSymbolFilesLocations: List<String>? = null
 
+    internal var composeInstrumentation: InstrumentationConfiguration = InstrumentationConfiguration()
+
+    /**
+     * This function allow to register the instrumentation mode for Jetpack Compose RUM views tracking, actions tracking
+     * and images recording. If the `composeInstrumentation` is not set, all the instrumentation will be disabled by
+     * default.
+     */
+    fun composeInstrumentation(configure: InstrumentationConfiguration.() -> Unit) {
+        composeInstrumentation.apply(configure)
+    }
+
     internal fun updateWith(config: DdExtensionConfiguration) {
         config.versionName?.let { versionName = it }
         config.serviceName?.let { serviceName = it }
@@ -123,5 +136,6 @@ open class DdExtensionConfiguration(
         mappingFileTrimIndents = config.mappingFileTrimIndents
         ignoreDatadogCiFileConfig = config.ignoreDatadogCiFileConfig
         nonDefaultObfuscation = config.nonDefaultObfuscation
+        composeInstrumentation = config.composeInstrumentation
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/InstrumentationMode.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/InstrumentationMode.kt
@@ -1,0 +1,39 @@
+package com.datadog.gradle.plugin
+
+/**
+ * Defines the mode of instrumentation for the plugin.
+ *
+ * This enum controls how the plugin applies instrumentation to the code, based on the selected mode.
+ */
+enum class InstrumentationMode {
+
+    /**
+     * **AUTO** mode enables automatic instrumentation.
+     *
+     * In this mode, the plugin automatically instruments all required code
+     * for the feature without requiring explicit annotations.
+     */
+    AUTO,
+
+    /**
+     * **ANNOTATION** mode enables selective instrumentation.
+     *
+     * In this mode, only functions explicitly annotated with the required annotation
+     * will be instrumented by the plugin.
+     */
+    ANNOTATION,
+
+    /**
+     * **DISABLE** mode turns off instrumentation.
+     *
+     * When this mode is set, the plugin does not apply any instrumentation
+     * for this feature, effectively disabling it.
+     */
+    DISABLE;
+
+    companion object {
+        internal fun from(value: String): InstrumentationMode? {
+            return entries.firstOrNull { it.name == value }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginCommandLineProcessor.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginCommandLineProcessor.kt
@@ -1,0 +1,61 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.google.auto.service.AutoService
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+@OptIn(ExperimentalCompilerApi::class)
+@AutoService(CommandLineProcessor::class)
+internal class DatadogKotlinCompilerPluginCommandLineProcessor : CommandLineProcessor {
+    override val pluginId: String = KOTLIN_COMPILER_PLUGIN_ID
+    override val pluginOptions: Collection<CliOption> = listOf(
+        CliOption(
+            optionName = KotlinCompilerPluginOptions.TRACK_VIEWS,
+            valueDescription = STRING_VALUE_DESCRIPTION,
+            description = TRACK_VIEWS_DESCRIPTION,
+            required = false
+        ),
+        CliOption(
+            optionName = KotlinCompilerPluginOptions.TRACK_ACTIONS,
+            valueDescription = STRING_VALUE_DESCRIPTION,
+            description = TRACK_ACTIONS_DESCRIPTION,
+            required = false
+        ),
+        CliOption(
+            optionName = KotlinCompilerPluginOptions.RECORD_IMAGES,
+            valueDescription = STRING_VALUE_DESCRIPTION,
+            description = RECORD_IMAGES_DESCRIPTION,
+            required = false
+        )
+    )
+
+    override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
+        when (option.optionName) {
+            KotlinCompilerPluginOptions.TRACK_VIEWS -> configuration.put(
+                DatadogPluginRegistrar.CONFIG_TRACK_VIEWS,
+                value
+            )
+
+            KotlinCompilerPluginOptions.TRACK_ACTIONS -> configuration.put(
+                DatadogPluginRegistrar.CONFIG_TRACK_ACTIONS,
+                value
+            )
+
+            KotlinCompilerPluginOptions.RECORD_IMAGES -> configuration.put(
+                DatadogPluginRegistrar.CONFIG_RECORD_IMAGES,
+                value
+            )
+        }
+    }
+
+    companion object {
+        private const val STRING_VALUE_DESCRIPTION = "<string>"
+        private const val TRACK_VIEWS_DESCRIPTION = "Track Views"
+        private const val TRACK_ACTIONS_DESCRIPTION = "Track Actions"
+        private const val RECORD_IMAGES_DESCRIPTION = "Record Images"
+        internal const val KOTLIN_COMPILER_PLUGIN_ID = "com.datadoghq.kotlin.compiler"
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/InstrumentationConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/InstrumentationConfiguration.kt
@@ -1,0 +1,43 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+
+/**
+ * This class defines settings that control how the plugin applies instrumentation
+ * for various features in the Gradle plugin configuration.
+ */
+class InstrumentationConfiguration {
+
+    /**
+     * Determines how RUM view tracking is instrumented.
+     *
+     * - **AUTO**: Automatically instruments views for tracking.
+     * - **ANNOTATION**: Instruments only the composable functions explicitly annotated.
+     * - **DISABLE**: Disables view tracking instrumentation.
+     *
+     * Default: **DISABLE**
+     */
+    var trackViews: InstrumentationMode = InstrumentationMode.DISABLE
+
+    /**
+     * Determines how RUM actions tracking is instrumented.
+     *
+     * - **AUTO**: Automatically instruments user actions for tracking.
+     * - **ANNOTATION**: Instruments only the composable functions  explicitly annotated.
+     * - **DISABLE**: Disables action tracking instrumentation.
+     *
+     * Default: **DISABLE**
+     */
+    var trackActions: InstrumentationMode = InstrumentationMode.DISABLE
+
+    /**
+     * Determines how Session Replay image recording is instrumented.
+     *
+     * - **AUTO**: Automatically instruments image-related code.
+     * - **ANNOTATION**: Instruments only the composable functions explicitly annotated.
+     * - **DISABLE**: Disables image recording instrumentation.
+     *
+     * Default: **DISABLE**
+     */
+    var recordImages: InstrumentationMode = InstrumentationMode.DISABLE
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/InternalCompilerConfiguration.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/InternalCompilerConfiguration.kt
@@ -1,0 +1,9 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+
+internal data class InternalCompilerConfiguration(
+    val trackViews: InstrumentationMode = InstrumentationMode.DISABLE,
+    val trackActions: InstrumentationMode = InstrumentationMode.DISABLE,
+    val recordImages: InstrumentationMode = InstrumentationMode.DISABLE
+)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerPluginOptions.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerPluginOptions.kt
@@ -1,0 +1,7 @@
+package com.datadog.gradle.plugin.kcp
+
+internal object KotlinCompilerPluginOptions {
+    const val TRACK_VIEWS = "TRACK_VIEWS"
+    const val TRACK_ACTIONS = "TRACK_ACTIONS"
+    const val RECORD_IMAGES = "RECORD_IMAGES"
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/DatadogIrExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/DatadogIrExtensionTest.kt
@@ -1,0 +1,184 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@OptIn(FirIncompatiblePluginAPI::class)
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogIrExtensionTest {
+
+    @Mock
+    private lateinit var mockMessageCollector: MessageCollector
+
+    @Mock
+    private lateinit var mockModuleFragment: IrModuleFragment
+
+    @Mock
+    private lateinit var mockPluginContext: IrPluginContext
+
+    @Mock
+    private lateinit var mockIrSimpleFunctionSymbol: IrSimpleFunctionSymbol
+
+    @Mock
+    private lateinit var mockClassSymbol: IrClassSymbol
+
+    @BeforeEach
+    fun `set up`() {
+        // Deep mock in PluginContext to make `initReference` pass for each transformer
+        val mockOwner = mock<IrClass>()
+        val mockCompanionObject = mock<IrClass>()
+        val mockCompanionSymbol = mock<IrClassSymbol>()
+        whenever(mockPluginContext.referenceFunctions(any<CallableId>())) doReturn listOf(mockIrSimpleFunctionSymbol)
+        whenever(mockPluginContext.referenceClass(any<ClassId>())) doReturn mockClassSymbol
+        whenever(mockClassSymbol.owner) doReturn mockOwner
+        whenever(mockOwner.declarations) doReturn mutableListOf(mockCompanionObject)
+        whenever(mockCompanionObject.isCompanion) doReturn true
+        whenever(mockCompanionObject.symbol) doReturn mockCompanionSymbol
+    }
+
+    @Test
+    fun `M register tag transformer W recordImages option is AUTO`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                recordImages = InstrumentationMode.AUTO
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeTagTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M register tag transformer W recordImages option is ANNOTATION`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                recordImages = InstrumentationMode.ANNOTATION
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeTagTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M not register tag transformer W recordImages option is DISABLE`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                recordImages = InstrumentationMode.DISABLE
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment, never()).accept(any<ComposeTagTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M register nav host transformer W track views option is AUTO`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.AUTO
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M register nav host transformer W track views option is ANNOTATION`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.ANNOTATION
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M not register nav host transformer W track views option is DISABLE`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = DatadogIrExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.DISABLE
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment, never()).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginCommandLineProcessorTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginCommandLineProcessorTest.kt
@@ -1,0 +1,88 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogKotlinCompilerPluginCommandLineProcessorTest {
+
+    private val testedProcessor = DatadogKotlinCompilerPluginCommandLineProcessor()
+
+    @Mock
+    private lateinit var mockCompilerConfiguration: CompilerConfiguration
+
+    @Test
+    fun `M put value W option name is track views`(
+        @StringForgery fakeValue: String,
+        @StringForgery fakeDescription: String
+    ) {
+        // Given
+        val fakeCliOption: AbstractCliOption = CliOption(
+            optionName = KotlinCompilerPluginOptions.TRACK_VIEWS,
+            valueDescription = "<string>",
+            description = fakeDescription
+        )
+
+        // When
+        testedProcessor.processOption(fakeCliOption, fakeValue, mockCompilerConfiguration)
+
+        // Then
+        verify(mockCompilerConfiguration).put(DatadogPluginRegistrar.CONFIG_TRACK_VIEWS, fakeValue)
+    }
+
+    @Test
+    fun `M put value W option name is track actions`(
+        @StringForgery fakeValue: String,
+        @StringForgery fakeDescription: String
+    ) {
+        // Given
+        val fakeCliOption: AbstractCliOption = CliOption(
+            optionName = KotlinCompilerPluginOptions.TRACK_ACTIONS,
+            valueDescription = "<string>",
+            description = fakeDescription
+        )
+
+        // When
+        testedProcessor.processOption(fakeCliOption, fakeValue, mockCompilerConfiguration)
+
+        // Then
+        verify(mockCompilerConfiguration).put(DatadogPluginRegistrar.CONFIG_TRACK_ACTIONS, fakeValue)
+    }
+
+    @Test
+    fun `M put value W option name is record images`(
+        @StringForgery fakeValue: String,
+        @StringForgery fakeDescription: String
+    ) {
+        // Given
+        val fakeCliOption: AbstractCliOption = CliOption(
+            optionName = KotlinCompilerPluginOptions.RECORD_IMAGES,
+            valueDescription = "<string>",
+            description = fakeDescription
+        )
+
+        // When
+        testedProcessor.processOption(fakeCliOption, fakeValue, mockCompilerConfiguration)
+
+        // Then
+        verify(mockCompilerConfiguration).put(DatadogPluginRegistrar.CONFIG_RECORD_IMAGES, fakeValue)
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
@@ -1,5 +1,6 @@
 package com.datadog.gradle.plugin.kcp
 
+import com.datadog.gradle.plugin.InstrumentationMode
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -46,7 +47,14 @@ open class KotlinCompilerTest {
         enablePlugin: Boolean = true
     ): KotlinCompilation.Result {
         val pluginRegistrars = if (enablePlugin) {
-            listOf(DatadogPluginRegistrar())
+            listOf(
+                DatadogPluginRegistrar(
+                    InternalCompilerConfiguration(
+                        trackViews = InstrumentationMode.AUTO,
+                        recordImages = InstrumentationMode.AUTO
+                    )
+                )
+            )
         } else {
             listOf()
         }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
@@ -17,6 +17,7 @@ internal class Configurator : ForgeConfigurator {
         forge.addFactory(DdExtensionForgeryFactory())
         forge.addFactory(DdExtensionConfigurationForgeryFactory())
         forge.addFactory(RepositoryInfoForgeryFactory())
+        forge.addFactory(InternalCompilerConfigurationFactory())
         forge.useJvmFactories()
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/InternalCompilerConfigurationFactory.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/InternalCompilerConfigurationFactory.kt
@@ -1,0 +1,16 @@
+package com.datadog.gradle.plugin.utils.forge
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.datadog.gradle.plugin.kcp.InternalCompilerConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class InternalCompilerConfigurationFactory : ForgeryFactory<InternalCompilerConfiguration> {
+    override fun getForgery(forge: Forge): InternalCompilerConfiguration {
+        return InternalCompilerConfiguration(
+            trackActions = forge.aValueFrom(InstrumentationMode::class.java),
+            trackViews = forge.aValueFrom(InstrumentationMode::class.java),
+            recordImages = forge.aValueFrom(InstrumentationMode::class.java)
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR implements the DSL config for auto instrumentation, so that clients can define the config like:

```
datadog{

      composeInstrumentation{
              trackViews =  InstrumentationMode.AUTO
              trackActions =  InstrumentationMode.ANNOTATION
              recordImages =  InstrumentationMode.DISABLE
      }
}
```

### Motivation

RUM-8950


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

