### PR TITLE
Bump Kotlin version to 2.3.20 for the project

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -7,6 +7,7 @@ build,org.jetbrains.dokka,Apache-2.0,"Copyright 2014-2019 JetBrains s.r.o. and D
 build,org.jetbrains.intellij.deps,LGPL-2.1-only,"Copyright (c) 2001-2002, Eric D. Friedman, Jason Baldridge, Copyright (c) 1999 CERN - European Organization for Nuclear Research"
 import,com.android.tools.build,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
 import,com.squareup.okhttp3,Apache-2.0,"Copyright 2019 Square, Inc"
+import,org.bouncycastle,BouncyCastle-License,"Copyright (c) 2000 - 2026 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)""
 import,org.jetbrains,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,com.google.auto.service,Apache-2.0,Copyright 2013 Google LLC

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ buildscript {
 }
 
 plugins {
-    alias(libs.plugins.kotlinPlugin21) apply false
+    alias(libs.plugins.kotlinPlugin23) apply false
     alias(libs.plugins.dokkaJavadocPlugin) apply false
     alias(libs.plugins.androidApplicationPlugin) apply false
     alias(libs.plugins.androidLibraryPlugin) apply false

--- a/dd-sdk-android-gradle-plugin-kcp-common/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=2.1.0
+kotlin_abi_version=2.3.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTest.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTest.kt
@@ -52,6 +52,10 @@ abstract class KotlinCompilerTest {
             // Kotlin 2.4.0 made CommonCompilerArguments.setOptIn non-null; kctfork
             // defaults this property to null, which triggers a NPE in the setter.
             optIn = emptyList()
+            // The project modules are compiled with a newer Kotlin version than the embedded
+            // compiler used in kotlin20/21/22 test modules. Skip the metadata version check
+            // so the embedded compiler can read classes compiled with a newer metadata format.
+            kotlincArguments += "-Xskip-metadata-version-check"
         }.compile()
     }
 

--- a/dd-sdk-android-gradle-plugin-kcp-common/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin-kcp-common/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20                       : 1762 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1700 Kb
+Total transitive dependencies size                              : 1779 Kb
 

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=2.1.0
+kotlin_abi_version=2.3.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20                       : 1762 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1700 Kb
+Total transitive dependencies size                              : 1779 Kb
 

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=2.1.0
+kotlin_abi_version=2.3.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20                       : 1762 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1700 Kb
+Total transitive dependencies size                              : 1779 Kb
 

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=2.1.0
+kotlin_abi_version=2.3.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20                       : 1762 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1700 Kb
+Total transitive dependencies size                              : 1779 Kb
 

--- a/dd-sdk-android-gradle-plugin/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=2.1.0
+kotlin_abi_version=2.3.0
 jvm_bytecode_version=11

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 kotlin20 = "2.0.21"
 kotlin21 = "2.1.21"
 kotlin22 = "2.2.20"
+kotlin23 = "2.3.20"
 kotlinComposePlugin = "2.1.21"
 json = "20231013"
 okHttp = "4.12.0"
@@ -171,7 +172,7 @@ testTools = [
 dokkaJavadocPlugin = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 androidApplicationPlugin = { id = "com.android.application", version.ref = "androidToolsPlugin" }
 androidLibraryPlugin = { id = "com.android.library", version.ref = "androidToolsPlugin" }
-kotlinPlugin21 = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin21" }
+kotlinPlugin23 = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin23" }
 mavenPublishPlugin = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublishPlugin" }
 versionsPluginGradle = { id = "com.github.ben-manes.versions", version.ref = "versionsPluginGradle" }
 kotlinComposePlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinComposePlugin" }

--- a/instrumented/build.gradle.kts
+++ b/instrumented/build.gradle.kts
@@ -72,8 +72,9 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
 
     kotlinCompilerPluginClasspath(project(":dd-sdk-android-gradle-plugin-kcp-common"))
-    kotlinCompilerPluginClasspath(project(":dd-sdk-android-gradle-plugin-kcp-kotlin21"))
-    // We use kotlin21 because the kotlin compiler for this project is kotlin 2.1.x
+    kotlinCompilerPluginClasspath(project(":dd-sdk-android-gradle-plugin-kcp-kotlin22"))
+    // We use kotlin22 because the kotlin compiler for this project is kotlin 2.3.x
+    // Kotlin Compiler 2.3.x can not read kotlin21 through classpath.
     implementation(project(":samples:lib-module"))
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.runtime.ktx)


### PR DESCRIPTION
### What does this PR do?

To be able to compile to incoming kotlin 2.4.0 artifact, we need to Bump Kotlin version from 2.1.21 to 2.3.20.

It is tested that after bumping the version, the app with 2.1.21 can still use the plugin.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

