### PR TITLE
RUM-10668: Use Maven Publish plugin for the publication

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.versionsPluginGradle)
     implementation(libs.fuzzyWuzzy)
     implementation(libs.dokkaPluginGradle)
+    implementation(libs.mavenPublishPlugin)
 
     // Tests
     testImplementation(libs.jUnit4)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JacocoConfig.kt
@@ -13,6 +13,7 @@ import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.math.BigDecimal
+import java.nio.file.Paths
 
 fun Project.jacocoConfig() {
     val jacocoTestReport = tasks.getByName("jacocoTestReport", JacocoReport::class)
@@ -43,7 +44,11 @@ fun Project.jacocoConfig() {
 
         val mainSrc = "${project.projectDir}/src/main/kotlin"
 
-        task.executionData.setFrom(files("${buildDir.path}/jacoco/test.exec"))
+        task.executionData.setFrom(
+            layout.buildDirectory.files(
+                Paths.get("jacoco", "test.exec")
+            )
+        )
         task.sourceDirectories.setFrom(files(mainSrc))
     }
     jacocoTestReport.dependsOn("test")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JavadocConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JavadocConfig.kt
@@ -7,16 +7,15 @@
 package com.datadog.gradle.config
 
 import org.gradle.api.Project
-import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.dokka.gradle.DokkaExtension
+import java.nio.file.Paths
 
 fun Project.javadocConfig() {
-    tasks.withType(DokkaTask::class.java) {
-        val toOutputDirectory = file("${buildDir.canonicalPath}/reports/javadoc")
-        outputDirectory.set(toOutputDirectory)
-        doFirst {
-            if (!toOutputDirectory.exists()) {
-                toOutputDirectory.mkdirs()
-            }
+    extensions.configure(DokkaExtension::class.java) {
+        dokkaPublications.named("javadoc") {
+            val toOutputDirectory = layout.buildDirectory
+                .dir(Paths.get("reports", "javadoc").toString())
+            outputDirectory.set(toOutputDirectory)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -6,15 +6,15 @@
 
 package com.datadog.gradle.config
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.kotlinConfig() {
     taskConfig<KotlinCompile> {
-        kotlinOptions {
+        compilerOptions {
             // TODO RUMM-3257 Target Java 17 bytecode at some point
-            jvmTarget = JavaVersion.VERSION_11.toString()
+            jvmTarget.set(JvmTarget.JVM_11)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -7,14 +7,13 @@
 package com.datadog.gradle.config
 
 import com.datadog.gradle.utils.Version
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.plugins.signing.SigningExtension
-import java.net.URI
 
 object MavenConfig {
 
@@ -28,7 +27,7 @@ fun Project.publishingConfig(projectDescription: String) {
     val signingExtension = extensions.findByType(SigningExtension::class)
 
     if (signingExtension == null) {
-        System.err.println("Missing signing extension for $projectName")
+        logger.error("Missing signing extension for $projectName")
         return
     }
     signingExtension.apply {
@@ -43,38 +42,18 @@ fun Project.publishingConfig(projectDescription: String) {
     afterEvaluate {
         tasks.named("javadocJar", Jar::class.java).configure {
             group = "publishing"
-            dependsOn("dokkaJavadoc")
+            dependsOn("dokkaGenerate")
             archiveClassifier.convention("javadoc")
             from("${layout.buildDirectory.dir("/reports/javadoc")}")
         }
 
-        val publishingExtension = extensions.findByType(PublishingExtension::class)
+        val publishingExtension = extensions.findByType<PublishingExtension>()
         if (publishingExtension == null) {
-            System.err.println("Missing publishing extension for $projectName")
+            logger.error("Missing publishing extension for $projectName")
             return@afterEvaluate
         }
 
         publishingExtension.apply {
-            repositories.maven {
-                // see https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-central
-                // For official documentation:
-                // staging repo publishing https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
-                // snapshot publishing https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-via-other-methods
-                val releaseUrl = URI("https://ossrh-staging-api.central.sonatype.com/service/local/")
-                val snapshotUrl = URI("https://central.sonatype.com/repository/maven-snapshots/")
-                url = if (version.toString().endsWith(Version.Type.Snapshot.suffix)) snapshotUrl else releaseUrl
-                val username = System.getenv("CENTRAL_PUBLISHER_USERNAME")
-                val password = System.getenv("CENTRAL_PUBLISHER_PASSWORD")
-                if ((!username.isNullOrEmpty()) && (!password.isNullOrEmpty())) {
-                    credentials(PasswordCredentials::class.java) {
-                        setUsername(username)
-                        setPassword(password)
-                    }
-                } else {
-                    System.err.println("Missing publishing credentials for $projectName")
-                }
-            }
-
             publications.getByName(MavenConfig.PUBLICATION) {
                 check(this is MavenPublication)
 
@@ -117,6 +96,16 @@ fun Project.publishingConfig(projectDescription: String) {
                     }
                 }
             }
+        }
+
+        val mavenPublishing = extensions.findByType<MavenPublishBaseExtension>()
+        if (mavenPublishing == null) {
+            logger.error("Missing Maven publishing extension for $projectName")
+            return@afterEvaluate
+        }
+
+        mavenPublishing.apply {
+            publishToMavenCentral(automaticRelease = false)
         }
     }
 }

--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -134,12 +134,12 @@ publish:publish-sonatype:
   stage: publish
   timeout: 30m
   script:
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
+    - echo "$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.gradle-properties --with-decryption --query "Parameter.Value" --out text)" >> ./gradle.properties
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
-    - export CENTRAL_PUBLISHER_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.publishing.central_username --with-decryption --query "Parameter.Value" --out text)
-    - export CENTRAL_PUBLISHER_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.publishing.central_password --with-decryption --query "Parameter.Value" --out text)
-    - ./gradlew :dd-sdk-android-gradle-plugin:publishPluginMavenPublicationToMavenRepository --stacktrace --no-daemon
+    - echo "mavenCentralUsername=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.publishing.central_username --with-decryption --query "Parameter.Value" --out text)" >> ./gradle.properties
+    - echo "mavenCentralPassword=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.publishing.central_password --with-decryption --query "Parameter.Value" --out text)" >> ./gradle.properties
+    - ./gradlew :dd-sdk-android-gradle-plugin:publishPluginMavenPublicationToMavenCentralRepository --stacktrace --no-daemon
 
 publish:publish-gradle-portal:
   tags: [ "arch:amd64" ]

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -21,8 +21,9 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
-    id("com.gradle.plugin-publish") version "1.1.0"
+    id("org.jetbrains.dokka-javadoc")
+    alias(libs.plugins.gradlePluginPublish)
+    id("com.vanniktech.maven.publish.base")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
@@ -16,7 +16,7 @@ internal object TaskUtils {
 
     @Suppress("StringLiteralDuplication")
     fun resolveDatadogRepositoryFile(target: Project): File {
-        val outputsDir = File(target.buildDir, "outputs")
+        val outputsDir = target.layout.buildDirectory.dir("outputs").get().asFile
         val reportsDir = File(outputsDir, "reports")
         val datadogDir = File(reportsDir, "datadog")
         return File(datadogDir, "repository.json")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,7 @@
 #
 org.gradle.jvmargs=-Xmx2560m
 android.useAndroidX=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
 # Leave the next line blank for CI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,8 +38,8 @@ unmock = "0.7.5"
 fuzzyWuzzy = "1.2.0"
 
 versionsPluginGradle = "0.33.0"
-
-kotlinGrammarParser = "c35b50fa44"
+gradlePluginPublishPlugin = "1.3.1"
+mavenPublishPlugin = "0.33.0"
 
 # Datadog
 datadogSdk = "2.23.0"
@@ -64,6 +64,7 @@ dokkaPluginGradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", versio
 unmockPluginGradle = { module = "de.mobilej.unmock:UnMockPlugin", version.ref = "unmock" }
 
 versionsPluginGradle = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "versionsPluginGradle" }
+mavenPublishPlugin = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version.ref = "mavenPublishPlugin" }
 
 kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 
@@ -157,3 +158,4 @@ testTools = [
 [plugins]
 versionsPluginGradle = { id = "com.github.ben-manes.versions", version.ref = "versionsPluginGradle" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinComposePlugin" }
+gradlePluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePluginPublishPlugin" }

--- a/instrumented/build.gradle.kts
+++ b/instrumented/build.gradle.kts
@@ -52,9 +52,12 @@ android {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs += listOf(
-            "-P", "plugin:com.datadoghq.kotlin.compiler:INSTRUMENTATION_MODE=AUTO"
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            listOf(
+                "-P",
+                "plugin:com.datadoghq.kotlin.compiler:INSTRUMENTATION_MODE=AUTO"
+            )
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes use of https://github.com/vanniktech/gradle-maven-publish-plugin to publish to the Maven Central.

The thing is that for the regular releases to appear in Maven Central staging repo deployments, the staging repo should be explicitly closed, and there is no support for that in the standard Gradle Publishing plugin.

We could use Nexus Publishing plugin, so that it does the job, but instead this project migrates to the newer Maven Publish plugin to call Central Publisher API instead of OSSRH Staging API in case of Nexus Publishing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

