### PR TITLE
Refactor compiler test infrastructure to support pluggable registrar APIs

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTest.kt
@@ -11,7 +11,6 @@ import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -29,29 +28,13 @@ abstract class KotlinCompilerTest {
     @Mock
     protected lateinit var mockCallback: (Boolean) -> Unit
 
-    abstract fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar
-
-    private val trackingEffectSourceFileContent = SourceFile.kotlin(
-        TRACKING_EFFECT_FILE_NAME,
-        TRACKING_EFFECT_SOURCE_FILE_CONTENT
-    )
-
-    private val datadogModifierSourceFileContent = SourceFile.kotlin(
-        DD_MODIFIER_CLASS_FILE_NAME,
-        DD_MODIFIER_SOURCE_FILE_CONTENT
-    )
-
-    private val composeInstrumentationAnnotationSourceFileContent = SourceFile.kotlin(
-        COMPOSE_INSTRUMENTATION_ANNOTATION_FILE_NAME,
-        COMPOSE_INSTRUMENTATION_ANNOTATION_SOURCE_FILE_CONTENT
+    abstract fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
     )
 
     // TODO RUM-8950: Dependency file should be separated in each file after the DSL configuration is introduced.
-    protected val dependencyFiles = listOf(
-        trackingEffectSourceFileContent,
-        datadogModifierSourceFileContent,
-        composeInstrumentationAnnotationSourceFileContent
-    )
+    protected val dependencyFiles = KotlinCompilerTestSources.dependencyFiles
 
     protected fun compileFile(
         target: SourceFile,
@@ -59,17 +42,16 @@ abstract class KotlinCompilerTest {
         enablePlugin: Boolean = true,
         instrumentationMode: InstrumentationMode = InstrumentationMode.AUTO
     ): JvmCompilationResult {
-        val pluginRegistrars = if (enablePlugin) {
-            listOf(getDatadogPluginRegistrar(instrumentationMode))
-        } else {
-            listOf()
-        }
-
         return KotlinCompilation().apply {
             sources = deps + target
-            componentRegistrars = pluginRegistrars
+            if (enablePlugin) {
+                registerDatadogPluginRegistrar(this, instrumentationMode)
+            }
             inheritClassPath = true
             messageOutputStream = System.out
+            // Kotlin 2.4.0 made CommonCompilerArguments.setOptIn non-null; kctfork
+            // defaults this property to null, which triggers a NPE in the setter.
+            optIn = emptyList()
         }.compile()
     }
 
@@ -81,9 +63,9 @@ abstract class KotlinCompilerTest {
         methodArgs: List<Any> = emptyList()
     ) {
         val deps = listOf(
-            NAV_HOST_BUILDER_PATH,
-            NAV_GRAPH_BUILDER_PATH,
-            NAV_HOST_CONTROLLER_PATH
+            KotlinCompilerTestSources.NAV_HOST_BUILDER_PATH,
+            KotlinCompilerTestSources.NAV_GRAPH_BUILDER_PATH,
+            KotlinCompilerTestSources.NAV_HOST_CONTROLLER_PATH
         )
 
         deps.forEach {
@@ -91,7 +73,7 @@ abstract class KotlinCompilerTest {
         }
 
         // Setup the TestCallbackContainer and the mock callback.
-        val testCallbackContainerClazz = classLoader.loadClass(TEST_CALLBACK_CONTAINER_PATH)
+        val testCallbackContainerClazz = classLoader.loadClass(KotlinCompilerTestSources.TEST_CALLBACK_CONTAINER_PATH)
         val setCallbackFunc = testCallbackContainerClazz.kotlin.declaredFunctions.find { it.name == "setCallback" }
         val testCallbackContainerInstance = testCallbackContainerClazz.getField("INSTANCE").get(null)
         setCallbackFunc?.call(testCallbackContainerInstance, mockCallback)
@@ -104,73 +86,5 @@ abstract class KotlinCompilerTest {
         // Call the function.
         val args = methodArgs.toTypedArray()
         method?.call(instance, *args)
-    }
-
-    companion object {
-
-        private const val TEST_CALLBACK_CONTAINER_PATH = "com.datadog.gradle.plugin.kcp.TestCallbackContainer"
-        private const val NAV_GRAPH_BUILDER_PATH = "androidx.navigation.compose.NavGraphBuilder"
-        private const val NAV_HOST_BUILDER_PATH = "androidx.navigation.compose.NavHost"
-        private const val NAV_HOST_CONTROLLER_PATH = "androidx.navigation.NavHostController"
-        private const val TRACKING_EFFECT_FILE_NAME = "Navigation.kt"
-        private const val DD_MODIFIER_CLASS_FILE_NAME = "DatadogModifier.kt"
-        private const val COMPOSE_INSTRUMENTATION_ANNOTATION_FILE_NAME = "ComposeInstrumentation.kt"
-
-        @Language("kotlin")
-        private val DD_MODIFIER_SOURCE_FILE_CONTENT =
-            """
-            package com.datadog.android.compose
-            
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.semantics.SemanticsPropertyKey
-            import androidx.compose.ui.semantics.SemanticsPropertyReceiver
-            import androidx.compose.ui.semantics.semantics
-            import com.datadog.gradle.plugin.kcp.TestCallbackContainer
-            
-            fun Modifier.instrumentedDatadog(name: String, isImageRole: Boolean = false): Modifier {
-                TestCallbackContainer.invokeCallback(isImageRole)
-                return this.semantics {
-                    this.datadog = name
-                }
-            }
-            
-            internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
-                name = "_dd_semantics",
-                mergePolicy = { parentValue, childValue ->
-                    parentValue
-                }
-            )
-
-            private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
-            """.trimIndent()
-
-        @Language("kotlin")
-        private val TRACKING_EFFECT_SOURCE_FILE_CONTENT =
-            """
-            package com.datadog.android.compose
-
-            import androidx.compose.runtime.Composable
-            import androidx.navigation.NavController
-            import androidx.navigation.NavDestination
-            import com.datadog.gradle.plugin.kcp.TestCallbackContainer
-            
-            
-            @Composable
-            fun InstrumentedNavigationViewTrackingEffect(
-                navController: NavController
-            ) {
-                TestCallbackContainer.invokeCallback()
-            }
-            """.trimIndent()
-
-        @Language("kotlin")
-        private val COMPOSE_INSTRUMENTATION_ANNOTATION_SOURCE_FILE_CONTENT =
-            """
-            package com.datadog.android.compose
-
-            @Retention(AnnotationRetention.BINARY)
-            annotation class ComposeInstrumentation
-
-            """.trimIndent()
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTestSources.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTestSources.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import com.tschuchort.compiletesting.SourceFile
+import org.intellij.lang.annotations.Language
+
+object KotlinCompilerTestSources {
+
+    const val TEST_CALLBACK_CONTAINER_PATH = "com.datadog.gradle.plugin.kcp.TestCallbackContainer"
+    const val NAV_GRAPH_BUILDER_PATH = "androidx.navigation.compose.NavGraphBuilder"
+    const val NAV_HOST_BUILDER_PATH = "androidx.navigation.compose.NavHost"
+    const val NAV_HOST_CONTROLLER_PATH = "androidx.navigation.NavHostController"
+    const val TRACKING_EFFECT_FILE_NAME = "Navigation.kt"
+    const val DD_MODIFIER_CLASS_FILE_NAME = "DatadogModifier.kt"
+    const val COMPOSE_INSTRUMENTATION_ANNOTATION_FILE_NAME = "ComposeInstrumentation.kt"
+
+    @Language("kotlin")
+    val DD_MODIFIER_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.compose
+
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.semantics.SemanticsPropertyKey
+        import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+        import androidx.compose.ui.semantics.semantics
+        import com.datadog.gradle.plugin.kcp.TestCallbackContainer
+
+        fun Modifier.instrumentedDatadog(name: String, isImageRole: Boolean = false): Modifier {
+            TestCallbackContainer.invokeCallback(isImageRole)
+            return this.semantics {
+                this.datadog = name
+            }
+        }
+
+        internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
+            name = "_dd_semantics",
+            mergePolicy = { parentValue, childValue ->
+                parentValue
+            }
+        )
+
+        private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
+        """.trimIndent()
+
+    @Language("kotlin")
+    val TRACKING_EFFECT_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.compose
+
+        import androidx.compose.runtime.Composable
+        import androidx.navigation.NavController
+        import androidx.navigation.NavDestination
+        import com.datadog.gradle.plugin.kcp.TestCallbackContainer
+
+
+        @Composable
+        fun InstrumentedNavigationViewTrackingEffect(
+            navController: NavController
+        ) {
+            TestCallbackContainer.invokeCallback()
+        }
+        """.trimIndent()
+
+    @Language("kotlin")
+    val COMPOSE_INSTRUMENTATION_ANNOTATION_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.compose
+
+        @Retention(AnnotationRetention.BINARY)
+        annotation class ComposeInstrumentation
+
+        """.trimIndent()
+
+    val trackingEffectSourceFile = SourceFile.kotlin(
+        TRACKING_EFFECT_FILE_NAME,
+        TRACKING_EFFECT_SOURCE_FILE_CONTENT
+    )
+
+    val datadogModifierSourceFile = SourceFile.kotlin(
+        DD_MODIFIER_CLASS_FILE_NAME,
+        DD_MODIFIER_SOURCE_FILE_CONTENT
+    )
+
+    val composeInstrumentationAnnotationSourceFile = SourceFile.kotlin(
+        COMPOSE_INSTRUMENTATION_ANNOTATION_FILE_NAME,
+        COMPOSE_INSTRUMENTATION_ANNOTATION_SOURCE_FILE_CONTENT
+    )
+
+    // TODO RUM-8950: Dependency file should be separated in each file after the DSL configuration is introduced.
+    val dependencyFiles = listOf(
+        trackingEffectSourceFile,
+        datadogModifierSourceFile,
+        composeInstrumentationAnnotationSourceFile
+    )
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation20Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation20Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeNavHostCompilation20Test : ComposeNavHostCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation20Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation20Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeTagCompilation20Test : ComposeTagCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation21Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation21Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeNavHostCompilation21Test : ComposeNavHostCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation21Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation21Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeTagCompilation21Test : ComposeTagCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation22Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation22Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeNavHostCompilation22Test : ComposeNavHostCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation22Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation22Test.kt
@@ -7,9 +7,15 @@
 package com.datadog.gradle.plugin.kcp
 
 import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
+@OptIn(ExperimentalCompilerApi::class)
 class ComposeTagCompilation22Test : ComposeTagCompilationTest() {
-    override fun getDatadogPluginRegistrar(instrumentationMode: InstrumentationMode): DatadogPluginRegistrar {
-        return DatadogPluginRegistrarImpl(instrumentationMode)
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.componentRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR is to prepare for the new version of `dev.zacsweers.kctfork:core` - Kotlin Compiler testing library, which is required for the adoption of Kotlin 2.4.0, in this version 0.12.1, `componentRegistrars` is removed from `KotlinCompilation` class, so we need to expose it through an abstract function and let each module to implement it.

There are also two following changes:
* Move all the constant into a dedicated file to make `KotlinCompilerTest` less fat
* added optIn = emptyList() to fix a NPE with Kotlin 2.4.0's non-null setOptIn.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

