### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -108,6 +108,11 @@ test:plugin:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin" ./gradlew :dd-sdk-android-gradle-plugin:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
   artifacts:
     reports:
       junit: dd-sdk-android-gradle-plugin/build/test-results/test/TEST-*.xml
@@ -123,6 +128,11 @@ test:common:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin-kcp-common" ./gradlew :dd-sdk-android-gradle-plugin-kcp-common:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
   artifacts:
     reports:
       junit: dd-sdk-android-gradle-plugin-kcp-common/build/test-results/test/TEST-*.xml
@@ -138,6 +148,11 @@ test:kotlin20:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin-kcp-kotlin20" ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin20:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
   artifacts:
     reports:
       junit: dd-sdk-android-gradle-plugin-kcp-kotlin20/build/test-results/test/TEST-*.xml
@@ -153,6 +168,11 @@ test:kotlin21:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin-kcp-kotlin21" ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin21:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
   artifacts:
     reports:
       junit: dd-sdk-android-gradle-plugin-kcp-kotlin21/build/test-results/test/TEST-*.xml
@@ -168,6 +188,11 @@ test:kotlin22:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin-kcp-kotlin22" ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin22:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
   artifacts:
     reports:
       junit: dd-sdk-android-gradle-plugin-kcp-kotlin22/build/test-results/test/TEST-*.xml

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,5 @@
+schema-version: v1
+ignore:
+  - "build/"
+  - "**/build/"
+  - "**/src/test/"


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

## Changes

- Added `datadog-ci coverage upload --format=jacoco` step after each Codecov upload in all 5 test jobs: `test:plugin`, `test:common`, `test:kotlin20`, `test:kotlin21`, `test:kotlin22`
- Added `code-coverage.datadog.yml` with ignore paths matching `.codecov.yml` (build directories and test sources)
- The upload is guarded by `DD_API_KEY` presence and uses `|| true` to avoid breaking CI
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- Coverage format: JaCoCo XML (auto-discovered)

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

CI has run on this PR and all tests passed. Datadog already receives coverage data for this repo via CI Visibility (5 reports on `develop`). Coverage numbers match:

| System | Coverage |
|--------|----------|
| Codecov | 76.98% |
| Datadog | 77.61% |

The 0.63% difference is within expected tolerance (minor differences in line counting methodology).

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Remove `.codecov.yml`
3. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload steps run independently of the existing CI pipeline and cannot cause test failures.