### PR TITLE
RUM-11266: Add Kotlin 2.1.x support in Kotlin Compiler Plugin

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension21.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension21.kt
@@ -1,0 +1,46 @@
+@file:OptIn(UnsafeDuringIrConstructionAPI::class)
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+
+/**
+ * The extension registers [ComposeNavHostTransformer21] into the plugin.
+ */
+@FirIncompatiblePluginAPI
+class ComposeNavHostExtension21(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerNavHostTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerNavHostTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeNavHostTransformer21(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer21.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer21.kt
@@ -1,0 +1,194 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.util.dumpKotlinLike
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * Transformer for Jetpack Compose Navigation's NavHostController.
+ *
+ * Internal use only.
+ */
+@UnsafeDuringIrConstructionAPI
+class ComposeNavHostTransformer21(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+    private val visitedScopes = ArrayDeque<IrDeclarationParent?>()
+
+    private lateinit var trackEffectFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var navHostControllerClassSymbol: IrClassSymbol
+    private lateinit var applyFunctionSymbol: IrSimpleFunctionSymbol
+
+    /**
+     * Initializes references to various symbols used in the plugin.
+     */
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+
+        navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
+            warn(ERROR_MISSING_COMPOSE_NAV)
+            return false
+        }
+        applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
+            warn(ERROR_MISSING_KOTLIN_STDLIB)
+            return false
+        }
+        return true
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            visitedScopes.add(declaration)
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            visitedScopes.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(
+            expression
+        )
+
+        val irSimpleFunction = expression.symbol.owner
+        if (pluginContextUtils.isNavHostCall(irSimpleFunction)) {
+            expression.logExpressionBeforeTransformation()
+            irSimpleFunction.valueParameters.forEachIndexed { index, irValueParameter ->
+                if (irValueParameter.type.getClass()?.symbol == navHostControllerClassSymbol) {
+                    expression.getValueArgument(index)?.let { argument ->
+                        val irExpression = appendTrackingEffect(argument, builder)
+                        expression.putValueArgument(index, irExpression)
+                    }
+                }
+            }
+            expression.logExpressionAfterTransformation()
+        }
+        return super.visitCall(expression)
+    }
+
+    private fun appendTrackingEffect(
+        expression: IrExpression,
+        builder: DeclarationIrBuilder
+    ): IrExpression {
+        // Build apply{ } call with function symbol
+        val applyIrCall = builder.irCall(
+            applyFunctionSymbol
+        )
+
+        // Assign expression return type to `apply{}` -> `apply<NavHostController>{}`
+        applyIrCall.putTypeArgument(0, expression.type)
+
+        // Assign expression as the dispatch receiver of `apply{ }` -> `navHost.apply<NavHostController>{ }`
+        applyIrCall.extensionReceiver = expression
+
+        // Build NavigationViewTrackingEffect function call
+        val trackEffectCall: IrCall = builder.irCall(trackEffectFunctionSymbol)
+
+        // Build lambda for apply function
+        val lambda = createLocalAnonymousFunc(
+            builder,
+            navHostControllerClassSymbol.defaultType,
+            trackEffectCall
+        )
+
+        lambda.function.extensionReceiverParameter?.let {
+            trackEffectCall.putValueArgument(0, builder.irGet(it))
+        }
+
+        // Set the lambda as the argument of `apply` call
+        applyIrCall.putValueArgument(0, lambda)
+        return applyIrCall
+    }
+
+    private fun createLocalAnonymousFunc(
+        builder: DeclarationIrBuilder,
+        navHostControllerType: IrType,
+        irCall: IrCall
+    ): IrFunctionExpression {
+        val scope = visitedScopes.lastOrNull()
+        val irBlockBody = builder.irBlockBody {
+            +irCall
+        }
+        return pluginContext.irUnitLambdaExpression(irBlockBody, scope, navHostControllerType)
+    }
+
+    private fun IrExpression.logExpressionBeforeTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression Before Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun IrExpression.logExpressionAfterTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression After Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
+    }
+
+    companion object {
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_NAV =
+            "Missing androidx.navigation:navigation-compose dependency."
+        private const val ERROR_MISSING_KOTLIN_STDLIB =
+            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension21.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension21.kt
@@ -1,0 +1,44 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+
+/**
+ * The extension registers [ComposeTagTransformer21] into the plugin.
+ */
+@FirIncompatiblePluginAPI
+class ComposeTagExtension21(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) :
+    IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerTagTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerTagTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeTagTransformer21(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer21.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer21.kt
@@ -1,0 +1,223 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBoolean
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGetObjectValue
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.createType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * Transformer for Jetpack Compose UI's Modifier.
+ *
+ * Internal use only.
+ */
+class ComposeTagTransformer21(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+    private lateinit var datadogTagFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierClass: IrClassSymbol
+    private lateinit var modifierThenSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierCompanionClassSymbol: IrClassSymbol
+
+    /**
+     * Initializes references to various symbols used in the plugin.
+     */
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
+            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+        modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
+            warn(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        return true
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    @Suppress("ReturnCount")
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(
+            expression
+        )
+        val dispatchReceiver = expression.dispatchReceiver
+        // Chained function call should be skipped
+        if (dispatchReceiver is IrCall) {
+            return super.visitCall(expression)
+        }
+        expression.symbol.owner.valueParameters.forEachIndexed { index, irValueParameter ->
+            // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
+            if (irValueParameter.type.classFqName == modifierClassFqName) {
+                val irExpression = buildIrExpression(
+                    expression = expression.getValueArgument(index),
+                    builder = builder,
+                    functionName = expression.symbol.owner.name.asString(),
+                    isImageComposableFunction = isImageComposableFunction(expression)
+                )
+                expression.putValueArgument(index, irExpression)
+            }
+        }
+        return super.visitCall(expression)
+    }
+
+    @Suppress("ReturnCount")
+    private fun isImageComposableFunction(irExpression: IrExpression): Boolean {
+        if (irExpression !is IrCall) {
+            return false
+        }
+        val function = irExpression.symbol.owner
+
+        // Look up the parents until the package level.
+        var parent = function.parent
+        while (parent !is IrPackageFragment && parent is IrDeclaration) {
+            parent = parent.parent
+        }
+        if (parent !is IrPackageFragment) {
+            return false
+        }
+        pluginContextUtils.apply {
+            return isFoundationImage(function, parent) ||
+                isMaterialIcon(function, parent) ||
+                isCoilAsyncImage(function, parent)
+        }
+    }
+
+    private fun buildIrExpression(
+        expression: IrExpression?,
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean
+    ): IrExpression {
+        val datadogTagModifier = buildDatadogTagModifierCall(
+            builder = builder,
+            functionName = functionName,
+            isImageComposableFunction = isImageComposableFunction
+        )
+        // A Column(){} will be transformed into following code during FIR:
+        // Column(modifier = // COMPOSITE {
+        //    null
+        // }, verticalArrangement = // COMPOSITE {
+        //    null
+        // }, horizontalAlignment = // COMPOSITE {
+        //    null
+        // }, content = @Composable
+        // checking if the argument is the type of `COMPOSITE`
+        // allows us to know if the modifier is absent in source code.
+        val overwriteModifier = expression == null ||
+            (expression is IrComposite && expression.type.classFqName == kotlinNothingFqName)
+        if (overwriteModifier) {
+            return datadogTagModifier
+        } else {
+            // Modifier.then()
+            val thenCall = builder.irCall(
+                modifierThenSymbol,
+                modifierClass.owner.defaultType
+            )
+            thenCall.putValueArgument(0, expression)
+            thenCall.dispatchReceiver = datadogTagModifier
+            return thenCall
+        }
+    }
+
+    private fun buildDatadogTagModifierCall(
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean = false
+    ): IrCall {
+        val datadogTagIrCall = builder.irCall(
+            datadogTagFunctionSymbol,
+            modifierClass.defaultType
+        ).also {
+            // Modifier
+            it.extensionReceiver = builder.irGetObjectValue(
+                type = modifierCompanionClassSymbol.createType(false, emptyList()),
+                classSymbol = modifierCompanionClassSymbol
+            )
+            it.putValueArgument(0, builder.irString(functionName))
+
+            // For the images, Role.Image must be assigned to Semantics.Role to ensure that
+            // Session Replay is able to resolve the role.
+            it.putValueArgument(1, builder.irBoolean(isImageComposableFunction))
+        }
+        return datadogTagIrCall
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private fun warn(message: String) {
+        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
+    }
+
+    private companion object {
+        private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
+        private val kotlinNothingFqName = FqName("kotlin.Nothing")
+        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+            "Missing com.datadoghq:dd-sdk-android-compose dependency."
+        private const val ERROR_MISSING_COMPOSE_UI =
+            "Missing androidx.compose.ui:ui dependency."
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/Ir21Ext.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21/kotlin/com/datadog/gradle/plugin/kcp/Ir21Ext.kt
@@ -1,0 +1,183 @@
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.DescriptorVisibility
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
+import org.jetbrains.kotlin.ir.expressions.IrBody
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.IrStatementOriginImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
+import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.primaryConstructor
+
+// Builds Lambda of (T.() -> Unit)
+internal fun IrPluginContext.irUnitLambdaExpression(
+    body: IrBody,
+    irDeclarationParent: IrDeclarationParent?,
+    receiverType: IrType
+): IrFunctionExpression {
+    return buildCompatIrFunctionExpression(
+        symbols.irBuiltIns.functionN(0).defaultType,
+        irSimpleFunction(
+            name = SpecialNames.ANONYMOUS,
+            visibility = DescriptorVisibilities.LOCAL,
+            returnType = symbols.unit.defaultType,
+            origin = getCompatLambdaOrigin(),
+            body = body
+        ).apply {
+            irDeclarationParent?.let {
+                this.parent = irDeclarationParent
+            }
+            this.extensionReceiverParameter = IrFactoryImpl.createValueParameter(
+                startOffset,
+                endOffset,
+                getCompatDefinedOrigin(),
+                symbol = getCompatValueParameterSymbolImpl(),
+                name = Name.identifier("receiver"),
+                index = -1,
+                type = receiverType,
+                varargElementType = null,
+                isCrossinline = false,
+                isNoinline = false,
+                isHidden = false,
+                isAssignable = false
+            ).apply {
+                irDeclarationParent?.let {
+                    this.parent = irDeclarationParent
+                }
+            }
+        }
+    )
+}
+
+private fun irSimpleFunction(
+    name: Name,
+    visibility: DescriptorVisibility,
+    returnType: IrType,
+    origin: IrDeclarationOrigin,
+    body: IrBody,
+    symbol: IrSimpleFunctionSymbol = getCompatSimpleFunctionSymbol(),
+    modality: Modality = Modality.FINAL,
+    isInline: Boolean = false,
+    isExternal: Boolean = false,
+    isTailrec: Boolean = false,
+    isSuspend: Boolean = false,
+    isOperator: Boolean = false,
+    isInfix: Boolean = false,
+    isExpect: Boolean = false,
+    isFakeOverride: Boolean = origin == getCompatFakeOverrideOrigin(),
+    containerSource: DeserializedContainerSource? = null
+): IrSimpleFunction = IrFactoryImpl.createSimpleFunction(
+    startOffset = UNDEFINED_OFFSET,
+    endOffset = UNDEFINED_OFFSET,
+    origin = origin,
+    symbol = symbol,
+    name = name,
+    visibility = visibility,
+    modality = modality,
+    returnType = returnType,
+    isInline = isInline,
+    isExternal = isExternal,
+    isTailrec = isTailrec,
+    isSuspend = isSuspend,
+    isOperator = isOperator,
+    isInfix = isInfix,
+    isExpect = isExpect,
+    isFakeOverride = isFakeOverride,
+    containerSource = containerSource
+).apply {
+    this.body = body
+}
+
+private fun getCompatLambdaOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("LOCAL_FUNCTION_FOR_LAMBDA") {
+        IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
+    }
+}
+
+private fun getCompatFakeOverrideOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("FAKE_OVERRIDE") {
+        IrDeclarationOrigin.FAKE_OVERRIDE
+    }
+}
+
+private fun getCompatDefinedOrigin(): IrDeclarationOriginImpl {
+    return getCompatDeclarationOrigin("DEFINED") {
+        IrDeclarationOrigin.DEFINED
+    }
+}
+
+private fun getCompatDeclarationOrigin(
+    name: String,
+    default: () -> IrDeclarationOriginImpl
+): IrDeclarationOriginImpl {
+    // In Kotlin 1.9, `IrDeclarationOriginImpl` is an abstract class, not in 2.0
+    return if (IrDeclarationOriginImpl::class.isAbstract) {
+        val nestedClass = IrDeclarationOrigin::class.nestedClasses
+            .firstOrNull { it.simpleName == name }
+        val instance = nestedClass?.objectInstance
+        instance as IrDeclarationOriginImpl
+    } else {
+        default.invoke()
+    }
+}
+
+private fun getCompatLambdaStateOrigin(): IrStatementOriginImpl {
+    // In Kotlin 1.9, `IrStatementOriginImpl` is an abstract class, not in 2.0
+    return if (IrStatementOriginImpl::class.isAbstract) {
+        val lambdaClass = IrStatementOrigin::class.nestedClasses
+            .firstOrNull { it.simpleName == "LAMBDA" }
+        val instance = lambdaClass?.objectInstance
+        return instance as IrStatementOriginImpl
+    } else {
+        IrStatementOrigin.LAMBDA
+    }
+}
+
+private fun getCompatSimpleFunctionSymbol(): IrSimpleFunctionSymbol {
+    return IrSimpleFunctionSymbolImpl::class.createInstance()
+}
+
+private fun getCompatValueParameterSymbolImpl(): IrValueParameterSymbolImpl {
+    return IrValueParameterSymbolImpl::class.createInstance()
+}
+
+private fun buildCompatIrFunctionExpression(
+    type: IrType,
+    function: IrSimpleFunction
+): IrFunctionExpression {
+    val primaryConstructor = IrFunctionExpressionImpl::class.primaryConstructor
+    return primaryConstructor?.takeIf {
+        it.visibility == KVisibility.PUBLIC
+    }?.call(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        getCompatLambdaStateOrigin()
+    ) ?: IrFunctionExpressionImpl(
+        UNDEFINED_OFFSET,
+        UNDEFINED_OFFSET,
+        type,
+        function,
+        getCompatLambdaStateOrigin()
+    )
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
@@ -72,14 +72,17 @@ internal class DatadogPluginRegistrar(
         messageCollector: MessageCollector,
         internalCompilerConfiguration: InstrumentationMode
     ): IrGenerationExtension {
-        // TODO RUM-11266: Support Kotlin 2.1.x
         return when (KotlinVersion.from(KotlinCompilerVersion.getVersion())) {
             KotlinVersion.KOTLIN22 -> ComposeNavHostExtension22(
                 messageCollector = messageCollector,
                 annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
             )
 
-            KotlinVersion.KOTLIN21,
+            KotlinVersion.KOTLIN21 -> ComposeNavHostExtension21(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+
             KotlinVersion.KOTLIN20 -> ComposeNavHostExtension20(
                 messageCollector = messageCollector,
                 annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
@@ -92,14 +95,17 @@ internal class DatadogPluginRegistrar(
         messageCollector: MessageCollector,
         internalCompilerConfiguration: InstrumentationMode
     ): IrGenerationExtension {
-        // TODO RUM-11266: Support Kotlin 2.1.x
         return when (KotlinVersion.from(KotlinCompilerVersion.getVersion())) {
             KotlinVersion.KOTLIN22 -> ComposeTagExtension22(
                 messageCollector = messageCollector,
                 annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
             )
 
-            KotlinVersion.KOTLIN21,
+            KotlinVersion.KOTLIN21 -> ComposeTagExtension21(
+                messageCollector = messageCollector,
+                annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION
+            )
+
             KotlinVersion.KOTLIN20 -> ComposeTagExtension20(
                 messageCollector = messageCollector,
                 annotationModeEnabled = internalCompilerConfiguration == InstrumentationMode.ANNOTATION

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
@@ -38,7 +38,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class ComposeNavHostExtensionTest {
 
-    private lateinit var testedExtension: ComposeNavHostExtension20
+    private lateinit var testedExtension: ComposeNavHostExtension21
 
     @Mock
     private lateinit var mockMessageCollector: MessageCollector
@@ -72,7 +72,7 @@ internal class ComposeNavHostExtensionTest {
     @Test
     fun `M accept ComposeNavHostTransformer20 W generate`(@BoolForgery annotationModeEnabled: Boolean) {
         // Given
-        testedExtension = ComposeNavHostExtension20(
+        testedExtension = ComposeNavHostExtension21(
             messageCollector = mockMessageCollector,
             annotationModeEnabled = annotationModeEnabled
         )
@@ -81,6 +81,6 @@ internal class ComposeNavHostExtensionTest {
         testedExtension.generate(mockModuleFragment, mockPluginContext)
 
         // Then
-        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer20>(), eq(null))
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer21>(), eq(null))
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
@@ -38,7 +38,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class ComposeTagExtensionTest {
 
-    private lateinit var testedExtension: ComposeTagExtension20
+    private lateinit var testedExtension: ComposeTagExtension21
 
     @Mock
     private lateinit var mockMessageCollector: MessageCollector
@@ -72,7 +72,7 @@ internal class ComposeTagExtensionTest {
     @Test
     fun `M accept ComposeTagTransformer20 W generate`(@BoolForgery annotationModeEnabled: Boolean) {
         // Given
-        testedExtension = ComposeTagExtension20(
+        testedExtension = ComposeTagExtension21(
             messageCollector = mockMessageCollector,
             annotationModeEnabled = annotationModeEnabled
         )
@@ -81,6 +81,6 @@ internal class ComposeTagExtensionTest {
         testedExtension.generate(mockModuleFragment, mockPluginContext)
 
         // Then
-        verify(mockModuleFragment).accept(any<ComposeTagTransformer20>(), eq(null))
+        verify(mockModuleFragment).accept(any<ComposeTagTransformer21>(), eq(null))
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformerTest.kt
@@ -48,11 +48,11 @@ internal class ComposeTagTransformerTest {
     @Mock
     private lateinit var mockModifierCompanionClassSymbol: IrClassSymbol
 
-    private lateinit var testedComposeTagTransformer: ComposeTagTransformer20
+    private lateinit var testedComposeTagTransformer: ComposeTagTransformer21
 
     @BeforeEach
     fun `set up`() {
-        testedComposeTagTransformer = ComposeTagTransformer20(
+        testedComposeTagTransformer = ComposeTagTransformer21(
             mockMessageCollector,
             mockPluginContext,
             false,


### PR DESCRIPTION
### Context
To widely support all known versions of Kotlin starting from 1.9.23, we need to create different sources set to let them compile with its own version of kotlin-embeddable.

Here is the whole plan:

- [x] Setup 3 source sets of Kotlin20, Kotlin21, Kotlin22 in the project
- [x] Since the current compiler supports Kotlin 2.0, move it directly to Kotlin20 source set. 
- [x] Dupilcate the compiler from Kotlin20 to Kotlin22 and adpats to Kotlin 2.2.x API     
- [ ] Dupilcate the compiler from Kotlin20 to Kotlin21 and adpats to Kotlin 2.1.x API.   <---- Current Step
- [ ]  Seperate unit tests for each source set

### What does this PR do?

* Duplicating following files to `Kotlin21` source set to support Kotlin 2.1.x compilation:
1. ComposeNavHostExtension21
2. ComposeNavHostTransformer21
4. ComposeTagExtension21
5. ComposeTagTransformer21


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

