### PR TITLE
RUM-11262: Upgrade Kotlin Version to 2.1.21 to remove metadata check error

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
 
     // Dependencies used to configure the gradle plugins
-    implementation(embeddedKotlin("gradle-plugin"))
+    implementation(libs.kotlinPluginGradle)
     implementation(libs.androidToolsPluginGradle)
     implementation(libs.versionsPluginGradle)
     implementation(libs.fuzzyWuzzy)

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -81,8 +81,8 @@ dependencies {
 
     // Compile-only dependencies
     compileOnly(libs.androidToolsPluginGradle) // for auto-wiring into Android projects
-    compileOnly(libs.kotlinPluginGradle)
     compileOnly(libs.kotlinCompilerEmbeddable)
+    compileOnly(libs.kotlinPluginGradle)
     compileOnly(kotlin20.output)
     compileOnly(kotlin21.output)
     compileOnly(kotlin22.output)
@@ -200,11 +200,4 @@ listOf(
 
 tasks.named("test") {
     dependsOn("testKotlin20", "testKotlin21", "testKotlin22")
-}
-
-// TODO RUM-11262: Currently we rely on the `-Xskip-metadata-version-check` compiler option to avoid compilation errors.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs += "-Xskip-metadata-version-check"
-    }
 }

--- a/dd-sdk-android-gradle-plugin/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin/transitiveDependencies
@@ -4,7 +4,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.json:json:20231013                                          :   72 Kb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
 # Commons
-kotlin = "2.0.21"
-kotlinComposePlugin = "2.0.21"
+kotlin = "2.1.21"
+kotlinComposePlugin = "2.1.21"
 json = "20231013"
 okHttp = "4.12.0"
 composeBom = "2024.04.01"


### PR DESCRIPTION
### Context
Prior to this PR, we use Kotlin 2.0.21 for the whole project, when compiling the `kotlin22` source set, the compiler will throw the error saying:
> Class 'org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI' was compiled with an incompatible version of Kotlin. The actual metadata version is 2.2.0, but the compiler version 2.0.0 can read versions up to 2.1.

Then we have to add following argument to the compiler to let it pass:
```
tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
    kotlinOptions {
        freeCompilerArgs += "-Xskip-metadata-version-check"
    }
}
```

### What does this PR do?

To remove this, we need to upgrade Kotlin compiler version to 2.1.x.

### Motivation

RUM-11262


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

