### PR TITLE
RUM-11303: Fix IrFunctionExpressionImpl in Kotlin 2.0.0 - 2.0.10

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/kotlin20/kotlin/com/datadog/gradle/plugin/kcp/Ir20Ext.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin20/kotlin/com/datadog/gradle/plugin/kcp/Ir20Ext.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.datadog.gradle.plugin.kcp
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -24,8 +26,10 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
+import kotlin.reflect.KClass
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.full.primaryConstructor
 
 // Builds Lambda of (T.() -> Unit)
@@ -164,8 +168,21 @@ private fun buildCompatIrFunctionExpression(
     type: IrType,
     function: IrSimpleFunction
 ): IrFunctionExpression {
+    // Kotlin Version 1.9.23 ~ 1.9.25 has `IrFunctionExpressionImpl` class with public constructor.
+    // Kotlin Version 2.0 ~ 2.0.10 has `IrFunctionExpressionImpl` class with internal constructor.
+    // Kotlin Version 2.0.20 ~ 2.0.21 has added `IrFunctionExpressionImpl` function in `builders.kt`
     val primaryConstructor = IrFunctionExpressionImpl::class.primaryConstructor
-    return primaryConstructor?.takeIf {
+    val kClass = getClassSafe("org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImplKt")
+    val kFunction = kClass?.declaredFunctions?.firstOrNull { it.name == "IrFunctionExpressionImpl" }
+    return kFunction?.let {
+        it.call(
+            UNDEFINED_OFFSET,
+            UNDEFINED_OFFSET,
+            type,
+            function,
+            getCompatLambdaStateOrigin()
+        ) as? IrFunctionExpression
+    } ?: primaryConstructor?.takeIf {
         it.visibility == KVisibility.PUBLIC
     }?.call(
         UNDEFINED_OFFSET,
@@ -180,4 +197,14 @@ private fun buildCompatIrFunctionExpression(
         function,
         getCompatLambdaStateOrigin()
     )
+}
+
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+private fun getClassSafe(className: String): KClass<*>? {
+    return try {
+        Class.forName(className).kotlin
+    } catch (e: Exception) {
+        // Ignore all the exceptions and return null
+        null
+    }
 }


### PR DESCRIPTION
### What does this PR do?

The function that we use for building `irFunction`  has changed during the version between 1.9.23 - 2.0.21:
* In version [1.9.23 - 1.9.25](https://github.com/JetBrains/kotlin/blob/v1.9.23/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionExpressionImpl.kt), `IrFunctionExpressionImpl` is a class with public constructor.
* In version[ 2.0.0 - 2.0.10](https://github.com/JetBrains/kotlin/blob/v2.0.10/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/IrFunctionExpressionImpl.kt), `IrFunctionExpressionImpl` stays as a class but the constructor becomes internal.
* In version [2.0.10 - 2.0.21](https://github.com/JetBrains/kotlin/blob/v2.0.21/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/expressions/impl/builders.kt), `IrFunctionExpressionImpl` is moved to `builders.kt` as a function.


So in this PR, we try to resolve it by reflection to handle this particular case.

### Motivation

RUM-11303


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

