### PR TITLE
RUM-8953: Add Instrumented test for view trackings instrumentation

### DIFF
--- a/instrumented/build.gradle.kts
+++ b/instrumented/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+    androidTestImplementation(libs.androidx.compose.navigation)
+    androidTestImplementation(libs.datadogSdkCompose)
+    androidTestImplementation(libs.datadogSdkRum)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/instrumented/src/androidTest/java/com/datadog/android/instrumented/NavigationTest.kt
+++ b/instrumented/src/androidTest/java/com/datadog/android/instrumented/NavigationTest.kt
@@ -1,0 +1,108 @@
+package com.datadog.android.instrumented
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.test.platform.app.InstrumentationRegistry
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NavigationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `M call function and have original components W instrument with the Plugin`() {
+        // Given
+        val latch = CountDownLatch(1)
+        var isFunctionCalled = false
+
+        // When
+        val lifecycleOwner = composeTestRule.setContentWithStubLifeCycle {
+            ScreenWithNavHost(onEvent = { navHost, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    val listeners = getOnDestinationChangedListenerSize(navHost)
+                    if (listeners > 0) {
+                        isFunctionCalled = true
+                    }
+                    latch.countDown()
+                }
+            })
+        }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            lifecycleOwner.setCurrentState(Lifecycle.State.RESUMED)
+        }
+
+        // Then
+        composeTestRule
+            .onNodeWithText(TEST_TEXT)
+            .assertIsDisplayed()
+
+        latch.await(5, TimeUnit.SECONDS)
+        assertThat(isFunctionCalled).isTrue()
+    }
+
+    private fun getOnDestinationChangedListenerSize(navHostController: NavHostController): Int {
+        val listenersField = NavController::class.java.getDeclaredField("onDestinationChangedListeners")
+        listenersField.isAccessible = true
+        val listeners = listenersField.get(navHostController) as Collection<*>
+        return listeners.size
+    }
+
+    private fun ComposeContentTestRule.setContentWithStubLifeCycle(
+        composable: @Composable () -> Unit
+    ): StubLifecycleOwner {
+        var stubLifecycleOwner: StubLifecycleOwner? = null
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            stubLifecycleOwner = StubLifecycleOwner()
+        }
+        this.setContent {
+            CompositionLocalProvider(
+                LocalLifecycleOwner provides stubLifecycleOwner!!
+            ) {
+                composable()
+            }
+        }
+        return stubLifecycleOwner!!
+    }
+
+    class StubLifecycleOwner : LifecycleOwner {
+
+        private val registry = LifecycleRegistry(this)
+
+        override val lifecycle: Lifecycle
+            get() = registry
+
+        init {
+            registry.currentState = Lifecycle.State.STARTED
+        }
+
+        fun setCurrentState(state: Lifecycle.State) {
+            registry.currentState = state
+        }
+    }
+}

--- a/instrumented/src/main/java/com/datadog/android/instrumented/NavHostTestScreen.kt
+++ b/instrumented/src/main/java/com/datadog/android/instrumented/NavHostTestScreen.kt
@@ -1,0 +1,35 @@
+package com.datadog.android.instrumented
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+internal fun ScreenWithNavHost(onEvent: (NavHostController, Lifecycle.Event) -> Unit) {
+    val navHost = rememberNavController()
+    NavHost(navHost, TEST_DESTINATION) {
+        composable(TEST_DESTINATION) {
+            Text(text = TEST_TEXT)
+        }
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { source, event ->
+            onEvent(navHost, event)
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}
+
+internal const val TEST_TEXT = "ScreenWithNavHost"
+internal const val TEST_DESTINATION = "destination"


### PR DESCRIPTION
### What does this PR do?

Add instrumented test for view trackings instrumentation, the test verifies two things:

* The instrumentation doesn't break client's code. (the original components should still be present on the screen after instrumentation)
* The function that we instrumented takes effect. (`NavigationViewTrackingEffect` registers listener inside the `navController`, so we use reflection to verify that navController's listener size)

### Motivation

RUM-8953

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

