### PR TITLE
Remove Kotlin Compiler Embeddable from the dependencies of the main plugin module

### DIFF
--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     implementation(libs.json)
     // Compile-only dependencies
     compileOnly(libs.androidToolsGradlePlugin) // for auto-wiring into Android projects
-    compileOnly(libs.kotlinCompilerEmbeddable)
     compileOnly(libs.kotlinGradlePlugin21)
 
     // Test dependencies


### PR DESCRIPTION
### What does this PR do?

This dependency is unused.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

