### PR TITLE
Sign new KCP modules

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -41,7 +41,14 @@ fun Project.publishingConfig(projectDescription: String, publishAsGradlePlugin: 
         isRequired = System.getenv("CI").toBoolean() && !hasProperty("dd-skip-signing")
         useInMemoryPgpKeys(privateKey, password)
         // com.gradle.plugin-publish plugin will automatically add signing task "signPluginMavenPublication"
-        // sign(publishingExtension.publications.getByName(MavenConfig.PUBLICATION))
+        // for KCP modules we need to do it manually
+        if (!publishAsGradlePlugin) {
+            afterEvaluate {
+                extensions.findByType<PublishingExtension>()?.apply {
+                    sign(publications.getByName(MavenConfig.KCP_PUBLICATION))
+                }
+            }
+        }
     }
 
     val mavenPublishing = extensions.findByType<MavenPublishBaseExtension>()


### PR DESCRIPTION
### What does this PR do?

Adds signing for the new KCP modules:

```
curl -I https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/dd-sdk-android-gradle-plugin-kcp-common/1.23.0-SNAPSHOT/dd-sdk-android-gradle-plugin-kcp-common-1.23.0-20260212.105703-3.jar.asc
HTTP/2 200
date: Thu, 12 Feb 2026 11:07:24 GMT
content-type: application/pgp-signature
content-length: 831
server: Nexus/3.76.1-01 (PRO)
x-content-type-options: nosniff
content-security-policy: sandbox allow-forms allow-modals allow-popups allow-presentation allow-scripts allow-top-navigation
x-xss-protection: 1; mode=block
etag: "a83ebaf60cf599cdac6fb50c7ef912de77305832"
last-modified: Thu, 12 Feb 2026 10:58:46 GMT
```

The necessary Gradle task is there:

```
./gradlew :dd-sdk-android-gradle-plugin-kcp-common:publishMavenPublicationToMavenCentralRepository --dry-run | grep sign
:dd-sdk-android-gradle-plugin-kcp-common:signMavenPublication SKIPPED
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

