### PR TITLE
Only warn missing dependencies instead of throwing errors

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
@@ -1,3 +1,5 @@
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
@@ -6,12 +8,12 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 
 /**
  * The extension registers [ComposeNavHostTransformer] into the plugin.
  */
 @FirIncompatiblePluginAPI
-@Suppress("UnusedParameter")
 internal class ComposeNavHostExtension(
     private val messageCollector: MessageCollector,
     private val internalInstrumentationMode: InstrumentationMode
@@ -41,7 +43,7 @@ internal class ComposeNavHostExtension(
         if (composeNavHostTransformer.initReferences()) {
             moduleFragment.accept(composeNavHostTransformer, null)
         } else {
-            messageCollector.abortError()
+            messageCollector.warnDependenciesError()
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -46,16 +46,16 @@ internal class ComposeNavHostTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
-            error(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
 
         navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
-            error(ERROR_MISSING_COMPOSE_NAV)
+            warn(ERROR_MISSING_COMPOSE_NAV)
             return false
         }
         applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
-            error(ERROR_MISSING_KOTLIN_STDLIB)
+            warn(ERROR_MISSING_KOTLIN_STDLIB)
             return false
         }
         return true
@@ -171,8 +171,8 @@ internal class ComposeNavHostTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
-    private fun error(message: String) {
-        messageCollector.report(CompilerMessageSeverity.ERROR, message)
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
     }
 
     companion object {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
@@ -40,7 +40,7 @@ internal class ComposeTagExtension(
         if (composeTagTransformer.initReferences()) {
             moduleFragment.accept(composeTagTransformer, null)
         } else {
-            messageCollector.abortError()
+            messageCollector.warnDependenciesError()
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -47,19 +47,19 @@ internal class ComposeTagTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
-            error(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
         modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
-            error(ERROR_MISSING_COMPOSE_UI)
+            warn(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
-            error(ERROR_MISSING_COMPOSE_UI)
+            warn(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
-            error(ERROR_MISSING_COMPOSE_UI)
+            warn(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         return true
@@ -200,8 +200,8 @@ internal class ComposeTagTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
-    private fun error(message: String) {
-        messageCollector.report(CompilerMessageSeverity.ERROR, message)
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
     }
 
     private companion object {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
@@ -3,11 +3,12 @@ package com.datadog.gradle.plugin.kcp
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 
-internal fun MessageCollector.abortError() {
-    report(CompilerMessageSeverity.ERROR, ERROR_MISSING_DEP)
+internal fun MessageCollector.warnDependenciesError() {
+    report(CompilerMessageSeverity.STRONG_WARNING, WARNING_MISSING_DEP)
 }
 
-private const val ERROR_MISSING_DEP =
-    "The Datadog Compose Instrumentation failed to initialize references and will abort.\n" +
-        "To proceed, you can either set `composeInstrumentation` to `DISABLE` or remove the " +
-        "`composeInstrumentation` setting entirely."
+private const val WARNING_MISSING_DEP =
+    "The Datadog Plugin has detected missing dependencies required for Compose Instrumentation in this module. " +
+        "Missing these dependencies may result in incomplete Compose Instrumentation functionality. " +
+        "You can ignore this warning if you're certain that the missing dependencies " +
+        "are not needed for your use case."

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
@@ -13,7 +13,7 @@ internal interface PluginContextUtils {
     fun getDatadogModifierSymbol(): IrSimpleFunctionSymbol?
     fun getModifierThen(): IrSimpleFunctionSymbol?
     fun isComposableFunction(owner: IrFunction): Boolean
-    fun referenceSingleFunction(callableId: CallableId): IrSimpleFunctionSymbol?
+    fun referenceSingleFunction(callableId: CallableId, isCritical: Boolean = false): IrSimpleFunctionSymbol?
     fun getDatadogTrackEffectSymbol(): IrSimpleFunctionSymbol?
     fun isNavHostCall(owner: IrFunction): Boolean
     fun getNavHostControllerClassSymbol(): IrClassSymbol?


### PR DESCRIPTION
### What does this PR do?

In android dev chat before we've agreed that we should throw errors when user has missing dependencies.

However, afterwards, we have agreement inside behavior team that we should merge all the DSL config for compose instrumentation into one, meaning that client will not be able to fine grained control the feature of instrumentation (actions tracking/view trackings or Session Replay Image recordings). 

In this case we should not force each module to contain the full dependencies, for example if user has a UI feature module only implementing some compose UI, and also App module only implementing AppScaffold with navigation. Then we should not force their UI feature module also contain compose navigation module.

So this PR downgrades the severity of following dependency to strong warnings:
* androidx.compose.ui:ui
* androidx.navigation:navigation-compose

Only keep "com.datadoghq:dd-sdk-android-compose" dependency as error since it will be needed in any case.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

