### PR TITLE
Commonize KCP messages and lower androix.nav message severity

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
@@ -21,8 +21,52 @@ fun MessageCollector.warnDependenciesError() {
     report(CompilerMessageSeverity.STRONG_WARNING, WARNING_MISSING_DEP)
 }
 
+/**
+ * Extension function to report a message with info level.
+ *
+ * @receiver MessageCollector - The message collector used to report.
+ * @param message message to report
+ */
+fun MessageCollector.info(message: String) {
+    report(CompilerMessageSeverity.INFO, message)
+}
+
+/**
+ * Extension function to report a message with strong warning level.
+ *
+ * @receiver MessageCollector - The message collector used to report.
+ * @param message message to report
+ */
+fun MessageCollector.strongWarning(message: String) {
+    report(CompilerMessageSeverity.STRONG_WARNING, message)
+}
+
 private const val WARNING_MISSING_DEP =
     "The Datadog Plugin has detected missing dependencies required for Compose Instrumentation in this module. " +
         "Missing these dependencies may result in incomplete Compose Instrumentation functionality. " +
         "You can ignore this warning if you're certain that the missing dependencies " +
         "are not needed for your use case."
+
+/**
+ * Error message of missing Datadog Jetpack Compose dependency.
+ */
+const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
+    "Missing com.datadoghq:dd-sdk-android-compose dependency."
+
+/**
+ * Error message of missing Android Compose UI dependency.
+ */
+const val ERROR_MISSING_COMPOSE_UI =
+    "Missing androidx.compose.ui:ui dependency."
+
+/**
+ * Error message of missing Android Compose Navigation dependency.
+ */
+const val ERROR_MISSING_COMPOSE_NAV =
+    "Missing androidx.navigation:navigation-compose dependency."
+
+/**
+ * Error message of missing Kotlin Stdlib dependency.
+ */
+const val ERROR_MISSING_KOTLIN_STDLIB =
+    "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -60,16 +60,17 @@ class ComposeNavHostTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
 
         navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_NAV)
+            // androidx.navigation:navigation-compose library is optional for a compose module.
+            messageCollector.info(ERROR_MISSING_COMPOSE_NAV)
             return false
         }
         applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
-            warn(ERROR_MISSING_KOTLIN_STDLIB)
+            messageCollector.strongWarning(ERROR_MISSING_KOTLIN_STDLIB)
             return false
         }
         return true
@@ -184,17 +185,4 @@ class ComposeNavHostTransformer(
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
-
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
-    companion object {
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_NAV =
-            "Missing androidx.navigation:navigation-compose dependency."
-        private const val ERROR_MISSING_KOTLIN_STDLIB =
-            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
-    }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -9,7 +9,6 @@ package com.datadog.gradle.plugin.kcp
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBoolean
@@ -61,19 +60,19 @@ class ComposeTagTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
         modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         return true
@@ -214,16 +213,8 @@ class ComposeTagTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
     private companion object {
         private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
         private val kotlinNothingFqName = FqName("kotlin.Nothing")
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_UI =
-            "Missing androidx.compose.ui:ui dependency."
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -60,16 +60,16 @@ class ComposeNavHostTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
 
         navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_NAV)
+            messageCollector.info(ERROR_MISSING_COMPOSE_NAV)
             return false
         }
         applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
-            warn(ERROR_MISSING_KOTLIN_STDLIB)
+            messageCollector.strongWarning(ERROR_MISSING_KOTLIN_STDLIB)
             return false
         }
         return true
@@ -184,17 +184,4 @@ class ComposeNavHostTransformer(
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
-
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
-    companion object {
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_NAV =
-            "Missing androidx.navigation:navigation-compose dependency."
-        private const val ERROR_MISSING_KOTLIN_STDLIB =
-            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
-    }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -9,7 +9,6 @@ package com.datadog.gradle.plugin.kcp
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBoolean
@@ -61,19 +60,19 @@ class ComposeTagTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
         modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         return true
@@ -214,16 +213,8 @@ class ComposeTagTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
     private companion object {
         private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
         private val kotlinNothingFqName = FqName("kotlin.Nothing")
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_UI =
-            "Missing androidx.compose.ui:ui dependency."
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -62,16 +62,16 @@ class ComposeNavHostTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
 
         navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_NAV)
+            messageCollector.info(ERROR_MISSING_COMPOSE_NAV)
             return false
         }
         applyFunctionSymbol = pluginContextUtils.getApplySymbol() ?: run {
-            warn(ERROR_MISSING_KOTLIN_STDLIB)
+            messageCollector.strongWarning(ERROR_MISSING_KOTLIN_STDLIB)
             return false
         }
         return true
@@ -191,17 +191,4 @@ class ComposeNavHostTransformer(
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
-
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
-    companion object {
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_NAV =
-            "Missing androidx.navigation:navigation-compose dependency."
-        private const val ERROR_MISSING_KOTLIN_STDLIB =
-            "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
-    }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irBoolean
@@ -65,19 +64,19 @@ class ComposeTagTransformer(
     @Suppress("ReturnCount")
     fun initReferences(): Boolean {
         datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
-            warn(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
             return false
         }
         modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
-            warn(ERROR_MISSING_COMPOSE_UI)
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
             return false
         }
         return true
@@ -225,16 +224,8 @@ class ComposeTagTransformer(
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
 
-    private fun warn(message: String) {
-        messageCollector.report(CompilerMessageSeverity.STRONG_WARNING, message)
-    }
-
     private companion object {
         private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
         private val kotlinNothingFqName = FqName("kotlin.Nothing")
-        private const val ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION =
-            "Missing com.datadoghq:dd-sdk-android-compose dependency."
-        private const val ERROR_MISSING_COMPOSE_UI =
-            "Missing androidx.compose.ui:ui dependency."
     }
 }


### PR DESCRIPTION
### What does this PR do?

* lower the message from strong warning to info if the module is missing `androidx.navigation:navigation-compose` dependency, since it's a common way in application project the compose navigation can be handled in a dedicated module, so that the customer will not be spammed by this message
* Commonize all the KCP messages in `dd-sdk-android-gradle-kcp-common` since they are exactly the same.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

