### PR TITLE
Enhance compiler plugin binary backward compatibility

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/IrExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/IrExt.kt
@@ -6,13 +6,14 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
-import org.jetbrains.kotlin.ir.declarations.IrFactory
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.IrStatementOriginImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
@@ -23,6 +24,9 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.primaryConstructor
 
 // Builds Lambda of (T.() -> Unit)
 internal fun IrPluginContext.irUnitLambdaExpression(
@@ -30,23 +34,23 @@ internal fun IrPluginContext.irUnitLambdaExpression(
     irDeclarationParent: IrDeclarationParent?,
     receiverType: IrType
 ): IrFunctionExpression {
-    return irFunctionExpression(
+    return buildCompatIrFunctionExpression(
         symbols.irBuiltIns.functionN(0).defaultType,
         irSimpleFunction(
             name = SpecialNames.ANONYMOUS,
             visibility = DescriptorVisibilities.LOCAL,
             returnType = symbols.unit.defaultType,
-            origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
+            origin = getCompatLambdaOrigin(),
             body = body
         ).apply {
             irDeclarationParent?.let {
                 this.parent = irDeclarationParent
             }
-            this.extensionReceiverParameter = irFactory.createValueParameter(
+            this.extensionReceiverParameter = IrFactoryImpl.createValueParameter(
                 startOffset,
                 endOffset,
-                IrDeclarationOrigin.DEFINED,
-                symbol = IrValueParameterSymbolImpl(),
+                getCompatDefinedOrigin(),
+                symbol = getCompatValueParameterSymbolImpl(),
                 name = Name.identifier("receiver"),
                 index = -1,
                 type = receiverType,
@@ -64,26 +68,13 @@ internal fun IrPluginContext.irUnitLambdaExpression(
     )
 }
 
-internal fun irFunctionExpression(
-    type: IrType,
-    function: IrSimpleFunction
-): IrFunctionExpression {
-    return IrFunctionExpressionImpl(
-        UNDEFINED_OFFSET,
-        UNDEFINED_OFFSET,
-        type,
-        function,
-        IrStatementOrigin.LAMBDA
-    )
-}
-
 internal fun irSimpleFunction(
     name: Name,
     visibility: DescriptorVisibility,
     returnType: IrType,
     origin: IrDeclarationOrigin,
     body: IrBody,
-    symbol: IrSimpleFunctionSymbol = IrSimpleFunctionSymbolImpl(),
+    symbol: IrSimpleFunctionSymbol = getCompatSimpleFunctionSymbol(),
     modality: Modality = Modality.FINAL,
     isInline: Boolean = false,
     isExternal: Boolean = false,
@@ -92,10 +83,9 @@ internal fun irSimpleFunction(
     isOperator: Boolean = false,
     isInfix: Boolean = false,
     isExpect: Boolean = false,
-    isFakeOverride: Boolean = origin == IrDeclarationOrigin.FAKE_OVERRIDE,
-    containerSource: DeserializedContainerSource? = null,
-    factory: IrFactory = IrFactoryImpl
-): IrSimpleFunction = factory.createSimpleFunction(
+    isFakeOverride: Boolean = origin == getCompatFakeOverrideOrigin(),
+    containerSource: DeserializedContainerSource? = null
+): IrSimpleFunction = IrFactoryImpl.createSimpleFunction(
     startOffset = UNDEFINED_OFFSET,
     endOffset = UNDEFINED_OFFSET,
     origin = origin,
@@ -115,4 +105,79 @@ internal fun irSimpleFunction(
     containerSource = containerSource
 ).apply {
     this.body = body
+}
+
+private fun getCompatLambdaOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("LOCAL_FUNCTION_FOR_LAMBDA") {
+        IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
+    }
+}
+
+private fun getCompatFakeOverrideOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("FAKE_OVERRIDE") {
+        IrDeclarationOrigin.FAKE_OVERRIDE
+    }
+}
+
+private fun getCompatDefinedOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("DEFINED") {
+        IrDeclarationOrigin.DEFINED
+    }
+}
+
+private fun getCompatDeclarationOrigin(
+    name: String,
+    default: () -> IrDeclarationOriginImpl
+): IrDeclarationOriginImpl {
+    // In Kotlin 1.9, `IrDeclarationOriginImpl` is an abstract class, not in 2.0
+    return if (IrDeclarationOriginImpl::class.isAbstract) {
+        val nestedClass = IrDeclarationOrigin::class.nestedClasses
+            .firstOrNull { it.simpleName == name }
+        val instance = nestedClass?.objectInstance
+        instance as IrDeclarationOriginImpl
+    } else {
+        default.invoke()
+    }
+}
+
+private fun getCompatLambdaStateOrigin(): IrStatementOriginImpl {
+    // In Kotlin 1.9, `IrStatementOriginImpl` is an abstract class, not in 2.0
+    return if (IrStatementOriginImpl::class.isAbstract) {
+        val lambdaClass = IrStatementOrigin::class.nestedClasses
+            .firstOrNull { it.simpleName == "LAMBDA" }
+        val instance = lambdaClass?.objectInstance
+        return instance as IrStatementOriginImpl
+    } else {
+        IrStatementOrigin.LAMBDA
+    }
+}
+
+private fun getCompatSimpleFunctionSymbol(): IrSimpleFunctionSymbol {
+    return IrSimpleFunctionSymbolImpl::class.createInstance()
+}
+
+private fun getCompatValueParameterSymbolImpl(): IrValueParameterSymbolImpl {
+    return IrValueParameterSymbolImpl::class.createInstance()
+}
+
+private fun buildCompatIrFunctionExpression(
+    type: IrType,
+    function: IrSimpleFunction
+): IrFunctionExpression {
+    val primaryConstructor = IrFunctionExpressionImpl::class.primaryConstructor
+    return primaryConstructor?.takeIf {
+        it.visibility == KVisibility.PUBLIC
+    }?.call(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        getCompatLambdaStateOrigin()
+    ) ?: IrFunctionExpressionImpl(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        getCompatLambdaStateOrigin()
+    )
 }


### PR DESCRIPTION
### What does this PR do?

The Kotlin compiler plugin relies on `Kotlin-embeddable` for Intermediate Representation phase, 
when plugin is running in the host application during the compilation,  the Kotlin version from Android Gradle Tool will override the one in plugin during the runtime. 

For example, if the Android Gradle Tool version is "8.8.2", the kotlin "1.9.24" version from it will be actually used during the runtime of the plugin despite "2.0.20" is declared in the plugin project. And since it's a major version change, it leads some binary compatibility issue which makes build failed.

The main idea of this PR is to check the known broken API version, by checking function signature, visibility, etc.. to instantiate it by reflection if we find it's not compatible with the compilation version.


Here is a list of breaking APIs:
|Usage| Version 1.9 |Version 2.0 | 
|--| -- | -- | 
|IrDeclarationOrigin.FAKE_OVERRIDE| object of an interface | companion object property of an interface | 
|IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA| object of an interface | companion object property of an interface |
|IrDeclarationOrigin.DEFINED| object of an interface | companion object property of an interface |
|IrFunctionExpressionImpl| a class constructor | top level function|
| IrValueParameterSymbolImpl| class constructor with one argument| class constructor with several arguments | 
| IrSimpleFunctionSymbolImpl| class constructor with one argument| class constructor with several arguments | 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

