### PR TITLE
Remove redundant duplicated fields in `MappingFileUploadTask`

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
@@ -194,13 +194,5 @@ abstract class MappingFileUploadTask
         private const val MAPPING_FILE_COMMENT_CHAR = '#'
         const val MAPPING_OPTIMIZED_FILE_NAME = "mapping-shrinked.txt"
         const val MAPPING_OPTIMIZED_FILE_WRITE_BUFFER_SIZE = 32 * 1024 // 32 Kb
-
-        const val API_KEY_MISSING_ERROR = "Make sure you define an API KEY to upload your mapping files to Datadog. " +
-            "Create a DD_API_KEY or DATADOG_API_KEY environment variable, gradle" +
-            " property or define it in datadog-ci.json file."
-        const val INVALID_API_KEY_FORMAT_ERROR =
-            "DD_API_KEY provided shouldn't contain quotes or apostrophes."
-        const val MISSING_BUILD_ID_ERROR =
-            "Build ID is missing, you need to run upload task only after APK/AAB file is generated."
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/MappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/MappingFileUploadTaskTest.kt
@@ -434,7 +434,7 @@ internal class MappingFileUploadTaskTest {
         }
 
         // Then
-        assertThat(exception.message).isEqualTo(MappingFileUploadTask.API_KEY_MISSING_ERROR)
+        assertThat(exception.message).isEqualTo(FileUploadTask.API_KEY_MISSING_ERROR)
         verifyNoInteractions(mockUploader)
     }
 
@@ -463,7 +463,7 @@ internal class MappingFileUploadTaskTest {
 
         // Then
         assertThat(exception.message)
-            .isEqualTo(MappingFileUploadTask.INVALID_API_KEY_FORMAT_ERROR)
+            .isEqualTo(FileUploadTask.INVALID_API_KEY_FORMAT_ERROR)
         verifyNoInteractions(mockUploader)
     }
 
@@ -481,7 +481,7 @@ internal class MappingFileUploadTaskTest {
         }
 
         // Then
-        assertThat(exception.message).isEqualTo(MappingFileUploadTask.MISSING_BUILD_ID_ERROR)
+        assertThat(exception.message).isEqualTo(FileUploadTask.MISSING_BUILD_ID_ERROR)
         verifyNoInteractions(mockUploader)
     }
 
@@ -499,7 +499,7 @@ internal class MappingFileUploadTaskTest {
         }
 
         // Then
-        assertThat(exception.message).isEqualTo(MappingFileUploadTask.MISSING_BUILD_ID_ERROR)
+        assertThat(exception.message).isEqualTo(FileUploadTask.MISSING_BUILD_ID_ERROR)
         verifyNoInteractions(mockUploader)
     }
 


### PR DESCRIPTION
### What does this PR do?

The same fields were duplicated between `MappingFileUploadTask` and `FileUploadTask`.

Keeping them only in the parent class.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

