### PR TITLE
[OkHttpUploader] Fix response not being closed in handleResponse()

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -197,7 +197,7 @@ internal class OkHttpUploader : Uploader {
                 }
             }
         }
-        response.close()
+        response.body?.close()
     }
 
     private fun validateApiKey(site: DatadogSite, apiKey: String): Boolean? {


### PR DESCRIPTION
### What does this PR do?

`ResponseBody#close`(which closes the `ResponseBody`) is called only in case of `statusCode` equals or superior to 
400 (last statement in `handleResponse`) not in the other cases. Ensure `ResponseBody#close` is being called at the end of `handleResponse`. 
Also avoid instantiating unnecessary `call` in `upload` in case of emulated environment.

### Motivation

This log which happens during our build:

> [Timestamp] | main | A connection to https://sourcemap-intake.datadoghq.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

