### PR TITLE
RUM-15129: Fix Kotlin 2.3.20 breaking changes for Kotlin Compiler Plugin

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/IrExt.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/IrExt.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.descriptors.DescriptorVisibility
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -31,8 +32,11 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedContainerSource
+import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
+import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 
 // Builds Lambda of (T.() -> Unit)
@@ -48,7 +52,7 @@ internal fun IrPluginContext.irUnitLambdaExpression(
             name = SpecialNames.ANONYMOUS,
             visibility = DescriptorVisibilities.LOCAL,
             returnType = irBuiltIns.unitType,
-            origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
+            origin = getCompatLambdaOrigin(),
             body = body
         ).apply {
             irDeclarationParent?.let {
@@ -57,7 +61,7 @@ internal fun IrPluginContext.irUnitLambdaExpression(
             this.extensionReceiverParameter = IrFactoryImpl.createValueParameter(
                 startOffset = startOffset,
                 endOffset = endOffset,
-                origin = IrDeclarationOrigin.DEFINED,
+                origin = getCompatDefinedOrigin(),
                 kind = IrParameterKind.ExtensionReceiver,
                 name = Name.identifier("receiver"),
                 type = receiverType,
@@ -91,7 +95,7 @@ internal fun irSimpleFunction(
     isOperator: Boolean = false,
     isInfix: Boolean = false,
     isExpect: Boolean = false,
-    isFakeOverride: Boolean = origin == IrDeclarationOrigin.FAKE_OVERRIDE,
+    isFakeOverride: Boolean = origin == getCompatFakeOverrideOrigin(),
     containerSource: DeserializedContainerSource? = null
 ): IrSimpleFunction = IrFactoryImpl.createSimpleFunction(
     startOffset = UNDEFINED_OFFSET,
@@ -113,6 +117,46 @@ internal fun irSimpleFunction(
     containerSource = containerSource
 ).apply {
     this.body = body
+}
+
+private fun getCompatLambdaOrigin(): IrDeclarationOrigin {
+    return getCompatDeclarationOrigin("LOCAL_FUNCTION_FOR_LAMBDA") {
+        IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA
+    }
+}
+
+private fun getCompatFakeOverrideOrigin(): IrDeclarationOrigin {
+    return getCompatDeclarationOrigin("FAKE_OVERRIDE") {
+        IrDeclarationOrigin.FAKE_OVERRIDE
+    }
+}
+
+private fun getCompatDefinedOrigin(): IrDeclarationOrigin {
+    return getCompatDeclarationOrigin("DEFINED") {
+        IrDeclarationOrigin.DEFINED
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun getCompatDeclarationOrigin(
+    name: String,
+    default: () -> IrDeclarationOrigin
+): IrDeclarationOrigin {
+    // In Kotlin 2.3.20+, IrDeclarationOriginImpl.Regular was introduced as a property delegate,
+    // changing the JVM return type of companion property getters (binary incompatibility).
+    // Use reflection to access the property by name when running on such versions.
+    val hasRegularSubtype = IrDeclarationOriginImpl::class.nestedClasses
+        .any { it.simpleName == "Regular" }
+    return if (hasRegularSubtype) {
+        IrDeclarationOrigin::class.companionObjectInstance?.let { instance ->
+            instance::class.memberProperties
+                .filterIsInstance<KProperty1<Any, *>>()
+                .first { it.name == name }
+                .get(instance) as IrDeclarationOrigin
+        } ?: default()
+    } else {
+        default()
+    }
 }
 
 private fun getCompatSimpleFunctionSymbol(): IrSimpleFunctionSymbol {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the breaking change introduced in Kotlin compiler embeddable 2.3.20 .

#### What has changed?

in Kotlin [2.3.0](https://github.com/JetBrains/kotlin/blob/v2.3.0/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclarationOrigin.kt#L59), `IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA` is declared as 
```
 val LOCAL_FUNCTION_FOR_LAMBDA by IrDeclarationOriginImpl
```

in Kotlin [2.3.20](https://github.com/JetBrains/kotlin/blob/v2.3.20/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/declarations/IrDeclarationOrigin.kt#L57), this field still exists but silently change the declaration under the hood, it becomes 
```
val LOCAL_FUNCTION_FOR_LAMBDA by IrDeclarationOriginImpl.Regular
```


#### How to fix

This can be covered by a tiny fix, so this fix is added in `kotlin22` module instead of creating a new module for this version.

Basically we check if `IrDeclarationOriginImpl.Regular` is introduced, if it is we use it to get `LOCAL_FUNCTION_FOR_LAMBDA` otherwise we fallback what we were using before.


### Motivation

RUM-15129


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

