### PR TITLE
RUM-8813: Use composable function name as the semantics tag

### DIFF
--- a/instrumented/src/androidTest/java/com/datadog/android/instrumented/SemanticsTest.kt
+++ b/instrumented/src/androidTest/java/com/datadog/android/instrumented/SemanticsTest.kt
@@ -38,8 +38,10 @@ class SemanticsTest {
         composeTestRule.setContent {
             ScreenWithDefaultModifier()
         }
-        val semanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, DD_SEMANTICS_VALUE_DEFAULT)
-        composeTestRule.onAllNodes(semanticsMatcher).assertCountEquals(2)
+        val textSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Text")
+        composeTestRule.onAllNodes(textSemanticsMatcher).assertCountEquals(1)
+        val columnSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Column")
+        composeTestRule.onAllNodes(columnSemanticsMatcher).assertCountEquals(1)
     }
 
     @Test
@@ -47,8 +49,10 @@ class SemanticsTest {
         composeTestRule.setContent {
             ScreenWithCustomModifier()
         }
-        val semanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, DD_SEMANTICS_VALUE_DEFAULT)
-        composeTestRule.onAllNodes(semanticsMatcher).assertCountEquals(2)
+        val textSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Text")
+        composeTestRule.onAllNodes(textSemanticsMatcher).assertCountEquals(1)
+        val columnSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Column")
+        composeTestRule.onAllNodes(columnSemanticsMatcher).assertCountEquals(1)
     }
 
     private fun <T> hasSemanticsValue(


### PR DESCRIPTION
### What does this PR do?

Currently we use `DD_DEFAULT_TAG` as semantics tag value for all the nodes, 

In this PR, we detect the composable function name of the expression, and use it as the value of the semantics tag.

For example, in the client code if they have:
```
Column{
     Image(painter = xx, contentDescription = null)
     Text(text = "something")
     CustomView()
}
```

In the semantics tree it will have:
```
    |-Node #16 
    | _dd_semantics = 'Column'
    |  |-Node #48 
    |     | _dd_semantics = 'Image'
    |  |-Node #49
    |     | _dd_semantics = 'Text'
    |  |-Node #50
    |     | _dd_semantics = 'CustomView'

```
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

