### PR TITLE
Setup kotlin24 module to support kotlin 2.4

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -200,6 +200,26 @@ test:kotlin22:
     reports:
       junit: dd-sdk-android-gradle-plugin-kcp-kotlin22/build/test-results/test/TEST-*.xml
 
+test:kotlin24:
+  tags: [ "arch:amd64" ]
+  image: $CI_IMAGE_DOCKER
+  stage: test
+  timeout: 1h
+  script:
+    - rm -rf ~/.gradle/daemon/
+    - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android-gradle-plugin.codecov-token --with-decryption --query "Parameter.Value" --out text)
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
+    - GRADLE_OPTS="-Xmx2560m" DD_TAGS="test.module:dd-sdk-android-gradle-plugin-kcp-kotlin24" ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin24:test --stacktrace --no-daemon -Dorg.gradle.jvmargs=-javaagent:$(pwd)/libs/dd-java-agent-1.54.0.jar=$DD_COMMON_AGENT_CONFIG
+    - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - |
+      if [ -n "$DD_API_KEY" ]; then
+        curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+        datadog-ci coverage upload --format=jacoco . || true
+      fi
+  artifacts:
+    reports:
+      junit: dd-sdk-android-gradle-plugin-kcp-kotlin24/build/test-results/test/TEST-*.xml
+
 test:build-config:
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
@@ -252,6 +272,7 @@ publish:publish-sonatype:
     - ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin20:publishMavenPublicationToMavenCentralRepository --stacktrace --no-daemon
     - ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin21:publishMavenPublicationToMavenCentralRepository --stacktrace --no-daemon
     - ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin22:publishMavenPublicationToMavenCentralRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-gradle-plugin-kcp-kotlin24:publishMavenPublicationToMavenCentralRepository --stacktrace --no-daemon
 
 publish:publish-gradle-portal:
   tags: [ "arch:amd64" ]

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=2.3.0
+jvm_bytecode_version=11

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/build.gradle.kts
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+plugins {
+    id("java-library")
+    kotlin("jvm")
+    kotlin("kapt")
+
+    // Publish
+    `maven-publish`
+    signing
+    id("org.jetbrains.dokka-javadoc")
+    id("com.vanniktech.maven.publish.base")
+
+    // Analysis tools
+    id("com.github.ben-manes.versions")
+
+    // Tests
+    jacoco
+
+    // Internal Generation
+    id("thirdPartyLicences")
+    id("transitiveDependencies")
+    id("compilerMetadata")
+    id("datadogBuildConfig")
+}
+
+dependencies {
+    implementation(project(":dd-sdk-android-gradle-plugin-kcp-common"))
+    compileOnly(libs.kotlinCompilerEmbeddable24)
+    compileOnly(libs.kotlinGradlePlugin24)
+    compileOnly(libs.autoServiceAnnotation)
+    compileOnly(libs.kotlinReflect)
+    kapt(libs.autoService)
+
+    testImplementation(testFixtures(project(":dd-sdk-android-gradle-plugin-kcp-common")))
+    testImplementation(libs.kotlinCompilerEmbeddable24)
+    testImplementation(libs.kotlinGradlePlugin24)
+    testImplementation(libs.kotlinCompilerTesting24)
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+datadogBuildConfig {
+    applyKotlinConfig()
+    applyJunitConfig()
+    applyJacocoConfig()
+    applyJavadocConfig()
+    applyDependencyUpdateConfig()
+    applyPublishingConfig("Module to support Datadog Compiler Plugin with kotlin 2.4.x or above")
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrarImpl.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrarImpl.kt
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+/**
+ * Place holder for later implementation.
+ */
+class DatadogPluginRegistrarImpl

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/transitiveDependencies
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/transitiveDependencies
@@ -1,0 +1,7 @@
+Dependencies List
+
+org.jetbrains.kotlin:kotlin-stdlib:2.3.20                       : 1762 Kb
+org.jetbrains:annotations:13.0                                  :   17 Kb
+
+Total transitive dependencies size                              : 1779 Kb
+

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
@@ -81,6 +81,7 @@ class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
             KotlinVersion.KOTLIN19, KotlinVersion.KOTLIN20 -> "$PLUGIN_ARTIFACT_ID_PREFIX-kotlin20"
             KotlinVersion.KOTLIN21 -> "$PLUGIN_ARTIFACT_ID_PREFIX-kotlin21"
             KotlinVersion.KOTLIN22 -> "$PLUGIN_ARTIFACT_ID_PREFIX-kotlin22"
+            KotlinVersion.KOTLIN24 -> "$PLUGIN_ARTIFACT_ID_PREFIX-kotlin24"
             KotlinVersion.UNSUPPORTED -> error("Unsupported Kotlin version: $kgpVersion")
         }
         return SubpluginArtifact(

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
@@ -7,6 +7,7 @@
 package com.datadog.gradle.plugin.kcp
 
 internal enum class KotlinVersion {
+    KOTLIN24,
     KOTLIN22,
     KOTLIN21,
     KOTLIN20,
@@ -34,9 +35,10 @@ internal enum class KotlinVersion {
 
             return when {
                 major == 1 && minor == 9 && patch >= 23 -> KOTLIN19
-                major == 2 && minor == 1 -> KOTLIN21
                 major == 2 && minor == 0 -> KOTLIN20
-                major > 2 || (major == 2 && minor >= 2) -> KOTLIN22
+                major == 2 && minor == 1 -> KOTLIN21
+                major == 2 && minor in 2..3 -> KOTLIN22
+                major > 2 || (major == 2 && minor >= 4) -> KOTLIN24
                 else -> UNSUPPORTED
             }
         }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
@@ -12,14 +12,25 @@ import org.junit.Test
 class KotlinVersionTest {
 
     @Test
-    fun `M return KOTLIN22 W give version 2_2_0 and newer`() {
+    fun `M return KOTLIN22 W give version 2_2_x and 2_3_x`() {
         assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.0"))
         assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.10"))
         assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.3.0"))
-        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("3.0.0"))
         assertEquals(
             KotlinVersion.KOTLIN22,
             KotlinVersion.from("2.2.0-alpha")
+        ) // Suffixes should be handled
+    }
+
+    @Test
+    fun `M return KOTLIN24 W give version 2_4_0 and newer`() {
+        assertEquals(KotlinVersion.KOTLIN24, KotlinVersion.from("2.4.0"))
+        assertEquals(KotlinVersion.KOTLIN24, KotlinVersion.from("2.4.10"))
+        assertEquals(KotlinVersion.KOTLIN24, KotlinVersion.from("2.5.0"))
+        assertEquals(KotlinVersion.KOTLIN24, KotlinVersion.from("3.0.0"))
+        assertEquals(
+            KotlinVersion.KOTLIN24,
+            KotlinVersion.from("2.4.0-alpha")
         ) // Suffixes should be handled
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ kotlin20 = "2.0.21"
 kotlin21 = "2.1.21"
 kotlin22 = "2.2.20"
 kotlin23 = "2.3.20"
+kotlin24 = "2.4.0"
 kotlinComposePlugin = "2.1.21"
 json = "20231013"
 okHttp = "4.12.0"
@@ -54,6 +55,7 @@ datadogPluginGradle = "1.26.0"
 kotlinCompilerTesting20 = "0.7.0"
 kotlinCompilerTesting21 = "0.7.0"
 kotlinCompilerTesting22 = "0.8.0"
+kotlinCompilerTesting24 = "0.12.1"
 autoService = "1.0.1"
 junitVersion = "1.2.1"
 espressoCoreVersion = "3.6.1"
@@ -67,6 +69,7 @@ androidToolsGradlePlugin = { module = "com.android.tools.build:gradle", version.
 kotlinGradlePlugin20 = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin20" }
 kotlinGradlePlugin21 = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin21" }
 kotlinGradlePlugin22 = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin22" }
+kotlinGradlePlugin24 = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin24" }
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 unmockGradlePlugin = { module = "de.mobilej.unmock:UnMockPlugin", version.ref = "unmock" }
 
@@ -126,9 +129,11 @@ kotlinCompilerEmbeddable = { group = "org.jetbrains.kotlin", name = "kotlin-comp
 kotlinCompilerEmbeddable20 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin20" }
 kotlinCompilerEmbeddable21 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin21" }
 kotlinCompilerEmbeddable22 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin22" }
+kotlinCompilerEmbeddable24 = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin24" }
 kotlinCompilerTesting20 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting20" }
 kotlinCompilerTesting21 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting21" }
 kotlinCompilerTesting22 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting22" }
+kotlinCompilerTesting24 = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompilerTesting24" }
 autoService = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 autoServiceAnnotation = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 
@@ -172,7 +177,9 @@ testTools = [
 dokkaJavadocPlugin = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 androidApplicationPlugin = { id = "com.android.application", version.ref = "androidToolsPlugin" }
 androidLibraryPlugin = { id = "com.android.library", version.ref = "androidToolsPlugin" }
+kotlinPlugin21 = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin21" }
 kotlinPlugin23 = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin23" }
+kotlinPlugin24 = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin24" }
 mavenPublishPlugin = { id = "com.vanniktech.maven.publish.base", version.ref = "mavenPublishPlugin" }
 versionsPluginGradle = { id = "com.github.ben-manes.versions", version.ref = "versionsPluginGradle" }
 kotlinComposePlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinComposePlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(":dd-sdk-android-gradle-plugin-kcp-common")
 include(":dd-sdk-android-gradle-plugin-kcp-kotlin20")
 include(":dd-sdk-android-gradle-plugin-kcp-kotlin21")
 include(":dd-sdk-android-gradle-plugin-kcp-kotlin22")
+include(":dd-sdk-android-gradle-plugin-kcp-kotlin24")
 
 include(":samples:basic")
 include(":samples:ndk")


### PR DESCRIPTION
### What does this PR do?

This PR simply sets up the module of `dd-sdk-android-gradle-plugin-kcp-kotlin24` module without any real implementation, this includes:
* The creation of the `dd-sdk-android-gradle-plugin-kcp-kotlin24` module
* Update of the `KotlinVersion` parsing
* Adds `dd-sdk-android-gradle-plugin-kcp-kotlin24` in the CI pipeline and sonatype publishing.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

