### PR TITLE
RUM-15333: Fix missing build ID error in case of configuration cache warn mode

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -16,7 +16,6 @@ import com.datadog.gradle.plugin.internal.ApiKeySource.GRADLE_PROPERTY
 import com.datadog.gradle.plugin.internal.CurrentAgpVersion
 import com.datadog.gradle.plugin.internal.GitRepositoryDetector
 import com.datadog.gradle.plugin.internal.VariantIterator
-import com.datadog.gradle.plugin.internal.lazyBuildIdProvider
 import com.datadog.gradle.plugin.internal.variant.AppVariant
 import com.datadog.gradle.plugin.internal.variant.NewApiAppVariant
 import com.datadog.gradle.plugin.kcp.DatadogKotlinCompilerPluginSupport
@@ -27,7 +26,6 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.process.ExecOperations
@@ -36,15 +34,13 @@ import org.json.JSONObject
 import java.io.File
 import java.io.IOException
 import javax.inject.Inject
-import kotlin.io.path.Path
 
 /**
  * Plugin adding tasks for Android projects using Datadog's SDK for Android.
  */
 @Suppress("TooManyFunctions")
 class DdAndroidGradlePlugin @Inject constructor(
-    private val execOps: ExecOperations,
-    private val providerFactory: ProviderFactory
+    private val execOps: ExecOperations
 ) : Plugin<Project> {
 
     // region Plugin
@@ -227,7 +223,7 @@ class DdAndroidGradlePlugin @Inject constructor(
             target,
             variant,
             buildIdTask,
-            providerFactory,
+            GenerateBuildIdTask.buildIdFile(target, variant.name),
             apiKeyProvider,
             extensionConfiguration,
             GitRepositoryDetector(execOps)
@@ -241,9 +237,7 @@ class DdAndroidGradlePlugin @Inject constructor(
         target: Project,
         variant: AppVariant
     ): TaskProvider<GenerateBuildIdTask> {
-        val buildIdDirectory = target.layout.buildDirectory
-            .dir(Path("generated", "datadog", "buildId", variant.name).toString())
-        val buildIdGenerationTask = GenerateBuildIdTask.register(target, variant, buildIdDirectory)
+        val buildIdGenerationTask = GenerateBuildIdTask.register(target, variant)
 
         return buildIdGenerationTask
     }
@@ -263,13 +257,6 @@ class DdAndroidGradlePlugin @Inject constructor(
             GitRepositoryDetector(execOps)
         ).apply {
             configure { uploadTask ->
-                @Suppress("MagicNumber")
-                if (TaskUtils.isGradleEqualOrAbove(target, 7, 5)) {
-                    uploadTask.notCompatibleWithConfigurationCache(
-                        "Datadog Upload Mapping task is not" +
-                            " compatible with configuration cache yet."
-                    )
-                }
                 val extensionConfiguration = resolveExtensionConfiguration(extension, variant)
                 configureVariantTask(
                     target.objects,
@@ -279,7 +266,8 @@ class DdAndroidGradlePlugin @Inject constructor(
                     variant
                 )
 
-                uploadTask.buildId.set(buildIdGenerationTask.lazyBuildIdProvider(providerFactory))
+                uploadTask.buildIdFile.set(GenerateBuildIdTask.buildIdFile(target, variant.name))
+                uploadTask.mustRunAfter(buildIdGenerationTask)
                 uploadTask.mappingFilePackagesAliases = extensionConfiguration.mappingFilePackageAliases
                 uploadTask.mappingFileTrimIndents = extensionConfiguration.mappingFileTrimIndents
                 if (!extensionConfiguration.ignoreDatadogCiFileConfig) {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
@@ -13,6 +13,7 @@ import com.datadog.gradle.plugin.internal.OkHttpUploader
 import com.datadog.gradle.plugin.internal.Uploader
 import com.datadog.gradle.plugin.internal.variant.AppVariant
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -24,6 +25,8 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.json.JSONArray
 import org.json.JSONException
@@ -100,10 +103,16 @@ abstract class FileUploadTask @Inject constructor(
     var remoteRepositoryUrl: String = ""
 
     /**
-     * Build ID which will be used for mapping file matching.
+     * File containing the build ID used for mapping file matching.
+     *
+     * We intentionally use InputFiles instead of InputFile, because the build ID file may be
+     * absent during configuration for standalone upload invocations. The task validates this
+     * condition itself at execution time to keep the plugin-specific error message.
      */
-    @get:Input
-    abstract val buildId: Property<String>
+    @get:Optional
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val buildIdFile: RegularFileProperty
 
     /**
      * datadog-ci.json file, if found or applicable for the particular task.
@@ -146,7 +155,8 @@ abstract class FileUploadTask @Inject constructor(
             INVALID_API_KEY_FORMAT_ERROR
         }
 
-        check(buildId.isPresent && buildId.get().isNotEmpty()) {
+        val buildId = readBuildId()
+        check(buildId.isNotEmpty()) {
             MISSING_BUILD_ID_ERROR
         }
 
@@ -188,7 +198,7 @@ abstract class FileUploadTask @Inject constructor(
                         version = versionName.get(),
                         versionCode = versionCode.get(),
                         variant = variantName,
-                        buildId = buildId.get()
+                        buildId = buildId
                     ),
                     repositories.firstOrNull(),
                     !disableGzipOption.isPresent,
@@ -242,6 +252,15 @@ abstract class FileUploadTask @Inject constructor(
     // endregion
 
     // region Private
+
+    private fun readBuildId(): String {
+        val file = buildIdFile.orNull?.asFile ?: return ""
+        return if (file.exists()) {
+            file.readText().trim()
+        } else {
+            ""
+        }
+    }
 
     private fun applySiteFromEnvironment() {
         val environmentSite = System.getenv(DATADOG_SITE)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/GenerateBuildIdTask.kt
@@ -14,11 +14,13 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.util.UUID
+import kotlin.io.path.Path
 
 /**
  * This task generates unique Build ID which is later used to match error and mapping file.
@@ -40,7 +42,7 @@ abstract class GenerateBuildIdTask : DefaultTask() {
     /**
      * Variant name this task is linked to.
      */
-    @get:Internal
+    @get:Input
     abstract val variantName: Property<String>
 
     init {
@@ -76,9 +78,9 @@ abstract class GenerateBuildIdTask : DefaultTask() {
          */
         fun register(
             target: Project,
-            variant: AppVariant,
-            buildIdDirectory: Provider<Directory>
+            variant: AppVariant
         ): TaskProvider<GenerateBuildIdTask> {
+            val buildIdDirectory = buildIdDirectory(target, variant.name)
             val generateBuildIdTask = target.tasks.register(
                 TASK_NAME + variant.name.capitalize(),
                 GenerateBuildIdTask::class.java
@@ -89,6 +91,17 @@ abstract class GenerateBuildIdTask : DefaultTask() {
             variant.bindWith(generateBuildIdTask, buildIdDirectory)
 
             return generateBuildIdTask
+        }
+
+        private fun buildIdFilePath(variantName: String) =
+            Path("generated", "datadog", "buildId", variantName, BUILD_ID_FILE_NAME)
+
+        private fun buildIdDirectory(target: Project, variantName: String): Provider<Directory> {
+            return target.layout.buildDirectory.dir(buildIdFilePath(variantName).parent.toString())
+        }
+
+        fun buildIdFile(target: Project, variantName: String): Provider<RegularFile> {
+            return target.layout.buildDirectory.file(buildIdFilePath(variantName).toString())
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTask.kt
@@ -8,10 +8,10 @@ package com.datadog.gradle.plugin
 
 import com.datadog.gradle.plugin.internal.ApiKey
 import com.datadog.gradle.plugin.internal.Uploader
-import com.datadog.gradle.plugin.internal.lazyBuildIdProvider
 import com.datadog.gradle.plugin.internal.variant.AppVariant
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
@@ -107,7 +107,7 @@ internal abstract class NdkSymbolFileUploadTask @Inject constructor(
             project: Project,
             variant: AppVariant,
             buildIdTask: TaskProvider<GenerateBuildIdTask>,
-            providerFactory: ProviderFactory,
+            buildIdFile: Provider<RegularFile>,
             apiKeyProvider: Provider<ApiKey>,
             extensionConfiguration: DdExtensionConfiguration,
             repositoryDetector: RepositoryDetector
@@ -133,7 +133,8 @@ internal abstract class NdkSymbolFileUploadTask @Inject constructor(
                         variant
                     )
 
-                    task.buildId.set(buildIdTask.lazyBuildIdProvider(providerFactory))
+                    task.buildIdFile.set(buildIdFile)
+                    task.mustRunAfter(buildIdTask)
                 }
             }
         }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
@@ -7,7 +7,6 @@
 package com.datadog.gradle.plugin.internal
 
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import com.datadog.gradle.plugin.GenerateBuildIdTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
@@ -30,25 +29,6 @@ internal fun ExternalNativeBuildTask.getSearchObjDirs(providerFactory: ProviderF
             is File -> providerFactory.provider { soFolder }
             is DirectoryProperty -> soFolder.map { it.asFile }
             else -> providerFactory.provider { null }
-        }
-    }
-}
-
-internal fun TaskProvider<GenerateBuildIdTask>.lazyBuildIdProvider(providerFactory: ProviderFactory): Provider<String> {
-    // upload task shouldn't depend on the build ID generation task, but only read its property,
-    // because upload task may be triggered after assemble task and we don't want to re-generate
-    // build ID, because it will be different then from the one which is already embedded in
-    // the application package
-    return flatMap {
-        it.buildIdFile.flatMap {
-            providerFactory.provider {
-                val file = it.asFile
-                if (file.exists()) {
-                    file.readText().trim()
-                } else {
-                    ""
-                }
-            }
         }
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginConfigureVariantForUploadTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginConfigureVariantForUploadTest.kt
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -52,13 +53,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -71,11 +71,11 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(task.mappingFile.get().asFile)
-            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
+            .isEqualTo(File(fakeProject.projectDir, checkNotNull(fakeExtension.mappingFilePath)))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -101,13 +101,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -120,13 +119,13 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(task.mappingFile.get().asFile)
-            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
+            .isEqualTo(File(fakeProject.projectDir, checkNotNull(fakeExtension.mappingFilePath)))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -162,13 +161,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -181,13 +179,13 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(task.mappingFile.get().asFile)
-            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
+            .isEqualTo(File(fakeProject.projectDir, checkNotNull(fakeExtension.mappingFilePath)))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases.minus(aliasToFilterOut.first))
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -222,13 +220,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -244,7 +241,7 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -283,13 +280,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -305,7 +301,7 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isEqualTo(fakeDatadogCiFile)
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -344,13 +340,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -366,7 +361,7 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.mappingFilePackagesAliases).isEmpty()
         assertThat(task.mappingFileTrimIndents).isFalse
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
     }
 
     @Test
@@ -521,13 +516,12 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         val task = testedPlugin.configureVariantForUploadTask(
             fakeProject,
             mockVariant,
-            mockBuildIdGenerationTask(fakeBuildId),
+            mock<TaskProvider<GenerateBuildIdTask>>(),
             fakeProject.providers.provider { fakeApiKey },
             fakeExtension
         ).get()
 
         // Then
-        check(task is MappingFileUploadTask)
         assertThat(task.repositoryDetector).isInstanceOf(GitRepositoryDetector::class.java)
         assertThat(task.name).isEqualTo(
             "uploadMapping${variantName.replaceFirstChar { capitalizeChar(it) }}"
@@ -540,12 +534,19 @@ internal class DdAndroidGradlePluginConfigureVariantForUploadTest : DdAndroidGra
         assertThat(task.site).isEqualTo(fakeExtension.site)
         assertThat(task.remoteRepositoryUrl).isEqualTo(fakeExtension.remoteRepositoryUrl)
         assertThat(task.mappingFile.get().asFile)
-            .isEqualTo(File(fakeProject.projectDir, fakeExtension.mappingFilePath))
+            .isEqualTo(File(fakeProject.projectDir, checkNotNull(fakeExtension.mappingFilePath)))
         assertThat(task.mappingFilePackagesAliases)
             .isEqualTo(fakeExtension.mappingFilePackageAliases)
         assertThat(task.mappingFileTrimIndents)
             .isEqualTo(fakeExtension.mappingFileTrimIndents)
         assertThat(task.datadogCiFile).isNull()
-        assertThat(task.buildId.get()).isEqualTo(fakeBuildId)
+        assertThat(task.buildIdFile.get().asFile).isEqualTo(expectedBuildIdFile(variantName))
+    }
+
+    private fun expectedBuildIdFile(variantName: String): File {
+        return File(
+            fakeProject.buildDir,
+            "generated/datadog/buildId/$variantName/${GenerateBuildIdTask.BUILD_ID_FILE_NAME}"
+        )
     }
 }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -1005,6 +1005,73 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
+    fun `M reuse configuration cache W assemble finalized by upload { warn mode }`(forge: Forge) {
+        // Given
+        // this test is targeting the specific behavior of Gradle 8
+        buildVersionConfig = BuildVersionConfig(
+            agpVersion = "8.13.2",
+            gradleVersion = "8.14.1",
+            buildToolsVersion = "36.1.0",
+            targetSdkVersion = "36",
+            kotlinVersion = "2.3.10",
+            jvmTarget = JavaVersion.VERSION_17.toString()
+        )
+        stubGradleBuildFromResourceFile(
+            "lib_module_build.gradle",
+            libModuleBuildGradleFile,
+            overwrite = true
+        )
+        stubGradlePropertiesFile(buildVersionConfig)
+        gradlePropertiesFile.appendText("\norg.gradle.configuration-cache.problems=warn\n")
+        stubGradleBuildFromResourceFile(
+            "build_with_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+        val color = forge.anElementFrom(colors)
+        val version = forge.anElementFrom(versions)
+        val variant = "${version.lowercase()}$color"
+        val variantCapitalized = variant.capitalize()
+
+        appBuildGradleFile.appendText(
+            """
+                tasks.configureEach {
+                    if (name == "minify${variantCapitalized}ReleaseWithR8") {
+                        finalizedBy(tasks.getByName("uploadMapping${variantCapitalized}Release"))
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val firstRun = gradleRunner(gradleVersion = buildVersionConfig.gradleVersion) {
+            withArguments(
+                "--info",
+                ":samples:app:assemble${variantCapitalized}Release",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call",
+                "--configuration-cache"
+            )
+        }.build()
+
+        // When
+        val secondRun = gradleRunner(gradleVersion = buildVersionConfig.gradleVersion) {
+            withArguments(
+                "--info",
+                ":samples:app:assemble${variantCapitalized}Release",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-emulate-upload-call",
+                "--configuration-cache"
+            )
+        }.build()
+
+        // Then
+        assertThat(firstRun).containsInOutput("Configuration cache entry stored.")
+        assertThat(secondRun).containsInOutput("Configuration cache entry reused.")
+        assertThat(secondRun.output).doesNotContain(FileUploadTask.MISSING_BUILD_ID_ERROR)
+    }
+
+    @Test
     fun `M not contain any uploadTasks W minifyNotEnabled`() {
         // Given
         stubGradleBuildFromResourceFile(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginResolveApiKeyTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginResolveApiKeyTest.kt
@@ -184,10 +184,7 @@ internal class DdAndroidGradlePluginResolveApiKeyTest : DdAndroidGradlePluginTes
         fakeProject = ProjectBuilder.builder()
             .withProjectDir(subProject)
             .build()
-        testedPlugin = DdAndroidGradlePlugin(
-            execOps = mock(),
-            providerFactory = fakeProject.providers
-        )
+        testedPlugin = DdAndroidGradlePlugin(execOps = mock())
 
         // When
         val apiKey = testedPlugin.resolveApiKey(fakeProject).get()

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTestBase.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginTestBase.kt
@@ -18,10 +18,8 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.gradle.api.Project
-import org.gradle.api.Transformer
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
@@ -29,10 +27,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.util.UUID
@@ -78,10 +73,7 @@ internal abstract class DdAndroidGradlePluginTestBase {
         fakeFlavorNames = fakeFlavorNames.take(5) // A D F G A♭ A A♭ G F
         fakeBuildId = forge.getForgery<UUID>().toString()
         fakeProject = ProjectBuilder.builder().build()
-        testedPlugin = DdAndroidGradlePlugin(
-            execOps = mock(),
-            providerFactory = fakeProject.providers
-        )
+        testedPlugin = DdAndroidGradlePlugin(execOps = mock())
 
         setEnv(DdAndroidGradlePlugin.DD_API_KEY, "")
         setEnv(DdAndroidGradlePlugin.DATADOG_API_KEY, "")
@@ -91,14 +83,6 @@ internal abstract class DdAndroidGradlePluginTestBase {
 
     protected fun List<String>.variantName(): String {
         return first() + drop(1).joinToString("") { it.replaceFirstChar { capitalizeChar(it) } }
-    }
-
-    protected fun mockBuildIdGenerationTask(buildId: String): TaskProvider<GenerateBuildIdTask> {
-        return mock<TaskProvider<GenerateBuildIdTask>>().apply {
-            whenever(
-                flatMap(any<Transformer<Provider<String>, GenerateBuildIdTask>>())
-            ) doReturn buildId.asProvider()
-        }
     }
 
     protected fun <T : Any> T.asProvider(): Provider<T> {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/MappingFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/MappingFileUploadTaskTest.kt
@@ -124,7 +124,7 @@ internal class MappingFileUploadTaskTest {
         testedTask.versionCode.set(fakeVersionCode)
         testedTask.serviceName.set(fakeService)
         testedTask.site = fakeSite.name
-        testedTask.buildId.set(fakeBuildId)
+        writeBuildIdFile(fakeBuildId)
         testedTask.mappingFile.set(fakeProject.objects.fileProperty().fileValue(File(tempDir, fakeMappingFileName)))
         setEnv(FileUploadTask.DATADOG_SITE, "")
     }
@@ -473,7 +473,7 @@ internal class MappingFileUploadTaskTest {
         val fakeMappingFile = File(tempDir, fakeMappingFileName)
         fakeMappingFile.writeText(fakeMappingFileContent)
         testedTask.mappingFile.set(fakeProject.objects.fileProperty().fileValue(File(fakeMappingFile.path)))
-        testedTask.buildId.set(null as String?)
+        testedTask.buildIdFile.set(null as File?)
 
         // When
         val exception = assertThrows<IllegalStateException> {
@@ -491,7 +491,7 @@ internal class MappingFileUploadTaskTest {
         val fakeMappingFile = File(tempDir, fakeMappingFileName)
         fakeMappingFile.writeText(fakeMappingFileContent)
         testedTask.mappingFile.set(fakeProject.objects.fileProperty().fileValue(File(fakeMappingFile.path)))
-        testedTask.buildId.set("")
+        writeBuildIdFile("")
 
         // When
         val exception = assertThrows<IllegalStateException> {
@@ -773,6 +773,12 @@ internal class MappingFileUploadTaskTest {
 
     private fun fileFromResourcesPath(resourceFilePath: String): File {
         return File(javaClass.classLoader.getResource(resourceFilePath)!!.file)
+    }
+
+    private fun writeBuildIdFile(buildId: String) {
+        val buildIdFile = File(tempDir, GenerateBuildIdTask.BUILD_ID_FILE_NAME)
+        buildIdFile.writeText(buildId)
+        testedTask.buildIdFile.fileValue(buildIdFile)
     }
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTaskTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/NdkSymbolFileUploadTaskTest.kt
@@ -113,7 +113,7 @@ internal class NdkSymbolFileUploadTaskTest {
         fakeBuildId = forge.getForgery<UUID>().toString()
 
         testedTask.searchDirectories.from(tempDir)
-        testedTask.buildId.set(fakeBuildId)
+        writeBuildIdFile(fakeBuildId)
 
         val fakeConfiguration = with(DdExtensionConfiguration()) {
             versionName = fakeVersion
@@ -402,7 +402,7 @@ internal class NdkSymbolFileUploadTaskTest {
     @Test
     fun `M throw error W applyTask() {buildId is missing}`() {
         // Given
-        testedTask.buildId.set(null as String?)
+        testedTask.buildIdFile.set(null as File?)
         writeFakeSoFile("arm64-v8a")
 
         // When
@@ -418,7 +418,7 @@ internal class NdkSymbolFileUploadTaskTest {
     @Test
     fun `M throw error W applyTask() {buildId is empty string}`() {
         // Given
-        testedTask.buildId.set("")
+        writeBuildIdFile("")
         writeFakeSoFile("arm64-v8a")
 
         // When
@@ -689,5 +689,11 @@ internal class NdkSymbolFileUploadTaskTest {
         fakeSoFile.writeText("fake")
 
         return fakeSoFile
+    }
+
+    private fun writeBuildIdFile(buildId: String) {
+        val buildIdFile = File(tempDir, GenerateBuildIdTask.BUILD_ID_FILE_NAME)
+        buildIdFile.writeText(buildId)
+        testedTask.buildIdFile.fileValue(buildIdFile)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR brings configuration cache support for the Upload Mapping task.

Before it was using [notCompatibleWithConfigurationCache](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-task/not-compatible-with-configuration-cache.html) API which has a specific behaviour in the configuration cache warn mode:

> The presence of incompatible tasks in the task graph will cause the configuration state to be discarded at the end of the build unless the global configuration-cache-problems option is set to warn, in which case the configuration state would still be cached in a best-effort manner as usual for the option.

That was causing `Build ID is missing ...` error.

Potentially it may address https://github.com/DataDog/dd-sdk-android-gradle-plugin/issues/516.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

