### PR TITLE
RUM-16378: Resolve dependencies through Magic Mirror Depot in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,15 @@ variables:
   KUBERNETES_MEMORY_REQUEST: "8Gi"
   KUBERNETES_MEMORY_LIMIT: "20Gi"
 
+  # Magic Mirror Depot proxy URLs. The depot proxies both Maven Central and the Gradle
+  # Plugin Portal for the Java ecosystem from the same endpoint. Setting these routes
+  # dependency/plugin resolution through Datadog's internal mirror to avoid HTTP 429
+  # rate-limits from upstream registries.
+  # Declared as ORG_GRADLE_PROJECT_* so Gradle reads them as
+  # `providers.gradleProperty("<name>")` and they propagate to triggered child pipelines.
+  ORG_GRADLE_PROJECT_mavenRepositoryProxy: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
+  ORG_GRADLE_PROJECT_gradlePluginProxy: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
+
 include:
   - local: 'ci/pipelines/default-pipeline.yml'
     rules:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,10 @@
 
 buildscript {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven { setUrl(url) } }
         google()
         mavenCentral()
         gradlePluginPortal()
@@ -29,6 +33,10 @@ plugins {
 
 allprojects {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven(url) }
         google()
         mavenCentral()
         maven("https://jitpack.io")

--- a/dd-sdk-android-gradle-plugin-kcp-common/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-common/build.gradle.kts
@@ -29,10 +29,6 @@ plugins {
     id("datadogBuildConfig")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compileOnly(libs.kotlinCompilerEmbeddable20)
     compileOnly(libs.kotlinGradlePlugin20)

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/build.gradle.kts
@@ -28,10 +28,6 @@ plugins {
     id("datadogBuildConfig")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(project(":dd-sdk-android-gradle-plugin-kcp-common"))
     compileOnly(libs.kotlinCompilerEmbeddable20)

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/build.gradle.kts
@@ -28,10 +28,6 @@ plugins {
     id("datadogBuildConfig")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(project(":dd-sdk-android-gradle-plugin-kcp-common"))
     compileOnly(libs.kotlinCompilerEmbeddable21)

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/build.gradle.kts
@@ -28,10 +28,6 @@ plugins {
     id("datadogBuildConfig")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(project(":dd-sdk-android-gradle-plugin-kcp-common"))
     compileOnly(libs.kotlinCompilerEmbeddable22)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@
 
 pluginManagement {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven(url) }
         google()
         gradlePluginPortal()
         mavenCentral()

--- a/tools/build-config/build.gradle.kts
+++ b/tools/build-config/build.gradle.kts
@@ -11,11 +11,19 @@ plugins {
 
 buildscript {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven { setUrl(url) } }
         mavenCentral()
     }
 }
 
 repositories {
+    // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+    listOf("gradlePluginProxy", "mavenRepositoryProxy")
+        .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+        .forEach { url -> maven { setUrl(url) } }
     mavenCentral()
     google()
     maven { setUrl("https://plugins.gradle.org/m2/") }

--- a/tools/build-config/settings.gradle.kts
+++ b/tools/build-config/settings.gradle.kts
@@ -6,6 +6,10 @@
 
 pluginManagement {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven(url) }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
### What does this PR do?

Routes Gradle dependency and plugin resolution through Datadog's internal Magic Mirror Depot (`depot-read-api-java`) when running in GitLab CI, to eliminate HTTP 429 rate-limits from public registries (Maven Central, Gradle Plugin Portal, Google's Android Maven).

The change is gated behind two Gradle properties (`mavenRepositoryProxy`, `gradlePluginProxy`) that are only set in CI via `.gitlab-ci.yml`. Local builds with no properties set are a strict no-op; the existing public registries (`mavenCentral`, `gradlePluginPortal`, `google`, `jitpack`) remain as fallbacks in every `repositories { }` block.

Concretely:

- **CI configuration** — `.gitlab-ci.yml` declares `ORG_GRADLE_PROJECT_mavenRepositoryProxy` and `ORG_GRADLE_PROJECT_gradlePluginProxy` env vars pointing at the depot URL. Gradle reads any `ORG_GRADLE_PROJECT_<name>` env var as `providers.gradleProperty("<name>")`, and the env vars naturally inherit to child Gradle processes via the shell environment.
- **Gradle build files** — a depot-proxy snippet is inlined at the top of every `repositories { }` block that contributes to dependency or plugin resolution:
  - Root `build.gradle.kts` — `buildscript { repositories { ... } }` and `allprojects { repositories { ... } }`
  - Root `settings.gradle.kts` — existing `pluginManagement { repositories { ... } }`
  - `tools/build-config/build.gradle.kts` — `buildscript { repositories { ... } }` and the top-level `repositories { ... }`
  - `tools/build-config/settings.gradle.kts` — `pluginManagement { repositories { ... } }`

  Each snippet prepends the depot URL(s) (when the proxy properties are set) ahead of the existing fallbacks; everything is a no-op when the properties are absent.
- **Cleanup** — removed redundant `repositories { mavenCentral() }` blocks from each `dd-sdk-android-gradle-plugin-kcp-*` module — they were overrides of (and a strict subset of) the root `allprojects` block, and removing them ensures the proxy reaches those subprojects too.

### Motivation

CI on this repo started hitting HTTP 429 again when downloading dependencies from Maven Central and the Gradle Plugin Portal, causing flaky/failed pipelines. Datadog has an internal solution (Magic Mirror Depot, exposed via `depot-read-api-java`) designed exactly for this; `dd-sdk-android` already migrated to it in [#3452](https://github.com/DataDog/dd-sdk-android/pull/3452), itself modeled on the `dd-trace-java` migration in [#9351](https://github.com/DataDog/dd-trace-java/pull/9351) and [#9802](https://github.com/DataDog/dd-trace-java/pull/9802) (which switched property injection from `gradle.properties` file writes to `ORG_GRADLE_PROJECT_*` environment variables). This PR brings the same approach to `dd-sdk-android-gradle-plugin`.

Tracking issue: [RUM-16378](https://datadoghq.atlassian.net/browse/RUM-16378).

### Additional Notes

**How to verify:**

1. **No-op locally** — build without the proxy properties (the normal developer flow) shows no behavior change. Confirmed via `./gradlew :dd-sdk-android-gradle-plugin:compileKotlin` and `./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin22:dependencies` with a cold cache; resolves entirely from public registries as today.
2. **Depot routing** — verified locally with an isolated `GRADLE_USER_HOME=/tmp/...` clean-room. Running `./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin22:dependencies --configuration testRuntimeClasspath -PgradlePluginProxy=... -PmavenRepositoryProxy=... --info` against an empty cache produced every fresh artifact download from `depot-read-api-java.us1.ddbuild.io`, with zero traffic to `repo.maven.apache.org`, `plugins.gradle.org`, `dl.google.com`, `central.sonatype.com`, or `jitpack.io`.
3. **Existing test suites pass** — full CI pipeline is expected to stay green; this PR is opened as a draft until CI confirms.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-16378]: https://datadoghq.atlassian.net/browse/RUM-16378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ