### PR TITLE
RUM-10224: Use tag in octo-sts-subject-pattern

### DIFF
--- a/.github/chainguard/all.gitlab.pr.sts.yaml
+++ b/.github/chainguard/all.gitlab.pr.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:branch:ref:.*"
+subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:tag:ref:.*"
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?

The GitLab CI job in `dd-sdk-android` that creates the pr with version update corresponds to a commit that has a tag. Thus the subject is `project_path:DataDog/dd-sdk-android:ref_type:tag:ref:<something>`. And the current jobs [failed](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/pipelines/68422570).

Allowing all tags is ok, because in `dd-sdk-android` all tags are protected (we have [this](https://github.com/DataDog/dd-sdk-android/settings/rules/3421839)).

Allowing all branches was also ok because we don't allow anyone from outside of datadog org to create branches (do any write operation) in the repo.

The new yaml is a bit more restrictive though.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

