### PR TITLE
RUM-11592: Add "allTests" to include all the unit tests in gradle plugin

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -106,7 +106,7 @@ test:plugin:
     - rm -rf ~/.gradle/daemon/
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin" ./gradlew :dd-sdk-android-gradle-plugin:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
+    - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin" ./gradlew :dd-sdk-android-gradle-plugin:allTests --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
   artifacts:
     reports:

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -198,6 +198,6 @@ listOf(
     }
 }
 
-tasks.named("test") {
-    dependsOn("testKotlin20", "testKotlin21", "testKotlin22")
+tasks.register("allTests") {
+    dependsOn("test", "testKotlin20", "testKotlin21", "testKotlin22")
 }


### PR DESCRIPTION
### What does this PR do?

This is a workaround to fix the issue when running the unit test from `test/`, `kotlin2xTest` will be run as well.

Instead of letting `test` depend on `kotlin2xTest`, this PR creates a new `allTests` gradle task to include them all.

And we use this task on CI for testing.

### Motivation

RUM-11592

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

