### PR TITLE
RUM-16082: Limit Jetpack Compose instrumentation only to Android compilations

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -448,7 +448,7 @@ class DdAndroidGradlePlugin @Inject constructor(
     }
 
     /**
-     * Returns the set of names registered in [extension.variants] that do not correspond to any
+     * Returns the set of names registered in [DdExtension.variants] that do not correspond to any
      * real partial variant combination generated from [knownVariants].
      *
      * Uses [VariantIterator] to produce all valid partial names for each real variant (the same
@@ -564,7 +564,7 @@ class DdAndroidGradlePlugin @Inject constructor(
         internal const val UPLOAD_TASK_NAME = "uploadMapping"
 
         private const val ERROR_NOT_ANDROID = "The dd-android-gradle-plugin has been applied on " +
-            "a non android application project"
+            "a non-Android application project"
 
         private const val MSG_PLUGIN_DISABLED =
             "Datadog extension disabled, no upload task created, no Compose instrumentation applied"

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
@@ -12,6 +12,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
@@ -19,9 +20,9 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 /**
  * Support class for configuring the Datadog Kotlin Compiler Plugin based on the Kotlin version.
  * This class implements [KotlinCompilerPluginSupportPlugin] to properly integrate with the
- * Kotlin Gradle Plugin and target the correct version-specific subplugin.
+ * Kotlin Gradle Plugin and target the correct version-specific sub-plugin.
  *
- * The plugin points to different subplugin based on kotlin compiler version (kotlin20, kotlin21, kotlin22).
+ * The plugin points to different sub-plugin based on kotlin compiler version (kotlin20, kotlin21, kotlin22).
  *
  */
 class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
@@ -31,17 +32,26 @@ class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
 
     @Suppress("ReturnCount")
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
-        val project = kotlinCompilation.target.project
+        val kotlinTarget = kotlinCompilation.target
+        if (kotlinTarget.platformType != KotlinPlatformType.androidJvm) {
+            // TODO RUM-16076 Explore .common type support
+            LOGGER.info(
+                "Datadog Jetpack Compose instrumentation cannot be" +
+                    " applied to the Kotlin Compilation of platform type = ${kotlinTarget.platformType}"
+            )
+            return false
+        }
+        val project = kotlinTarget.project
         kgpVersion = project.getKotlinPluginVersion()
         kotlinVersion = KotlinVersion.from(kgpVersion)
         if (kotlinVersion == KotlinVersion.UNSUPPORTED) {
-            LOGGER.debug("Unsupported Kotlin version for the Datadog Jetpack Compose instrumentation: \$kgpVersion\"")
+            LOGGER.info("Unsupported Kotlin version for the Datadog Jetpack Compose instrumentation: \$kgpVersion\"")
             return false
         }
         val ddExtension = project.extensions.findByType(DdExtension::class.java) ?: return false
 
         if (ddExtension.composeInstrumentation == InstrumentationMode.DISABLE) {
-            LOGGER.debug("Datadog Jetpack Compose instrumentation is disabled")
+            LOGGER.info("Datadog Jetpack Compose instrumentation is disabled")
             return false
         }
 


### PR DESCRIPTION
### What does this PR do?

In the Kotlin Multiplatform project Kotlin compilations can be for different platform targets, so for now limit Jetpack Compose instrumentation only to Android, we can explore Compose Multiplatform later.

Otherwise it is applied to non-Android compilations and can fail with something like:

```
:some-feature:compileKotlinIosSimulatorArm64 FAILED error: java.lang.NoClassDefFoundError: com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

