### PR TITLE
Bump dd-trace-java version to 1.53.0

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -106,7 +106,7 @@ test:plugin:
     - rm -rf ~/.gradle/daemon/
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin" ./gradlew :dd-sdk-android-gradle-plugin:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.26.1.jar=$DD_COMMON_AGENT_CONFIG
+    - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin" ./gradlew :dd-sdk-android-gradle-plugin:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.53.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
   artifacts:
     reports:


### PR DESCRIPTION
### What does this PR do?

Bumps the version of [dd-trace-java](https://github.com/DataDog/dd-trace-java) used in CI to the latest one ([v1.53.0](https://github.com/DataDog/dd-trace-java/releases/tag/v1.53.0)).

### Motivation

The latest version of the tracer can upload code coverage reports to Datadog.
I would like to enable code coverage upload for this repository, to have Datadog Code Coverage working in parallel with CodeCov.

### Additional Notes

The end goal is to eventually replace CodeCov with Datadog Code Coverage across all DD repos.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

