### PR TITLE
RUM-9011: Implement annotation mode for instrumentation

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
@@ -35,8 +35,12 @@ internal class ComposeNavHostExtension(
         moduleFragment: IrModuleFragment,
         annotationModeEnabled: Boolean
     ) {
-        // TODO RUM-9011: apply annotationModeEnabled to extension
-        val composeNavHostTransformer = ComposeNavHostTransformer(messageCollector, pluginContext)
+        val composeNavHostTransformer =
+            ComposeNavHostTransformer(
+                messageCollector = messageCollector,
+                pluginContext = pluginContext,
+                annotationModeEnabled = annotationModeEnabled
+            )
         if (composeNavHostTransformer.initReferences()) {
             moduleFragment.accept(composeNavHostTransformer, null)
         } else {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
@@ -36,8 +36,11 @@ internal class ComposeTagExtension(
         moduleFragment: IrModuleFragment,
         annotationModeEnabled: Boolean
     ) {
-        // TODO RUM-9011: apply annotationModeEnabled to extension
-        val composeTagTransformer = ComposeTagTransformer(messageCollector, pluginContext)
+        val composeTagTransformer = ComposeTagTransformer(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        )
         if (composeTagTransformer.initReferences()) {
             moduleFragment.accept(composeTagTransformer, null)
         } else {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
@@ -95,6 +95,26 @@ internal class DefaultPluginContextUtils(
             .singleOrNull() ?: logSingleMatchError(callableId.callableName.asString())
     }
 
+    override fun isNavHostTargetFunc(
+        irFunction: IrFunction,
+        annotationModeEnabled: Boolean
+    ): Boolean {
+        return isComposableFunction(irFunction) && (
+            !annotationModeEnabled ||
+                irFunction.hasAnnotation(TrackViewsAnnotationName)
+            )
+    }
+
+    override fun isDatadogTagTargetFunc(
+        irFunction: IrFunction,
+        annotationModeEnabled: Boolean
+    ): Boolean {
+        return isComposableFunction(irFunction) && (
+            !annotationModeEnabled ||
+                irFunction.hasAnnotation(RecordImageAnnotationName)
+            )
+    }
+
     private fun <T> logSingleMatchError(target: String): T? {
         messageCollector.report(CompilerMessageSeverity.ERROR, ERROR_SINGLE_MATCH.format(target))
         return null
@@ -136,5 +156,8 @@ internal class DefaultPluginContextUtils(
         private val IconIdentifier = Name.identifier("Icon")
         private val coilPackageName = FqName("coil.compose")
         private val AsyncImageIdentifier = Name.identifier("AsyncImage")
+        private val TrackViewsAnnotationName = FqName("com.datadog.kcp.compose.TrackViews")
+        private val RecordImageAnnotationName =
+            FqName("com.datadog.kcp.compose.RecordImages")
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
@@ -21,4 +21,9 @@ internal interface PluginContextUtils {
     fun isFoundationImage(owner: IrFunction, parent: IrPackageFragment): Boolean
     fun isMaterialIcon(owner: IrFunction, parent: IrPackageFragment): Boolean
     fun isCoilAsyncImage(owner: IrFunction, parent: IrPackageFragment): Boolean
+    fun isDatadogTagTargetFunc(irFunction: IrFunction, annotationModeEnabled: Boolean): Boolean
+    fun isNavHostTargetFunc(
+        irFunction: IrFunction,
+        annotationModeEnabled: Boolean
+    ): Boolean
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
@@ -1,7 +1,11 @@
 package com.datadog.gradle.plugin.kcp
 
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -20,10 +25,13 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @OptIn(ExperimentalCompilerApi::class)
-class ComposeNavHostCompilationTest : KotlinCompilerTest() {
+@ForgeConfiguration(Configurator::class)
+internal class ComposeNavHostCompilationTest : KotlinCompilerTest() {
 
     @Test
-    fun `M inject 'NavigationViewTrackingEffect' W found nav host`() {
+    fun `M inject 'NavigationViewTrackingEffect' W found nav host`(
+        @Forgery configuration: InternalCompilerConfiguration
+    ) {
         // Given
         val navHostTestCaseSource = SourceFile.kotlin(
             NAV_HOST_TEST_CASE_FILE_NAME,
@@ -33,22 +41,29 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
         // When
         val result = compileFile(
             target = navHostTestCaseSource,
-            deps = dependencyFiles
+            deps = dependencyFiles,
+            internalCompilerConfiguration = configuration
         )
         executeClassFile(
             result.classLoader,
-            "com.datadog.android.instrumented.NavHostTestCase",
+            "com.datadog.kcp.NavHostTestCase",
             "NavHostTestCase",
             emptyList()
         )
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke(false)
+        if (configuration.trackViews == InstrumentationMode.AUTO) {
+            verify(mockCallback).invoke(false)
+        } else {
+            verifyNoInteractions(mockCallback)
+        }
     }
 
     @Test
-    fun `M inject 'NavigationViewTrackingEffect' W found nav host with apply expression`() {
+    fun `M inject 'NavigationViewTrackingEffect' W found nav host with apply expression`(
+        @Forgery configuration: InternalCompilerConfiguration
+    ) {
         // Given
         val navHostTestCaseSource = SourceFile.kotlin(
             NAV_HOST_TEST_CASE_FILE_NAME,
@@ -58,22 +73,29 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
         // When
         val result = compileFile(
             target = navHostTestCaseSource,
-            deps = dependencyFiles
+            deps = dependencyFiles,
+            internalCompilerConfiguration = configuration
         )
         executeClassFile(
             result.classLoader,
-            "com.datadog.android.instrumented.NavHostTestCase",
+            "com.datadog.kcp.NavHostTestCase",
             "NavHostTestCase",
             emptyList()
         )
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke(false)
+        if (configuration.trackViews == InstrumentationMode.AUTO) {
+            verify(mockCallback).invoke(false)
+        } else {
+            verifyNoInteractions(mockCallback)
+        }
     }
 
     @Test
-    fun `M inject 'NavigationViewTrackingEffect' W found nav host with rememberNavController call`() {
+    fun `M inject 'NavigationViewTrackingEffect' W found nav host with rememberNavController call`(
+        @Forgery configuration: InternalCompilerConfiguration
+    ) {
         // Given
         val navHostTestCaseSource = SourceFile.kotlin(
             NAV_HOST_TEST_CASE_FILE_NAME,
@@ -83,18 +105,55 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
         // When
         val result = compileFile(
             target = navHostTestCaseSource,
-            deps = dependencyFiles
+            deps = dependencyFiles,
+            internalCompilerConfiguration = configuration
         )
         executeClassFile(
             result.classLoader,
-            "com.datadog.android.instrumented.NavHostTestCase",
+            "com.datadog.kcp.NavHostTestCase",
             "NavHostTestCase",
             emptyList()
         )
 
         // Then
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
-        verify(mockCallback).invoke(false)
+        if (configuration.trackViews == InstrumentationMode.AUTO) {
+            verify(mockCallback).invoke(false)
+        } else {
+            verifyNoInteractions(mockCallback)
+        }
+    }
+
+    @Test
+    fun `M match given instrumentation mode W instrument annotated function`(
+        @Forgery configuration: InternalCompilerConfiguration
+    ) {
+        // Given
+        val navHostTestCaseSource = SourceFile.kotlin(
+            NAV_HOST_TEST_CASE_FILE_NAME,
+            NAV_HOST_TEST_CASE_WITH_ANNOTATION_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = navHostTestCaseSource,
+            deps = dependencyFiles,
+            internalCompilerConfiguration = configuration
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.NavHostTestCase",
+            "NavHostTestCase",
+            emptyList()
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        if (configuration.trackViews != InstrumentationMode.DISABLE) {
+            verify(mockCallback).invoke(false)
+        } else {
+            verifyNoInteractions(mockCallback)
+        }
     }
 
     companion object {
@@ -104,7 +163,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
         @Language("kotlin")
         private val NAV_HOST_TEST_CASE_SOURCE_FILE_CONTENT =
             """
-            package com.datadog.android.instrumented
+            package com.datadog.kcp
 
             import androidx.compose.runtime.Composable
             import androidx.navigation.compose.NavHost
@@ -125,7 +184,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
         @Language("kotlin")
         private val NAV_HOST_TEST_CASE_WITH_APPLY_EXPRESSION_SOURCE_FILE_CONTENT =
             """
-            package com.datadog.android.instrumented
+            package com.datadog.kcp
 
             import androidx.compose.runtime.Composable
             import androidx.navigation.compose.NavHost
@@ -150,7 +209,7 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
     @Language("kotlin")
     private val NAV_HOST_TEST_CASE_WITH_CALL_SOURCE_FILE_CONTENT =
         """
-            package com.datadog.android.instrumented
+            package com.datadog.kcp
 
             import androidx.compose.runtime.Composable
             import androidx.navigation.compose.NavHost
@@ -161,6 +220,29 @@ class ComposeNavHostCompilationTest : KotlinCompilerTest() {
                 @Composable
                 internal fun NavHostTestCase() {
                     NavHost(rememberNavController(),""){
+                
+                    }          
+                }
+            }
+        """.trimIndent()
+
+    @Language("kotlin")
+    private val NAV_HOST_TEST_CASE_WITH_ANNOTATION_SOURCE_FILE_CONTENT =
+        """
+            package com.datadog.kcp
+
+            import androidx.compose.runtime.Composable
+            import androidx.navigation.compose.NavHost
+            import androidx.navigation.compose.composable
+            import androidx.navigation.compose.rememberNavController
+            import com.datadog.kcp.compose.TrackViews
+            
+            class NavHostTestCase{
+                @TrackViews
+                @Composable
+                internal fun NavHostTestCase() {
+                    val navHost = rememberNavController()       
+                    NavHost(navHost,""){
                 
                     }          
                 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformerTest.kt
@@ -25,7 +25,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-class ComposeTagTransformerTest {
+internal class ComposeTagTransformerTest {
 
     @Mock
     private lateinit var mockPluginContext: IrPluginContext
@@ -55,7 +55,9 @@ class ComposeTagTransformerTest {
         testedComposeTagTransformer = ComposeTagTransformer(
             mockMessageCollector,
             mockPluginContext,
+            false,
             mockPluginContextUtils
+
         )
     }
 

--- a/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/RecordImages.kt
+++ b/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/RecordImages.kt
@@ -1,0 +1,7 @@
+package com.datadog.kcp.compose
+
+/**
+ * Fake annotation for kotlin compiler plugin testing purpose.
+ */
+@Retention(AnnotationRetention.BINARY)
+annotation class RecordImages

--- a/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/TrackViews.kt
+++ b/samples/lib-module/src/main/kotlin/com/datadog/kcp/compose/TrackViews.kt
@@ -1,0 +1,7 @@
+package com.datadog.kcp.compose
+
+/**
+ * Fake annotation for kotlin compiler plugin testing purpose.
+ */
+@Retention(AnnotationRetention.BINARY)
+annotation class TrackViews


### PR DESCRIPTION
### What does this PR do?

* Add annotations class `RecordImages` and `TrackViews` in `samples/lib-module` to simulate the real implementation in sdk.
* In `ComposeNavHostTransformer` and `ComposeTagTransformer`, filter in the annotated functions if annotation mode is enabled, and instrument only for these functions

### Motivation

RUM-9011

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

