### PR TITLE
Fix publishing

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -28,6 +28,8 @@ object MavenConfig {
 fun Project.publishingConfig(projectDescription: String, publishAsGradlePlugin: Boolean = true) {
     val projectName = name
     val signingExtension = extensions.findByType(SigningExtension::class)
+    project.group = MavenConfig.GROUP_ID
+    project.version = MavenConfig.VERSION.name
 
     if (signingExtension == null) {
         logger.error("Missing signing extension for $projectName")
@@ -53,9 +55,6 @@ fun Project.publishingConfig(projectDescription: String, publishAsGradlePlugin: 
     }
 
     afterEvaluate {
-        // should be in afterEvaluate
-        mavenPublishing.publishToMavenCentral(automaticRelease = false)
-
         if (publishAsGradlePlugin) {
             tasks.named("javadocJar", Jar::class.java).configure {
                 group = "publishing"
@@ -120,5 +119,8 @@ fun Project.publishingConfig(projectDescription: String, publishAsGradlePlugin: 
                 }
             }
         }
+
+        // should be in afterEvaluate
+        mavenPublishing.publishToMavenCentral(automaticRelease = false)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Another publishing fix. Apparently in case of plain Java lib modules version wasn't set by the time publishing plugin makes set up and decides if publishing should be to the snapshots repo or not (based on the version name), so publishing was attempted to the regular releases repo.

Now new artifacts can be found:

```
curl -I https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/dd-sdk-android-gradle-plugin-kcp-kotlin20/maven-metadata.xml
HTTP/2 200
date: Wed, 11 Feb 2026 18:24:31 GMT
content-type: application/xml
content-length: 352
server: Nexus/3.76.1-01 (PRO)
x-content-type-options: nosniff
content-security-policy: sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation
x-xss-protection: 1; mode=block
etag: "743dd89ae036602a2909e19e65023286defcd8a6"
last-modified: Wed, 11 Feb 2026 18:22:35 GMT
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

