### PR TITLE
RUM-16046: Fix oom in test:plugin

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -102,6 +102,9 @@ test:plugin:
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
+  variables:
+    # Functional test is very memory heavy due to spinning real Gradle runners, having daemons in memory
+    KUBERNETES_MEMORY_LIMIT: "25Gi"
   script:
     - rm -rf ~/.gradle/daemon/
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -1657,7 +1657,8 @@ internal class DdAndroidGradlePluginFunctionalTest {
             include(":samples:lib-module")
         """
         val GRADLE_PROPERTIES_FILE_CONTENT = """
-           org.gradle.jvmargs=-Xmx2560m
+           org.gradle.jvmargs=-Xmx1280m
+           org.gradle.daemon.idletimeout=10000
            android.useAndroidX=true
            agpVersion=%s
            buildToolsVersion=%s


### PR DESCRIPTION
### What does this PR do?

@0xnm: picking work of @aleksandr-gringauz, because cannot get through https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/557 and https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/556 due to OOM.

Changes are:

* reducing daemon heap size
* killing daemon after 10s of inactivity
* bumping memory limit to 25GB, just to have more space available 

seems it helps a bit, working set doesn't cross the memory limit:

<img width="559" height="238" alt="image" src="https://github.com/user-attachments/assets/d3074b95-308a-4610-bd0d-acc576e54b6a" />

we can do other changes later if this is not enough.

The reason for OOM at the container level is having daemons in the `GradleRunner` invocations:

`GradleRunner` always runs through a real Gradle daemon (it has no `--no-daemon` mode). The daemon is a separate JVM that the test JVM cannot directly stop, and TestKit keeps it alive for the daemon's idle timeout (default 2 minutes for TestKit) — meaning daemons easily outlive the tests that spawned them.

  A few specifics in `DdAndroidGradlePluginFunctionalTest.kt` that compound this:

  1. Three Gradle versions in play: `TESTED_CONFIGURATIONS` runs against 7.4 and 9.4.0, plus one test at line 1048-1054 pinned to 8.14.1. TestKit keeps a separate daemon pool per Gradle version, so you can have 3
  long-lived daemon JVMs in parallel.
  2. Each TestKit daemon is sized at `-Xmx2560m` via `GRADLE_PROPERTIES_FILE_CONTENT` (line 1660) — and that daemon then forks its own workers for AGP / Kotlin compiler / R8 / D8.
  3. Each test runs a real `assembleRelease` / `bundleRelease` with R8 minification on 4 variants (`demoBlue`, `demoGreen`, `fullBlue`, `fullGreen`) — peak memory of those forked workers can hit several GB on top of the daemon.

Keeping daemons for now, because `DdAndroidGradlePluginFunctionalTest` execution is already quite long.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

