### PR TITLE
Separate compose extension to register respectively

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
@@ -1,0 +1,50 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+
+/**
+ * The extension registers [ComposeNavHostTransformer] into the plugin.
+ */
+@FirIncompatiblePluginAPI
+@Suppress("UnusedParameter")
+internal class ComposeNavHostExtension(
+    private val messageCollector: MessageCollector,
+    private val internalCompilerConfiguration: InternalCompilerConfiguration
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        internalCompilerConfiguration.apply {
+            if (trackViews != InstrumentationMode.DISABLE) {
+                registerNavHostTransformer(
+                    pluginContext = pluginContext,
+                    moduleFragment = moduleFragment,
+                    annotationModeEnabled = trackViews == InstrumentationMode.ANNOTATION
+                )
+            }
+        }
+    }
+
+    private fun registerNavHostTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        // TODO RUM-9011: apply annotationModeEnabled to extension
+        val composeNavHostTransformer = ComposeNavHostTransformer(messageCollector, pluginContext)
+        if (composeNavHostTransformer.initReferences()) {
+            moduleFragment.accept(composeNavHostTransformer, null)
+        } else {
+            messageCollector.report(
+                CompilerMessageSeverity.ERROR,
+                "Datadog Kotlin Compiler Plugin didn't succeed initializing references, abort. " +
+                    "Have you added dd-sdk-android-compose library to the dependencies?"
+            )
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
@@ -9,25 +9,18 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 
 /**
- * The extension registers all the visitors that need to explore the code being compiled.
+ * The extension registers [ComposeTagTransformer] into the plugin.
  */
 @FirIncompatiblePluginAPI
 @Suppress("UnusedParameter")
-internal class DatadogIrExtension(
+internal class ComposeTagExtension(
     private val messageCollector: MessageCollector,
     private val internalCompilerConfiguration: InternalCompilerConfiguration
-) : IrGenerationExtension {
+) :
+    IrGenerationExtension {
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         internalCompilerConfiguration.apply {
-            if (trackViews != InstrumentationMode.DISABLE) {
-                registerNavHostTransformer(
-                    pluginContext = pluginContext,
-                    moduleFragment = moduleFragment,
-                    annotationModeEnabled = trackViews == InstrumentationMode.ANNOTATION
-                )
-            }
-
             if (recordImages != InstrumentationMode.DISABLE) {
                 registerTagTransformer(
                     pluginContext = pluginContext,
@@ -51,24 +44,6 @@ internal class DatadogIrExtension(
             messageCollector.report(
                 CompilerMessageSeverity.ERROR,
                 "Datadog Kotlin Compiler Plugin didn't succeed initializing references, abort."
-            )
-        }
-    }
-
-    private fun registerNavHostTransformer(
-        pluginContext: IrPluginContext,
-        moduleFragment: IrModuleFragment,
-        annotationModeEnabled: Boolean
-    ) {
-        // TODO RUM-9011: apply annotationModeEnabled to extension
-        val composeNavHostTransformer = ComposeNavHostTransformer(messageCollector, pluginContext)
-        if (composeNavHostTransformer.initReferences()) {
-            moduleFragment.accept(composeNavHostTransformer, null)
-        } else {
-            messageCollector.report(
-                CompilerMessageSeverity.ERROR,
-                "Datadog Kotlin Compiler Plugin didn't succeed initializing references, abort. " +
-                    "Have you added dd-sdk-android-compose library to the dependencies?"
             )
         }
     }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
@@ -44,8 +44,14 @@ internal class DatadogPluginRegistrar(
             overrideCompilerConfiguration ?: resolveConfiguration(configuration)
         project.extensionArea.getExtensionPoint(IrGenerationExtension.extensionPointName)
             .registerExtension(
-                DatadogIrExtension(messageCollector, internalCompilerConfiguration),
+                ComposeNavHostExtension(messageCollector, internalCompilerConfiguration),
                 LoadingOrder.FIRST,
+                project
+            )
+        project.extensionArea.getExtensionPoint(IrGenerationExtension.extensionPointName)
+            .registerExtension(
+                ComposeTagExtension(messageCollector, internalCompilerConfiguration),
+                LoadingOrder.LAST,
                 project
             )
     }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
@@ -1,0 +1,127 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@OptIn(FirIncompatiblePluginAPI::class)
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ComposeNavHostExtensionTest {
+
+    @Mock
+    private lateinit var mockMessageCollector: MessageCollector
+
+    @Mock
+    private lateinit var mockModuleFragment: IrModuleFragment
+
+    @Mock
+    private lateinit var mockPluginContext: IrPluginContext
+
+    @Mock
+    private lateinit var mockIrSimpleFunctionSymbol: IrSimpleFunctionSymbol
+
+    @Mock
+    private lateinit var mockClassSymbol: IrClassSymbol
+
+    @BeforeEach
+    fun `set up`() {
+        // Deep mock in PluginContext to make `initReference` pass for each transformer
+        val mockOwner = mock<IrClass>()
+        val mockCompanionObject = mock<IrClass>()
+        val mockCompanionSymbol = mock<IrClassSymbol>()
+        whenever(mockPluginContext.referenceFunctions(any<CallableId>())) doReturn listOf(mockIrSimpleFunctionSymbol)
+        whenever(mockPluginContext.referenceClass(any<ClassId>())) doReturn mockClassSymbol
+        whenever(mockClassSymbol.owner) doReturn mockOwner
+        whenever(mockOwner.declarations) doReturn mutableListOf(mockCompanionObject)
+        whenever(mockCompanionObject.isCompanion) doReturn true
+        whenever(mockCompanionObject.symbol) doReturn mockCompanionSymbol
+    }
+
+    @Test
+    fun `M register nav host transformer W track views option is AUTO`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = ComposeNavHostExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.AUTO
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M register nav host transformer W track views option is ANNOTATION`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = ComposeNavHostExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.ANNOTATION
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M not register nav host transformer W track views option is DISABLE`(
+        @Forgery fakeConfiguration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val datadogIrExtension = ComposeNavHostExtension(
+            mockMessageCollector,
+            fakeConfiguration.copy(
+                trackViews = InstrumentationMode.DISABLE
+            )
+        )
+
+        // When
+        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment, never()).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
@@ -37,8 +37,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class DatadogIrExtensionTest {
-
+internal class ComposeTagExtensionTest {
     @Mock
     private lateinit var mockMessageCollector: MessageCollector
 
@@ -73,7 +72,7 @@ internal class DatadogIrExtensionTest {
         @Forgery fakeConfiguration: InternalCompilerConfiguration
     ) {
         // Given
-        val datadogIrExtension = DatadogIrExtension(
+        val datadogIrExtension = ComposeTagExtension(
             mockMessageCollector,
             fakeConfiguration.copy(
                 recordImages = InstrumentationMode.AUTO
@@ -92,7 +91,7 @@ internal class DatadogIrExtensionTest {
         @Forgery fakeConfiguration: InternalCompilerConfiguration
     ) {
         // Given
-        val datadogIrExtension = DatadogIrExtension(
+        val datadogIrExtension = ComposeTagExtension(
             mockMessageCollector,
             fakeConfiguration.copy(
                 recordImages = InstrumentationMode.ANNOTATION
@@ -111,7 +110,7 @@ internal class DatadogIrExtensionTest {
         @Forgery fakeConfiguration: InternalCompilerConfiguration
     ) {
         // Given
-        val datadogIrExtension = DatadogIrExtension(
+        val datadogIrExtension = ComposeTagExtension(
             mockMessageCollector,
             fakeConfiguration.copy(
                 recordImages = InstrumentationMode.DISABLE
@@ -123,62 +122,5 @@ internal class DatadogIrExtensionTest {
 
         // Then
         verify(mockModuleFragment, never()).accept(any<ComposeTagTransformer>(), eq(null))
-    }
-
-    @Test
-    fun `M register nav host transformer W track views option is AUTO`(
-        @Forgery fakeConfiguration: InternalCompilerConfiguration
-    ) {
-        // Given
-        val datadogIrExtension = DatadogIrExtension(
-            mockMessageCollector,
-            fakeConfiguration.copy(
-                trackViews = InstrumentationMode.AUTO
-            )
-        )
-
-        // When
-        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
-
-        // Then
-        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
-    }
-
-    @Test
-    fun `M register nav host transformer W track views option is ANNOTATION`(
-        @Forgery fakeConfiguration: InternalCompilerConfiguration
-    ) {
-        // Given
-        val datadogIrExtension = DatadogIrExtension(
-            mockMessageCollector,
-            fakeConfiguration.copy(
-                trackViews = InstrumentationMode.ANNOTATION
-            )
-        )
-
-        // When
-        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
-
-        // Then
-        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
-    }
-
-    @Test
-    fun `M not register nav host transformer W track views option is DISABLE`(
-        @Forgery fakeConfiguration: InternalCompilerConfiguration
-    ) {
-        // Given
-        val datadogIrExtension = DatadogIrExtension(
-            mockMessageCollector,
-            fakeConfiguration.copy(
-                trackViews = InstrumentationMode.DISABLE
-            )
-        )
-
-        // When
-        datadogIrExtension.generate(mockModuleFragment, mockPluginContext)
-
-        // Then
-        verify(mockModuleFragment, never()).accept(any<ComposeNavHostTransformer>(), eq(null))
     }
 }


### PR DESCRIPTION
### What does this PR do?

`ComposeTagTransformer` and `ComposeNavHostTransformer` needs to perform in different stages of Kotlin IR.

`ComposeNavHostTransformer` needs to execute **before** Compose Compiler plugin, so that our `@composable` function injected into client code can be instrumented by Compose Compiler plugin.

`ComposeTagTransformer` needs to be execute **after** Compose Compiler plugin, so that embedded composable block will be lowered to flat java functions, for visiting calls, it's easier to scan out all the modifiers.

With that purpose, `DatadogIrExtension` is separated to two to register extensions respectively.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

