### PR TITLE
RUM-11203: Upgrade Kotlin version to 2.1.21 for Compiler Plugin

### DIFF
--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -52,9 +52,8 @@ dependencies {
     testImplementation(libs.kotlinCompilerTesting)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui)
-
-    compileOnly(libs.kotlinPluginGradle)
     compileOnly(libs.kotlinCompilerEmbeddable)
+    compileOnly(libs.kotlinPluginGradle)
     compileOnly(libs.autoServiceAnnotation)
     kapt(libs.autoService)
 }

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -4,7 +4,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20231013                                          :   72 Kb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
 # Commons
-kotlin = "2.0.21"
-kotlinComposePlugin = "2.0.21"
+kotlin = "2.1.21"
+kotlinComposePlugin = "2.1.21"
 json = "20231013"
 okHttp = "4.12.0"
 composeBom = "2024.04.01"
@@ -10,7 +10,7 @@ activityCompose = "1.9.3"
 androidXComposeNavigation = "2.8.8"
 
 # Android
-androidToolsPlugin = "8.9.0"
+androidToolsPlugin = "8.11.0"
 
 # AndroidX
 androidx-core = "1.3.2"
@@ -47,7 +47,7 @@ datadogSdkSnapshot = "2.25.0-SNAPSHOT"
 datadogPluginGradle = "1.18.0"
 
 # Kotlin Compiler Plugin
-kotlinCompilerEmbeddable = "2.0.21"
+kotlinCompilerEmbeddable = "2.1.21"
 kotlinCompilerTesting = "0.7.0"
 autoService = "1.0.1"
 junitVersion = "1.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### What does this PR do?

Follow up this GH issue: https://github.com/DataDog/dd-sdk-android/issues/2810 , our KCP stops working for Kotlin 2.1.21 because there is some APIs changes for kotlin embeddable, thus we need upgrade the kotlin version to support it. 

Attention: after upgrading the version, KCP will stop supporting the older version of Kotlin.

* Upgrade Kotlin version to 2.1.21
* Upgrade gradle version and AGP version of the project
* reverse the order of deps  `kotlinPluginGradle` and `kotlinCompilerEmbeddable ` since they have duplicate class, the compiler will resolve firstly the wrong one for KCP

### Motivation

RUM-11203

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

