### PR TITLE
RUM-11692: Unbox default type to fix Kotlin 2.2.20 breaking change

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer22.kt
@@ -20,8 +20,8 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.dumpKotlinLike
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
@@ -145,7 +145,7 @@ class ComposeNavHostTransformer22(
         // Build lambda for apply function
         val lambda = createLocalAnonymousFunc(
             builder,
-            navHostControllerClassSymbol.defaultType,
+            navHostControllerClassSymbol.owner.defaultType,
             trackEffectCall
         )
 

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer22.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer22.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.createType
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -197,7 +196,7 @@ class ComposeTagTransformer22(
     ): IrCall {
         val datadogTagIrCall = builder.irCall(
             datadogTagFunctionSymbol,
-            modifierClass.defaultType
+            modifierClass.owner.defaultType
         ).also {
             // Modifier
             // ExtensionReceiver argument

--- a/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/Ir22Ext.kt
+++ b/dd-sdk-android-gradle-plugin/src/kotlin22/kotlin/com/datadog/gradle/plugin/kcp/Ir22Ext.kt
@@ -1,3 +1,4 @@
+
 package com.datadog.gradle.plugin.kcp
 
 import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
@@ -17,10 +18,10 @@ import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.expressions.impl.IrFunctionExpressionImpl
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueParameterSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.symbols.impl.IrValueParameterSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
@@ -30,7 +31,7 @@ import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.primaryConstructor
 
 // Builds Lambda of (T.() -> Unit)
-@OptIn(DeprecatedForRemovalCompilerApi::class)
+@OptIn(DeprecatedForRemovalCompilerApi::class, UnsafeDuringIrConstructionAPI::class)
 internal fun IrPluginContext.irUnitLambdaExpression(
     body: IrBody,
     irDeclarationParent: IrDeclarationParent?,
@@ -41,7 +42,7 @@ internal fun IrPluginContext.irUnitLambdaExpression(
         function = irSimpleFunction(
             name = SpecialNames.ANONYMOUS,
             visibility = DescriptorVisibilities.LOCAL,
-            returnType = symbols.unit.defaultType,
+            returnType = symbols.unit.owner.defaultType,
             origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
             body = body
         ).apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ datadogPluginGradle = "1.20.0"
 # Kotlin Compiler Plugin
 kotlinCompilerEmbeddable20 = "2.0.21"
 kotlinCompilerEmbeddable21 = "2.1.21"
-kotlinCompilerEmbeddable22 = "2.2.0"
+kotlinCompilerEmbeddable22 = "2.2.20"
 kotlinCompilerTesting20 = "0.7.0"
 kotlinCompilerTesting21 = "0.7.0"
 kotlinCompilerTesting22 = "0.8.0"


### PR DESCRIPTION
### What does this PR do?

We use `IrClassifierSymbol.defaultType` extension function from Kotlin embeddable to get the unboxed default type, this function has changed the return value from Kotlin 2.2.0 to Kotlin 2.2.20, causing `NoSuchMethodException` during the build time.

In Kotlin 2.2.20:
```
val IrClassifierSymbol.defaultType: IrType
    get() = when (this) {
        is IrClassSymbol -> owner.defaultType
        is IrTypeParameterSymbol -> owner.defaultType
        is IrScriptSymbol -> unexpectedSymbolKind<IrClassifierSymbol>()
    }
```

In Kotlin 2.2.20, the function changes to:
```
val IrClassifierSymbol.defaultType: IrSimpleType
    get() = when (this) {
        is IrClassSymbol -> owner.defaultType
        is IrTypeParameterSymbol -> defaultType
        is IrScriptSymbol -> unexpectedSymbolKind<IrClassifierSymbol>()
    }
```

To fix this bug, instead of using this extension function, we can just unbox it since we know that we have only `IrClassSymbol` using it.

### Motivation

RUM-11692

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

