### PR TITLE
RUM-11263: Add unit test for each kotlin source sets

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation20Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation20Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeNavHostCompilation20Test : ComposeNavHostCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension20Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension20Test.kt
@@ -1,0 +1,33 @@
+package com.datadog.gradle.plugin.kcp
+
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class, UnsafeDuringIrConstructionAPI::class)
+internal class ComposeNavHostExtension20Test : ComposeNavHostExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeNavHostTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        val composeNavHostExtension = ComposeNavHostExtension20(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeNavHostExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer20>(), eq(null))
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation20Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation20Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeTagCompilation20Test : ComposeTagCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension20Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin20Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension20Test.kt
@@ -1,0 +1,39 @@
+package com.datadog.gradle.plugin.kcp
+
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class)
+internal class ComposeTagExtension20Test : ComposeTagExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeTagTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        // Given
+        val composeTagExtension = ComposeTagExtension20(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeTagExtension.generate(
+            moduleFragment = mockModuleFragment,
+            pluginContext = mockPluginContext
+        )
+
+        // Then
+        verify(mockModuleFragment).accept(
+            any<ComposeTagTransformer20>(),
+            isNull()
+        )
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation21Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation21Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeNavHostCompilation21Test : ComposeNavHostCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension21Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension21Test.kt
@@ -1,0 +1,33 @@
+package com.datadog.gradle.plugin.kcp
+
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class, UnsafeDuringIrConstructionAPI::class)
+internal class ComposeNavHostExtension21Test : ComposeNavHostExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeNavHostTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        val composeNavHostExtension = ComposeNavHostExtension21(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeNavHostExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer21>(), eq(null))
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation21Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation21Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeTagCompilation21Test : ComposeTagCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension21Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin21Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension21Test.kt
@@ -1,0 +1,39 @@
+package com.datadog.gradle.plugin.kcp
+
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class)
+internal class ComposeTagExtension21Test : ComposeTagExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeTagTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        // Given
+        val composeTagExtension = ComposeTagExtension21(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeTagExtension.generate(
+            moduleFragment = mockModuleFragment,
+            pluginContext = mockPluginContext
+        )
+
+        // Then
+        verify(mockModuleFragment).accept(
+            any<ComposeTagTransformer21>(),
+            isNull()
+        )
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation22Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation22Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeNavHostCompilation22Test : ComposeNavHostCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension22Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension22Test.kt
@@ -1,0 +1,36 @@
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class, UnsafeDuringIrConstructionAPI::class)
+@ForgeConfiguration(Configurator::class)
+internal class ComposeNavHostExtension22Test : ComposeNavHostExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeNavHostTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        val composeNavHostExtension = ComposeNavHostExtension22(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeNavHostExtension.generate(mockModuleFragment, mockPluginContext)
+
+        // Then
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer22>(), eq(null))
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation22Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation22Test.kt
@@ -1,0 +1,3 @@
+package com.datadog.gradle.plugin.kcp
+
+internal class ComposeTagCompilation22Test : ComposeTagCompilationTest()

--- a/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension22Test.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22Test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension22Test.kt
@@ -1,0 +1,39 @@
+package com.datadog.gradle.plugin.kcp
+
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@OptIn(FirIncompatiblePluginAPI::class)
+internal class ComposeTagExtension22Test : ComposeTagExtensionTest() {
+
+    @Test
+    override fun `M accept ComposeTagTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean) {
+        // Given
+        val composeTagExtension = ComposeTagExtension22(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        // When
+        composeTagExtension.generate(
+            moduleFragment = mockModuleFragment,
+            pluginContext = mockPluginContext
+        )
+
+        // Then
+        verify(mockModuleFragment).accept(
+            any<ComposeTagTransformer22>(),
+            isNull()
+        )
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilationTest.kt
@@ -1,11 +1,9 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
-import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -13,20 +11,12 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.quality.Strictness
 
-@Extensions(
-    ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
-)
-@MockitoSettings(strictness = Strictness.LENIENT)
+@Extensions(ExtendWith(ForgeExtension::class))
 @OptIn(ExperimentalCompilerApi::class)
-@ForgeConfiguration(Configurator::class)
-internal class ComposeNavHostCompilationTest : KotlinCompilerTest() {
+abstract class ComposeNavHostCompilationTest : KotlinCompilerTest() {
 
     @Test
     fun `M inject 'NavigationViewTrackingEffect' W found nav host`(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtensionTest.kt
@@ -23,9 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -36,18 +34,16 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class ComposeNavHostExtensionTest {
-
-    private lateinit var testedExtension: ComposeNavHostExtension21
+abstract class ComposeNavHostExtensionTest {
 
     @Mock
-    private lateinit var mockMessageCollector: MessageCollector
+    lateinit var mockMessageCollector: MessageCollector
 
     @Mock
-    private lateinit var mockModuleFragment: IrModuleFragment
+    lateinit var mockModuleFragment: IrModuleFragment
 
     @Mock
-    private lateinit var mockPluginContext: IrPluginContext
+    lateinit var mockPluginContext: IrPluginContext
 
     @Mock
     private lateinit var mockIrSimpleFunctionSymbol: IrSimpleFunctionSymbol
@@ -70,17 +66,5 @@ internal class ComposeNavHostExtensionTest {
     }
 
     @Test
-    fun `M accept ComposeNavHostTransformer20 W generate`(@BoolForgery annotationModeEnabled: Boolean) {
-        // Given
-        testedExtension = ComposeNavHostExtension21(
-            messageCollector = mockMessageCollector,
-            annotationModeEnabled = annotationModeEnabled
-        )
-
-        // When
-        testedExtension.generate(mockModuleFragment, mockPluginContext)
-
-        // Then
-        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer21>(), eq(null))
-    }
+    abstract fun `M accept ComposeNavHostTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilationTest.kt
@@ -1,11 +1,9 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
-import com.datadog.gradle.plugin.utils.forge.Configurator
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -15,20 +13,16 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
 )
-@MockitoSettings(strictness = Strictness.LENIENT)
 @OptIn(ExperimentalCompilerApi::class)
-@ForgeConfiguration(Configurator::class)
-internal class ComposeTagCompilationTest : KotlinCompilerTest() {
+abstract class ComposeTagCompilationTest : KotlinCompilerTest() {
 
     @Mock
     private var mockCustomModifierCallback: () -> Unit = {}

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtensionTest.kt
@@ -23,9 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -36,18 +34,16 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class ComposeTagExtensionTest {
-
-    private lateinit var testedExtension: ComposeTagExtension21
+abstract class ComposeTagExtensionTest {
 
     @Mock
-    private lateinit var mockMessageCollector: MessageCollector
+    lateinit var mockMessageCollector: MessageCollector
 
     @Mock
-    private lateinit var mockModuleFragment: IrModuleFragment
+    lateinit var mockModuleFragment: IrModuleFragment
 
     @Mock
-    private lateinit var mockPluginContext: IrPluginContext
+    lateinit var mockPluginContext: IrPluginContext
 
     @Mock
     private lateinit var mockIrSimpleFunctionSymbol: IrSimpleFunctionSymbol
@@ -70,17 +66,5 @@ internal class ComposeTagExtensionTest {
     }
 
     @Test
-    fun `M accept ComposeTagTransformer20 W generate`(@BoolForgery annotationModeEnabled: Boolean) {
-        // Given
-        testedExtension = ComposeTagExtension21(
-            messageCollector = mockMessageCollector,
-            annotationModeEnabled = annotationModeEnabled
-        )
-
-        // When
-        testedExtension.generate(mockModuleFragment, mockPluginContext)
-
-        // Then
-        verify(mockModuleFragment).accept(any<ComposeTagTransformer21>(), eq(null))
-    }
+    abstract fun `M accept ComposeTagTransformer W generate`(@BoolForgery annotationModeEnabled: Boolean)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinCompilerTest.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.full.declaredFunctions
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @OptIn(ExperimentalCompilerApi::class)
-internal open class KotlinCompilerTest {
+open class KotlinCompilerTest {
 
     @Mock
     protected lateinit var mockCallback: (Boolean) -> Unit

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/forge/Configurator.kt
@@ -10,7 +10,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeConfigurator
 import fr.xgouchet.elmyr.jvm.useJvmFactories
 
-internal class Configurator : ForgeConfigurator {
+class Configurator : ForgeConfigurator {
 
     override fun configure(forge: Forge) {
         forge.addFactory(IdentifierForgeryFactory())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,9 @@ datadogPluginGradle = "1.18.0"
 kotlinCompilerEmbeddable20 = "2.0.21"
 kotlinCompilerEmbeddable21 = "2.1.21"
 kotlinCompilerEmbeddable22 = "2.2.0"
-kotlinCompilerTesting = "0.7.0"
+kotlinCompilerTesting20 = "0.7.0"
+kotlinCompilerTesting21 = "0.7.0"
+kotlinCompilerTesting22 = "0.8.0"
 autoService = "1.0.1"
 junitVersion = "1.2.1"
 espressoCoreVersion = "3.6.1"
@@ -120,7 +122,9 @@ kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-comp
 kotlinCompilerEmbeddable20 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlinCompilerEmbeddable20" }
 kotlinCompilerEmbeddable21 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlinCompilerEmbeddable21" }
 kotlinCompilerEmbeddable22 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlinCompilerEmbeddable22" }
-kotlinCompilerTesting = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting" }
+kotlinCompilerTesting20 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting20" }
+kotlinCompilerTesting21 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting21" }
+kotlinCompilerTesting22 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting22" }
 autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 autoServiceAnnotation = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 


### PR DESCRIPTION
### Context
To widely support all known versions of Kotlin starting from 1.9.23, we need to create different sources set to let them compile with its own version of kotlin-embeddable.

Here is the whole plan:

- [x] Setup 3 source sets of Kotlin20, Kotlin21, Kotlin22 in the project
- [x] Since the current compiler supports Kotlin 2.0, move it directly to Kotlin20 source set. 
- [x] Dupilcate the compiler from Kotlin20 to Kotlin22 and adpats to Kotlin 2.2.x API     
- [x] Dupilcate the compiler from Kotlin20 to Kotlin21 and adpats to Kotlin 2.1.x API.  
- [ ]  Seperate unit tests for each source set.  <---- Current Step

### What does this PR do?

To test each source sets of compiler plugin, we create also source sets for unit test
* kotlin20Test
* kotlin21Test
* kotlin22Test

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

