### PR TITLE
RUM-9088: Add semantics role for Image, Icon and AsyncImage

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.util.companionObject
@@ -76,6 +77,18 @@ internal class DefaultPluginContextUtils(
         return !isAndroidX(owner) && hasComposableAnnotation(owner)
     }
 
+    override fun isFoundationImage(owner: IrFunction, parent: IrPackageFragment): Boolean {
+        return owner.name == ImageIdentifier && parent.fqName == foundationPackageName
+    }
+
+    override fun isMaterialIcon(owner: IrFunction, parent: IrPackageFragment): Boolean {
+        return owner.name == IconIdentifier && parent.fqName == materialPackageName
+    }
+
+    override fun isCoilAsyncImage(owner: IrFunction, parent: IrPackageFragment): Boolean {
+        return owner.name == AsyncImageIdentifier && parent.fqName == coilPackageName
+    }
+
     override fun referenceSingleFunction(callableId: CallableId): IrSimpleFunctionSymbol? {
         return pluginContext
             .referenceFunctions(callableId)
@@ -117,5 +130,11 @@ internal class DefaultPluginContextUtils(
         private val datadogTrackEffectIdentifier = Name.identifier("NavigationViewTrackingEffect")
         private val kotlinPackageName = FqName("kotlin")
         private val applyFunctionIdentifier = Name.identifier("apply")
+        private val foundationPackageName = FqName("androidx.compose.foundation")
+        private val ImageIdentifier = Name.identifier("Image")
+        private val materialPackageName = FqName("androidx.compose.material")
+        private val IconIdentifier = Name.identifier("Icon")
+        private val coilPackageName = FqName("coil.compose")
+        private val AsyncImageIdentifier = Name.identifier("AsyncImage")
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
@@ -1,10 +1,12 @@
 package com.datadog.gradle.plugin.kcp
 
 import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.name.CallableId
 
+@Suppress("TooManyFunctions")
 internal interface PluginContextUtils {
     fun getModifierCompanionClass(): IrClassSymbol?
     fun getModifierClassSymbol(): IrClassSymbol?
@@ -16,4 +18,7 @@ internal interface PluginContextUtils {
     fun isNavHostCall(owner: IrFunction): Boolean
     fun getNavHostControllerClassSymbol(): IrClassSymbol?
     fun getApplySymbol(): IrSimpleFunctionSymbol?
+    fun isFoundationImage(owner: IrFunction, parent: IrPackageFragment): Boolean
+    fun isMaterialIcon(owner: IrFunction, parent: IrPackageFragment): Boolean
+    fun isCoilAsyncImage(owner: IrFunction, parent: IrPackageFragment): Boolean
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/compose/foundation/Image.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/compose/foundation/Image.kt
@@ -1,0 +1,11 @@
+@file:Suppress("UnusedParameter")
+
+package androidx.compose.foundation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Image(modifier: Modifier = Modifier) {
+    // fake function
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/compose/material/Icon.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/androidx/compose/material/Icon.kt
@@ -1,0 +1,13 @@
+@file:Suppress("UnusedParameter")
+
+package androidx.compose.material
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Icon(
+    modifier: Modifier = Modifier
+) {
+    // fake function
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/coil/compose/AsyncImage.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/coil/compose/AsyncImage.kt
@@ -1,0 +1,13 @@
+@file:Suppress("UnusedParameter")
+
+package coil.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AsyncImage(
+    modifier: Modifier = Modifier
+) {
+    // fake function
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
@@ -44,7 +44,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
     }
 
     @Test
@@ -69,7 +69,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
     }
 
     @Test
@@ -94,7 +94,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
     }
 
     companion object {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilationTest.kt
@@ -75,7 +75,7 @@ class ComposeTagCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
     }
 
     @Test
@@ -126,7 +126,7 @@ class ComposeTagCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
     }
 
     @Test
@@ -178,7 +178,85 @@ class ComposeTagCompilationTest : KotlinCompilerTest() {
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke()
+        verify(mockCallback).invoke(false)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M inject dd modifier with Image Role W Image is present`() {
+        // Given
+        val imageTestCaseSource = SourceFile.kotlin(
+            IMAGE_TEST_CASE_FILE_NAME,
+            IMAGE_TEST_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = imageTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.ImageTestCase",
+            "ImageTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCallback).invoke(true)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M inject dd modifier with Image Role W Icon is present`() {
+        // Given
+        val imageTestCaseSource = SourceFile.kotlin(
+            ICON_TEST_CASE_FILE_NAME,
+            ICON_TEST_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = imageTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.IconTestCase",
+            "IconTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCallback).invoke(true)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M inject dd modifier with Image Role W Async is present`() {
+        // Given
+        val imageTestCaseSource = SourceFile.kotlin(
+            COIL_TEST_CASE_FILE_NAME,
+            COIL_TEST_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = imageTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.CoilTestCase",
+            "CoilTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCallback).invoke(true)
         verify(mockCustomModifierCallback).invoke()
     }
 
@@ -187,6 +265,9 @@ class ComposeTagCompilationTest : KotlinCompilerTest() {
         private const val NO_MODIFIER_TEST_CASE_FILE_NAME = "NoModifierTestCase.kt"
         private const val DEFAULT_MODIFIER_TEST_CASE_FILE_NAME = "DefaultModifierTestCase.kt"
         private const val CUSTOM_MODIFIER_TEST_CASE_FILE_NAME = "CustomModifierTestCase.kt"
+        private const val IMAGE_TEST_CASE_FILE_NAME = "ImageTestCase.kt"
+        private const val ICON_TEST_CASE_FILE_NAME = "IconTestCase.kt"
+        private const val COIL_TEST_CASE_FILE_NAME = "CoilTestCase.kt"
 
         @Language("kotlin")
         private val NO_MODIFIER_SOURCE_FILE_CONTENT =
@@ -269,5 +350,83 @@ class ComposeTagCompilationTest : KotlinCompilerTest() {
 
             }
             """.trimIndent()
+
+        @Language("kotlin")
+        private val IMAGE_TEST_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import androidx.compose.foundation.Image
+            import androidx.compose.ui.Modifier
+            
+            class ImageTestCase{
+                @Composable
+                fun ImageTestCase(customCallback : () -> Unit) {
+                    Image(
+                        modifier = Modifier.stubModifier(customCallback)
+                    )
+                }
+                
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+            """.trimIndent()
+
+        @Language("kotlin")
+        private val ICON_TEST_SOURCE_FILE_CONTENT =
+            """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import androidx.compose.material.Icon
+            import androidx.compose.ui.Modifier
+            
+            class IconTestCase{
+                @Composable
+                fun IconTestCase(customCallback : () -> Unit) {
+                    Icon(
+                        modifier = Modifier.stubModifier(customCallback)
+                    )
+                }
+                
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+            """.trimIndent()
     }
+
+    @Language("kotlin")
+    private val COIL_TEST_SOURCE_FILE_CONTENT =
+        """
+            package com.datadog.kcp
+    
+            import androidx.compose.runtime.Composable
+            import coil.compose.AsyncImage
+            import androidx.compose.ui.Modifier
+            
+            class CoilTestCase{
+                @Composable
+                fun CoilTestCase(customCallback : () -> Unit) {
+                    AsyncImage(
+                        modifier = Modifier.stubModifier(customCallback)
+                    )
+                }
+                
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+        """.trimIndent()
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.full.declaredFunctions
 open class KotlinCompilerTest {
 
     @Mock
-    protected lateinit var mockCallback: () -> Unit
+    protected lateinit var mockCallback: (Boolean) -> Unit
 
     private val trackingEffectSourceFileContent = SourceFile.kotlin(
         TRACKING_EFFECT_FILE_NAME,
@@ -119,8 +119,8 @@ open class KotlinCompilerTest {
             import androidx.compose.ui.semantics.semantics
             import com.datadog.gradle.plugin.kcp.TestCallbackContainer
             
-            fun Modifier.datadog(name: String): Modifier {
-                TestCallbackContainer.invokeCallback()
+            fun Modifier.datadog(name: String, isImageRole: Boolean = false): Modifier {
+                TestCallbackContainer.invokeCallback(isImageRole)
                 return this.semantics {
                     this.datadog = name
                 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/TestCallbackContainer.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/TestCallbackContainer.kt
@@ -9,21 +9,21 @@ package com.datadog.gradle.plugin.kcp
  */
 object TestCallbackContainer {
 
-    private var callback: () -> Unit = {}
+    private var callback: (Boolean) -> Unit = {}
 
     /**
      * Sets the callback function to be invoked during testing.
      *
      * @param callback The function to be stored and later invoked.
      */
-    fun setCallback(callback: () -> Unit) {
+    fun setCallback(callback: (Boolean) -> Unit) {
         this.callback = callback
     }
 
     /**
      * Invokes the stored callback function.
      */
-    fun invokeCallback() {
-        callback.invoke()
+    fun invokeCallback(isImageRole: Boolean = false) {
+        callback.invoke(isImageRole)
     }
 }

--- a/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/DatadogModifier.kt
+++ b/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/DatadogModifier.kt
@@ -1,6 +1,8 @@
 package com.datadog.kcp.compose
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
@@ -10,9 +12,12 @@ import androidx.compose.ui.semantics.semantics
  * This function should have exactly the same package name, function signature and return type
  * with the production one.
  */
-fun Modifier.datadog(name: String): Modifier {
+fun Modifier.datadog(name: String, isImageRole: Boolean = false): Modifier {
     return this.semantics {
         this.datadog = name
+        if (isImageRole) {
+            this[SemanticsProperties.Role] = Role.Image
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

In dd-sdk-android, Session Replay Compose resolves the components differently based on the Semantics Role.
Prior to this PR, `datadog` modifier only add semantics tag to help the components merged into the tree, but Images still don't have a `Role` since the `contentDescription` can be absent.

This PR enriches the `datadog` modifier with a new argument `isImageRole: Boolean`, and kotlin compiler plugin will sca the component for `Image`, `Icon` or `AsyncImage`, then put `true` on this argument to append semantics role for the components.

### Motivation

RUM-9088

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

