### PR TITLE
Update Datadog Gradle Plugin to version 1.17.0-rc1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
 datadogSdk = "2.19.2"
-datadogPluginGradle = "1.16.0"
+datadogPluginGradle = "1.17.0-rc1"
 
 # Kotlin Compiler Plugin
 kotlinCompilerEmbeddable = "2.0.21"


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog Gradle Plugin from version 1.16.0 to version 1.17.0-rc1: [diff](https://github.com/DataDog/dd-sdk-android-gradle-plugin/compare/1.16.0...1.17.0-rc1)