### PR TITLE
RUM-9278: Add precise error message for missing dependencies

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
@@ -4,7 +4,6 @@ import com.datadog.gradle.plugin.InstrumentationMode
 import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 
@@ -42,11 +41,7 @@ internal class ComposeNavHostExtension(
         if (composeNavHostTransformer.initReferences()) {
             moduleFragment.accept(composeNavHostTransformer, null)
         } else {
-            messageCollector.report(
-                CompilerMessageSeverity.ERROR,
-                "Datadog Kotlin Compiler Plugin didn't succeed initializing references, abort. " +
-                    "Have you added dd-sdk-android-compose library to the dependencies?"
-            )
+            messageCollector.abortError()
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -43,9 +43,19 @@ internal class ComposeNavHostTransformer(
 
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
-        trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: return false
-        navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: return false
-        applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: return false
+        trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
+            error(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+
+        navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
+            error(ERROR_MISSING_COMPOSE_NAV)
+            return false
+        }
+        applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
+            error(ERROR_MISSING_KOTLIN_STDLIB)
+            return false
+        }
         return true
     }
 
@@ -158,4 +168,17 @@ internal class ComposeNavHostTransformer(
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private fun error(message: String) {
+        messageCollector.report(CompilerMessageSeverity.ERROR, message)
+    }
+
+    companion object {
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_NAV =
+            "Missing androidx.navigation:navigation-compose dependency."
+        private const val ERROR_MISSING_KOTLIN_STDLIB =
+            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
+    }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
@@ -4,7 +4,6 @@ import com.datadog.gradle.plugin.InstrumentationMode
 import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 
@@ -41,10 +40,7 @@ internal class ComposeTagExtension(
         if (composeTagTransformer.initReferences()) {
             moduleFragment.accept(composeTagTransformer, null)
         } else {
-            messageCollector.report(
-                CompilerMessageSeverity.ERROR,
-                "Datadog Kotlin Compiler Plugin didn't succeed initializing references, abort."
-            )
+            messageCollector.abortError()
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -3,6 +3,7 @@ package com.datadog.gradle.plugin.kcp
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBoolean
@@ -45,10 +46,22 @@ internal class ComposeTagTransformer(
 
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
-        datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: return false
-        modifierClass = pluginContextUtils.getModifierClassSymbol() ?: return false
-        modifierThenSymbol = pluginContextUtils.getModifierThen() ?: return false
-        modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: return false
+        datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
+            error(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+        modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
+            error(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
+            error(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
+            error(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
         return true
     }
 
@@ -187,8 +200,16 @@ internal class ComposeTagTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
+    private fun error(message: String) {
+        messageCollector.report(CompilerMessageSeverity.ERROR, message)
+    }
+
     private companion object {
         private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
         private val kotlinNothingFqName = FqName("kotlin.Nothing")
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_UI =
+            "Missing androidx.compose.ui:ui dependency."
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
@@ -1,0 +1,13 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+
+internal fun MessageCollector.abortError() {
+    report(CompilerMessageSeverity.ERROR, ERROR_MISSING_DEP)
+}
+
+private const val ERROR_MISSING_DEP =
+    "The Datadog Compose Instrumentation failed to initialize references and will abort.\n" +
+        "To proceed, you can either set `composeInstrumentation` to `DISABLE` or remove the " +
+        "`composeInstrumentation` setting entirely."


### PR DESCRIPTION
### What does this PR do?

Priror to this PR, only a general compilation error will be thrown when any dependency is missing, that is not precise enough for client to understand the issue.
In this PR, error message is thrown with exact dependency path, for example if `androidx.navigation:navigation-compose` is missing, client will see this:

<img width="846" alt="Screenshot 2025-04-11 at 09 47 45" src="https://github.com/user-attachments/assets/3ebd7dd0-7403-406d-ac5b-14cce7a6d206" />


### Motivation

RUM-9278


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

