### PR TITLE
RUM-11267: Add Kotlin 2.2.0 support in Kotlin Compiler Plugin

### DIFF
--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -142,3 +142,10 @@ java {
 tasks.withType<Test> {
     dependsOn("pluginUnderTestMetadata")
 }
+
+// TODO RUM-11262: Currently we rely on the `-Xskip-metadata-version-check` compiler option to avoid compilation errors.
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xskip-metadata-version-check"
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension22.kt
@@ -1,0 +1,47 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+
+/**
+ * The extension registers [ComposeNavHostTransformer22] into the plugin.
+ *
+ * Internal use only.
+ */
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+@FirIncompatiblePluginAPI
+class ComposeNavHostExtension22(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerNavHostTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerNavHostTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeNavHostTransformer22(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer22.kt
@@ -1,0 +1,201 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.util.dumpKotlinLike
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * Transformer to instrument Jetpack Compose Navigation Host.
+ * Internal use only.
+ */
+@UnsafeDuringIrConstructionAPI
+@OptIn(DeprecatedForRemovalCompilerApi::class)
+class ComposeNavHostTransformer22(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+    private val visitedScopes = ArrayDeque<IrDeclarationParent?>()
+
+    private lateinit var trackEffectFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var navHostControllerClassSymbol: IrClassSymbol
+    private lateinit var applyFunctionSymbol: IrSimpleFunctionSymbol
+
+    /**
+     * Initializes references to required symbols for the transformer.
+     */
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+
+        navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
+            warn(ERROR_MISSING_COMPOSE_NAV)
+            return false
+        }
+        applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
+            warn(ERROR_MISSING_KOTLIN_STDLIB)
+            return false
+        }
+        return true
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            visitedScopes.add(declaration)
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            visitedScopes.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(
+            expression
+        )
+
+        val irSimpleFunction = expression.symbol.owner
+        if (pluginContextUtils.isNavHostCall(irSimpleFunction)) {
+            expression.logExpressionBeforeTransformation()
+            irSimpleFunction.symbol.owner.parameters
+                .filter { it.kind == IrParameterKind.Regular || it.kind == IrParameterKind.Context }
+                .forEachIndexed { index, irValueParameter ->
+                    if (irValueParameter.type.getClass()?.symbol == navHostControllerClassSymbol) {
+                        expression.getValueArgument(index)?.let { argument ->
+                            val irExpression = appendTrackingEffect(argument, builder)
+                            expression.putValueArgument(index, irExpression)
+                        }
+                    }
+                }
+            expression.logExpressionAfterTransformation()
+        }
+        return super.visitCall(expression)
+    }
+
+    private fun appendTrackingEffect(
+        expression: IrExpression,
+        builder: DeclarationIrBuilder
+    ): IrExpression {
+        // Build apply{ } call with function symbol
+        val applyIrCall = builder.irCall(
+            applyFunctionSymbol
+        )
+
+        // Assign expression return type to `apply{}` -> `apply<NavHostController>{}`
+        applyIrCall.typeArguments[0] = expression.type
+
+        // Assign expression as the dispatch receiver of `apply{ }` -> `navHost.apply<NavHostController>{ }`
+        applyIrCall.arguments[
+            applyIrCall.symbol.owner.parameters
+                .indexOfFirst { it.kind == IrParameterKind.ExtensionReceiver }
+        ] = expression
+
+        // Build NavigationViewTrackingEffect function call
+        val trackEffectCall: IrCall = builder.irCall(trackEffectFunctionSymbol)
+
+        // Build lambda for apply function
+        val lambda = createLocalAnonymousFunc(
+            builder,
+            navHostControllerClassSymbol.defaultType,
+            trackEffectCall
+        )
+
+        lambda.function.parameters.firstOrNull { it.kind == IrParameterKind.ExtensionReceiver }?.let {
+            trackEffectCall.arguments[0] = builder.irGet(it)
+        }
+
+        // Set the lambda as the argument of `apply` call
+        applyIrCall.putValueArgument(0, lambda)
+        return applyIrCall
+    }
+
+    private fun createLocalAnonymousFunc(
+        builder: DeclarationIrBuilder,
+        navHostControllerType: IrType,
+        irCall: IrCall
+    ): IrFunctionExpression {
+        val scope = visitedScopes.lastOrNull()
+        val irBlockBody = builder.irBlockBody {
+            +irCall
+        }
+        return pluginContext.irUnitLambdaExpression(irBlockBody, scope, navHostControllerType)
+    }
+
+    private fun IrExpression.logExpressionBeforeTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression Before Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun IrExpression.logExpressionAfterTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression After Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
+    }
+
+    companion object {
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_NAV =
+            "Missing androidx.navigation:navigation-compose dependency."
+        private const val ERROR_MISSING_KOTLIN_STDLIB =
+            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension22.kt
@@ -1,0 +1,45 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+
+/**
+ * The extension registers [ComposeTagTransformer22] into the plugin.
+ *
+ * Internal use only
+ */
+@FirIncompatiblePluginAPI
+class ComposeTagExtension22(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerTagTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerTagTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeTagTransformer22(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer22.kt
@@ -1,0 +1,235 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBoolean
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGetObjectValue
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.createType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * The extension registers [ComposeTagTransformer22] into the plugin.
+ *
+ * Internal use only
+ */
+@OptIn(DeprecatedForRemovalCompilerApi::class, UnsafeDuringIrConstructionAPI::class)
+class ComposeTagTransformer22(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+    private lateinit var datadogTagFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierClass: IrClassSymbol
+    private lateinit var modifierThenSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierCompanionClassSymbol: IrClassSymbol
+
+    /**
+     * Initializes references to required symbols for the transformer.
+     */
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+        modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        return true
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    @Suppress("ReturnCount")
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(
+            expression
+        )
+        val dispatchReceiver = expression.dispatchReceiver
+        // Chained function call should be skipped
+        if (dispatchReceiver is IrCall) {
+            return super.visitCall(expression)
+        }
+        expression.symbol.owner.parameters
+            .filter { it.kind == IrParameterKind.Regular || it.kind == IrParameterKind.Context }
+            .forEachIndexed { index, irValueParameter ->
+                // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
+                if (irValueParameter.type.classFqName == modifierClassFqName) {
+                    val irExpression = buildIrExpression(
+                        expression = expression.getValueArgument(index),
+                        builder = builder,
+                        functionName = expression.symbol.owner.name.asString(),
+                        isImageComposableFunction = isImageComposableFunction(expression)
+                    )
+                    expression.putValueArgument(index, irExpression)
+                }
+            }
+        return super.visitCall(expression)
+    }
+
+    @Suppress("ReturnCount")
+    private fun isImageComposableFunction(irExpression: IrExpression): Boolean {
+        if (irExpression !is IrCall) {
+            return false
+        }
+        val function = irExpression.symbol.owner
+
+        // Look up the parents until the package level.
+        var parent = function.parent
+        while (parent !is IrPackageFragment && parent is IrDeclaration) {
+            parent = parent.parent
+        }
+        if (parent !is IrPackageFragment) {
+            return false
+        }
+        pluginContextUtils.apply {
+            return isFoundationImage(function, parent) ||
+                isMaterialIcon(function, parent) ||
+                isCoilAsyncImage(function, parent)
+        }
+    }
+
+    private fun buildIrExpression(
+        expression: IrExpression?,
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean
+    ): IrExpression {
+        val datadogTagModifier = buildDatadogTagModifierCall(
+            builder = builder,
+            functionName = functionName,
+            isImageComposableFunction = isImageComposableFunction
+        )
+        // A Column(){} will be transformed into following code during FIR:
+        // Column(modifier = // COMPOSITE {
+        //    null
+        // }, verticalArrangement = // COMPOSITE {
+        //    null
+        // }, horizontalAlignment = // COMPOSITE {
+        //    null
+        // }, content = @Composable
+        // checking if the argument is the type of `COMPOSITE`
+        // allows us to know if the modifier is absent in source code.
+        val overwriteModifier = expression == null ||
+            (expression is IrComposite && expression.type.classFqName == kotlinNothingFqName)
+        if (overwriteModifier) {
+            return datadogTagModifier
+        } else {
+            // Modifier.then()
+            val thenCall = builder.irCall(
+                modifierThenSymbol,
+                modifierClass.owner.defaultType
+            )
+            thenCall.putValueArgument(0, expression)
+            thenCall.dispatchReceiver = datadogTagModifier
+            return thenCall
+        }
+    }
+
+    private fun buildDatadogTagModifierCall(
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean = false
+    ): IrCall {
+        val datadogTagIrCall = builder.irCall(
+            datadogTagFunctionSymbol,
+            modifierClass.defaultType
+        ).also {
+            // Modifier
+            // ExtensionReceiver argument
+            it.arguments[
+                it.symbol.owner.parameters.indexOfFirst { argument ->
+                    argument.kind == IrParameterKind.ExtensionReceiver
+                }
+            ] = builder.irGetObjectValue(
+                type = modifierCompanionClassSymbol.createType(false, emptyList()),
+                classSymbol = modifierCompanionClassSymbol
+            )
+            it.putValueArgument(0, builder.irString(functionName))
+
+            // For the images, Role.Image must be assigned to Semantics.Role to ensure that
+            // Session Replay is able to resolve the role.
+            it.putValueArgument(1, builder.irBoolean(isImageComposableFunction))
+        }
+        return datadogTagIrCall
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
+    }
+
+    private companion object {
+        private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
+        private val kotlinNothingFqName = FqName("kotlin.Nothing")
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_UI =
+            "Missing androidx.compose.ui:ui dependency."
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/Ir22Ext.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/Ir22Ext.kt
@@ -1,0 +1,140 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.DescriptorVisibility
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
+import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
+import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.primaryConstructor
+
+// Builds Lambda of (T.() -> Unit)
+@OptIn(DeprecatedForRemovalCompilerApi::class)
+internal fun IrPluginContext.irUnitLambdaExpression(
+    body: IrBody,
+    irDeclarationParent: IrDeclarationParent?,
+    receiverType: IrType
+): IrFunctionExpression {
+    return buildCompatIrFunctionExpression(
+        type = symbols.irBuiltIns.functionN(0).defaultType,
+        function = irSimpleFunction(
+            name = SpecialNames.ANONYMOUS,
+            visibility = DescriptorVisibilities.LOCAL,
+            returnType = symbols.unit.defaultType,
+            origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
+            body = body
+        ).apply {
+            irDeclarationParent?.let {
+                this.parent = irDeclarationParent
+            }
+            this.extensionReceiverParameter = IrFactoryImpl.createValueParameter(
+                startOffset = startOffset,
+                endOffset = endOffset,
+                origin = IrDeclarationOrigin.DEFINED,
+                kind = IrParameterKind.ExtensionReceiver,
+                name = Name.identifier("receiver"),
+                type = receiverType,
+                isAssignable = false,
+                symbol = getCompatValueParameterSymbolImpl(),
+                varargElementType = null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false
+            ).apply {
+                irDeclarationParent?.let {
+                    this.parent = irDeclarationParent
+                }
+            }
+        }
+    )
+}
+
+internal fun irSimpleFunction(
+    name: Name,
+    visibility: DescriptorVisibility,
+    returnType: IrType,
+    origin: IrDeclarationOrigin,
+    body: IrBody,
+    symbol: IrSimpleFunctionSymbol = getCompatSimpleFunctionSymbol(),
+    modality: Modality = Modality.FINAL,
+    isInline: Boolean = false,
+    isExternal: Boolean = false,
+    isTailrec: Boolean = false,
+    isSuspend: Boolean = false,
+    isOperator: Boolean = false,
+    isInfix: Boolean = false,
+    isExpect: Boolean = false,
+    isFakeOverride: Boolean = origin == IrDeclarationOrigin.FAKE_OVERRIDE,
+    containerSource: DeserializedContainerSource? = null
+): IrSimpleFunction = IrFactoryImpl.createSimpleFunction(
+    startOffset = UNDEFINED_OFFSET,
+    endOffset = UNDEFINED_OFFSET,
+    origin = origin,
+    symbol = symbol,
+    name = name,
+    visibility = visibility,
+    modality = modality,
+    returnType = returnType,
+    isInline = isInline,
+    isExternal = isExternal,
+    isTailrec = isTailrec,
+    isSuspend = isSuspend,
+    isOperator = isOperator,
+    isInfix = isInfix,
+    isExpect = isExpect,
+    isFakeOverride = isFakeOverride,
+    containerSource = containerSource
+).apply {
+    this.body = body
+}
+
+private fun getCompatSimpleFunctionSymbol(): IrSimpleFunctionSymbol {
+    return IrSimpleFunctionSymbolImpl::class.createInstance()
+}
+
+private fun getCompatValueParameterSymbolImpl(): IrValueParameterSymbol {
+    return IrValueParameterSymbolImpl::class.createInstance()
+}
+
+private fun buildCompatIrFunctionExpression(
+    type: IrType,
+    function: IrSimpleFunction
+): IrFunctionExpression {
+    val primaryConstructor = IrFunctionExpressionImpl::class.primaryConstructor
+    return primaryConstructor?.takeIf {
+        it.visibility == KVisibility.PUBLIC
+    }?.call(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        IrStatementOrigin.LAMBDA
+    ) ?: IrFunctionExpressionImpl(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        IrStatementOrigin.LAMBDA
+    )
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
 /**
  * Note that [ComponentRegistrar] is only deprecated in Kotlin 1.x and will not be deprecated in
@@ -72,11 +73,18 @@ internal class DatadogPluginRegistrar(
         internalCompilerConfiguration: InstrumentationMode
     ): IrGenerationExtension {
         // TODO RUM-11266: Support Kotlin 2.1.x
-        // TODO rum-11267: Support Kotlin 2.2.x
-        return ComposeNavHostExtension20(
-            messageCollector = messageCollector,
-            annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
-        )
+        return when (KotlinVersion.from(KotlinCompilerVersion.getVersion())) {
+            KotlinVersion.KOTLIN22 -> ComposeNavHostExtension22(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+
+            KotlinVersion.KOTLIN21,
+            KotlinVersion.KOTLIN20 -> ComposeNavHostExtension20(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+        }
     }
 
     @OptIn(FirIncompatiblePluginAPI::class)
@@ -85,11 +93,18 @@ internal class DatadogPluginRegistrar(
         internalCompilerConfiguration: InstrumentationMode
     ): IrGenerationExtension {
         // TODO RUM-11266: Support Kotlin 2.1.x
-        // TODO rum-11267: Support Kotlin 2.2.x
-        return ComposeTagExtension20(
-            messageCollector = messageCollector,
-            annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
-        )
+        return when (KotlinVersion.from(KotlinCompilerVersion.getVersion())) {
+            KotlinVersion.KOTLIN22 -> ComposeTagExtension22(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+
+            KotlinVersion.KOTLIN21,
+            KotlinVersion.KOTLIN20 -> ComposeTagExtension20(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+        }
     }
 
     private fun resolveConfiguration(configuration: CompilerConfiguration): InstrumentationMode {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
@@ -1,0 +1,34 @@
+package com.datadog.gradle.plugin.kcp
+
+internal enum class KotlinVersion {
+    KOTLIN22,
+    KOTLIN21,
+    KOTLIN20;
+
+    companion object {
+
+        @Suppress("ReturnCount", "MagicNumber")
+        fun from(versionString: String?): KotlinVersion {
+            if (versionString == null) {
+                return KOTLIN20 // Default or handle error as preferred
+            }
+
+            val versionParts =
+                versionString.split('.').mapNotNull { it.substringBefore('-').toIntOrNull() }
+
+            if (versionParts.size < 3) {
+                return KOTLIN20 // Or handle malformed version string
+            }
+
+            val major = versionParts[0]
+            val minor = versionParts[1]
+            val patch = versionParts[2]
+
+            return when {
+                major > 2 || (major == 2 && minor >= 2) -> KOTLIN22
+                major == 2 && minor == 1 && patch >= 20 -> KOTLIN21
+                else -> KOTLIN20
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
@@ -1,0 +1,59 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KotlinVersionTest {
+
+    @Test
+    fun `M return KOTLIN22 W give version 2_2_0 and newer`() {
+        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.0"))
+        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.10"))
+        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.3.0"))
+        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("3.0.0"))
+        assertEquals(
+            KotlinVersion.KOTLIN22,
+            KotlinVersion.from("2.2.0-alpha")
+        ) // Suffixes should be handled
+    }
+
+    @Test
+    fun `M return KOTLIN21 W give versions from 2_1_20 up to (but not including) 2_2_0`() {
+        assertEquals(KotlinVersion.KOTLIN21, KotlinVersion.from("2.1.20"))
+        assertEquals(KotlinVersion.KOTLIN21, KotlinVersion.from("2.1.21"))
+        assertEquals(KotlinVersion.KOTLIN21, KotlinVersion.from("2.1.99"))
+        assertEquals(KotlinVersion.KOTLIN21, KotlinVersion.from("2.1.20-release-123"))
+    }
+
+    @Test
+    fun `M return KOTLIN20 W give versions older than 2_1_20`() {
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("2.1.19"))
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("2.0.0"))
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("1.9.23"))
+        assertEquals(
+            KotlinVersion.KOTLIN20,
+            KotlinVersion.from("2.1.19-whatever")
+        ) // Suffixes should be handled
+    }
+
+    @Test
+    fun `M return KOTLIN20 W give null versionString`() {
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from(null))
+    }
+
+    @Test
+    fun `M returns KOTLIN20 W give malformed versionStrings`() {
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("2.1")) // Not enough parts
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("2")) // Not enough parts
+        assertEquals(
+            KotlinVersion.KOTLIN20,
+            KotlinVersion.from("foo.bar.baz")
+        ) // Non-numeric parts
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("")) // Empty string
+        assertEquals(KotlinVersion.KOTLIN20, KotlinVersion.from("a.b.c")) // Non-numeric parts
+        assertEquals(
+            KotlinVersion.KOTLIN20,
+            KotlinVersion.from("2.1.x-beta")
+        ) // Non-numeric patch part before stripping suffix
+    }
+}


### PR DESCRIPTION
### Context
To widely support all known versions of Kotlin starting from 1.9.23, we need to create different sources set to let them compile with its own version of kotlin-embeddable.

Here is the whole plan:

- [x] Setup 3 source sets of Kotlin20, Kotlin21, Kotlin22 in the project
- [x] Since the current compiler supports Kotlin 2.0, move it directly to Kotlin20 source set. 
- [ ] Dupilcate the compiler from Kotlin20 to Kotlin22 and adpats to Kotlin 2.2.x API     <---- Current Step
- [ ] Dupilcate the compiler from Kotlin20 to Kotlin21 and adpats to Kotlin 2.1.x API
- [ ]  Seperate unit tests for each source set

### What does this PR do?

* Duplicating following files to `Kotlin22` source set to support Kotlin 2.2.x compilation:
1. ComposeNavHostExtension22
2. ComposeNavHostTransformer22
3. ComposeTagExtension22
4. ComposeTagTransformer22

* Adding `getKotlinVersionEnum` function to allow `DatadogPluginRegistrar` to switch the corresponding class during the runtime

### Motivation

RUM-11267

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

