### PR TITLE
RUM-11320: Fix Gradle 9.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ repo/
 # MacOS garbage
 .DS_Store
 
+# Kotlin
+.kotlin/

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -215,7 +215,7 @@ class DdAndroidGradlePlugin @Inject constructor(
         ).apply {
             configure { uploadTask ->
                 @Suppress("MagicNumber")
-                if (TaskUtils.isGradleAbove(target, 7, 5)) {
+                if (TaskUtils.isGradleEqualOrAbove(target, 7, 5)) {
                     uploadTask.notCompatibleWithConfigurationCache(
                         "Datadog Upload Mapping task is not" +
                             " compatible with configuration cache yet."

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/TaskUtils.kt
@@ -36,24 +36,36 @@ internal object TaskUtils {
         return null
     }
 
-    fun isAgpAbove(major: Int, minor: Int, patch: Int): Boolean {
-        return isVersionAbove(Version.ANDROID_GRADLE_PLUGIN_VERSION, major, minor, patch)
+    fun isAgpEqualOrAbove(major: Int, minor: Int, patch: Int): Boolean {
+        return isVersionEqualOrAbove(Version.ANDROID_GRADLE_PLUGIN_VERSION, major, minor, patch)
     }
 
     // Gradle version may not have patch version
-    fun isGradleAbove(project: Project, major: Int, minor: Int, patch: Int = 0): Boolean {
-        return isVersionAbove(project.gradle.gradleVersion, major, minor, patch)
+    fun isGradleEqualOrAbove(project: Project, major: Int, minor: Int, patch: Int = 0): Boolean {
+        return isVersionEqualOrAbove(project.gradle.gradleVersion, major, minor, patch)
     }
 
-    @Suppress("MagicNumber", "ReturnCount")
-    private fun isVersionAbove(refVersion: String, major: Int, minor: Int, patch: Int): Boolean {
+    @Suppress("MagicNumber")
+    fun isVersionEqualOrAbove(refVersion: String, major: Int, minor: Int, patch: Int): Boolean {
         val groups = refVersion.split(".")
         // should be at least major and minor versions
         if (groups.size < 2) return false
         val currentMajor = groups[0].toIntOrNull() ?: 0
         val currentMinor = groups[1].toIntOrNull() ?: 0
         val currentPatch = groups.getOrNull(2)?.substringBefore("-")?.toIntOrNull() ?: 0
-        return currentMajor >= major && currentMinor >= minor && currentPatch >= patch
+        return SemVer(currentMajor, currentMinor, currentPatch) >= SemVer(major, minor, patch)
+    }
+
+    private class SemVer(val major: Int, val minor: Int, val patch: Int)
+
+    private operator fun SemVer.compareTo(other: SemVer): Int {
+        return if (this.major != other.major) {
+            this.major - other.major
+        } else if (this.minor != other.minor) {
+            this.minor - other.minor
+        } else {
+            this.patch - other.patch
+        }
     }
 }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
@@ -13,14 +13,14 @@ internal object CurrentAgpVersion {
 
     // can work probably even with lower versions, but legacy Variant API is working fine there as well
     val CAN_ENABLE_NEW_VARIANT_API: Boolean
-        get() = TaskUtils.isAgpAbove(major = 8, minor = 4, patch = 0)
+        get() = TaskUtils.isAgpEqualOrAbove(major = 8, minor = 4, patch = 0)
 
     val SUPPORTS_KOTLIN_DIRECTORIES_SOURCE_PROVIDER: Boolean
-        get() = TaskUtils.isAgpAbove(major = 7, minor = 0, patch = 0)
+        get() = TaskUtils.isAgpEqualOrAbove(major = 7, minor = 0, patch = 0)
 
     val EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC: Boolean
-        get() = TaskUtils.isAgpAbove(major = 8, minor = 0, patch = 0)
+        get() = TaskUtils.isAgpEqualOrAbove(major = 8, minor = 0, patch = 0)
 
     val CAN_QUERY_MAPPING_FILE_PROVIDER: Boolean
-        get() = TaskUtils.isAgpAbove(major = 7, minor = 0, patch = 0)
+        get() = TaskUtils.isAgpEqualOrAbove(major = 7, minor = 0, patch = 0)
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -1552,7 +1552,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             }
         """.trimIndent()
 
-        private const val LATEST_GRADLE_VERSION = "8.14.3"
+        private const val LATEST_GRADLE_VERSION = "9.0.0"
         private const val LATEST_AGP_VERSION = "8.13.0"
 
         val LATEST_VERSIONS_TEST_CONFIGURATION = BuildVersionConfig(


### PR DESCRIPTION
### What does this PR do?

A bug squeezed in https://github.com/DataDog/dd-sdk-android-gradle-plugin/commit/b95e0d7bd0f18e517727455e40f47577d89ba70b, breaking a proper Gradle version check.

As a result, with Gradle 9.0 the method to mark tasks as not compatible with configuration cache wasn't executed, because `9.0 >= 8.4` was returning `false`.

This PR does a proper bugfix.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

