### PR TITLE
RUM-10224: Allow pr creation by dd-sdk-android repository using octo-sts

### DIFF
--- a/.github/chainguard/all.gitlab.pr.sts.yaml
+++ b/.github/chainguard/all.gitlab.pr.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:branch:ref:.*"
+
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?

Adding yaml policy to allow pr creation by `dd-sdk-android` repo using token obtained using `dd-octo-sts`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

