### PR TITLE
RUMS-6028: Set `readTimeout` on `OkHttpClient` to match `writeTimeout`

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -43,6 +43,7 @@ internal class OkHttpUploader : Uploader {
             .callTimeout(0, TimeUnit.MILLISECONDS) // unlimited
             .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .connectTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .readTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .build()
 
     @Suppress("TooGenericExceptionCaught")

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -150,6 +150,13 @@ internal class OkHttpUploaderTest {
     }
 
     @Test
+    fun `M set client readTimeout W init()`() {
+        assertThat(testedUploader.client.readTimeoutMillis).isEqualTo(
+            OkHttpUploader.NETWORK_TIMEOUT_MS.toInt()
+        )
+    }
+
+    @Test
     fun `M upload proper request W upload()`() {
         // Given
         mockUploadResponse = MockResponse()


### PR DESCRIPTION
`OkHttpUploader` never set `readTimeout`, leaving it at OkHttp's 10-second default. For large mapping files as the support ticket describes, the server takes longer than 10s to process the received payload before sending an HTTP response, causing `SocketTimeoutException: Read timed out` even though the upload succeeded.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

