### PR TITLE
RUM-10224: Add dd-octo-sts to docker image and add policy yamls

### DIFF
--- a/.github/chainguard/all.gitlab.pr.sts.yaml
+++ b/.github/chainguard/all.gitlab.pr.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:tag:ref:.*"
+subject_pattern: "project_path:DataDog/(dd-sdk-android|dd-sdk-android-gradle-plugin):ref_type:tag:ref:.*"
 
 permissions:
   contents: write

--- a/.github/chainguard/self.gitlab.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.read.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-android-gradle-plugin:ref_type:branch:ref:.*"
+
+permissions:
+  contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ include:
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "11"
+  CURRENT_CI_IMAGE: "12"
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android-gradle-plugin:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -95,3 +95,5 @@ RUN curl -L https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/
  && tar -xf woke-linux-amd64.tar.gz \
  && mv woke-${WOKE_VERSION}-linux-amd64/woke /usr/bin/woke \
  && rm -Rf woke-${WOKE_VERSION}-linux-amd64 woke-${WOKE_VERSION}-linux-amd64.tar.gz
+
+COPY --from=registry.ddbuild.io/dd-octo-sts:v1.8.2 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts


### PR DESCRIPTION
### What does this PR do?

I need to introduce `dd-octo-sts` to this repo the same way I did in `dd-sdk-android`. In this pr:

1. Added `dd-octo-sts` to the Docker image.
2. Changed `all.gitlab.pr.sts.yaml` to also allow pr creation from `dd-sdk-android-gradle-plugin`. Needed [here](https://github.com/DataDog/dd-sdk-android-gradle-plugin/blob/develop/.gitlab-ci.yml#L250).
3. Added `self.gitlab.read.sts.yaml` - policy to read `dd-sdk-android-gradle-plugin`. It will be used when I create a pipeline to check the release similar to [this](https://github.com/DataDog/dd-sdk-android/blob/develop/ci/pipelines/check-release-pipeline.yml).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

