### PR TITLE
Update Datadog SDK to version 2.15.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ versionsPluginGradle = "0.33.0"
 kotlinGrammarParser = "c35b50fa44"
 
 # Datadog
-datadogSdk = "2.21.0"
+datadogSdk = "2.15.2"
 datadogSdkSnapshot = "2.22.0-SNAPSHOT"
 datadogPluginGradle = "1.16.0"
 


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog SDK from version 2.21.0 to version 2.15.2: [diff](https://github.com/DataDog/dd-sdk-android/compare/2.21.0...2.15.2)