### PR TITLE
Update `org.json:json` library version to 20231013

### DIFF
--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -6,7 +6,7 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
-org.json:json:20180813                                          :   63 Kb
+org.json:json:20231013                                          :   72 Kb
 
 Total transitive dependencies size                              :    2 Mb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Commons
 kotlin = "2.0.21"
-json = "20180813"
+json = "20231013"
 okHttp = "4.12.0"
 
 # Android


### PR DESCRIPTION
### What does this PR do?

Closes #344.

We are not affected by these CVEs (because they are for the server-side attack or when talking with untrusted source), but bumping library version to avoid scanner alarms.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

