### PR TITLE
Update Datadog Gradle Plugin to version 1.18.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ kotlinGrammarParser = "c35b50fa44"
 # Datadog
 datadogSdk = "2.23.0"
 datadogSdkSnapshot = "2.24.0-SNAPSHOT"
-datadogPluginGradle = "1.17.0"
+datadogPluginGradle = "1.18.0"
 
 # Kotlin Compiler Plugin
 kotlinCompilerEmbeddable = "2.0.21"


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating Datadog Gradle Plugin from version 1.17.0 to version 1.18.0: [diff](https://github.com/DataDog/dd-sdk-android-gradle-plugin/compare/1.17.0...1.18.0)