### PR TITLE
Implement Kotlin 2.4 KCP support for Compose instrumentation

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/InstrumentationMode.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/InstrumentationMode.kt
@@ -37,8 +37,12 @@ enum class InstrumentationMode {
      */
     DISABLE;
 
-    internal companion object {
-        internal fun from(value: String): InstrumentationMode? {
+    /** Factory methods for [InstrumentationMode]. */
+    companion object {
+        /**
+         * Returns the [InstrumentationMode] whose name matches [value], or null if none matches.
+         */
+        fun from(value: String): InstrumentationMode? {
             return entries.firstOrNull { it.name == value }
         }
     }

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrar.kt
@@ -100,9 +100,12 @@ abstract class DatadogPluginRegistrar(
         return value?.let { InstrumentationMode.from(it) } ?: InstrumentationMode.DISABLE
     }
 
-    internal companion object {
+    /** Compiler configuration keys shared across all versioned plugin registrar implementations. */
+    companion object {
         private const val OPTION_KEY_INSTRUMENTATION_MODE = "INSTRUMENTATION_MODE"
-        internal val CONFIG_INSTRUMENTATION_MODE =
+
+        /** Configuration key used to pass the instrumentation mode string to the compiler plugin. */
+        val CONFIG_INSTRUMENTATION_MODE =
             CompilerConfigurationKey.create<String>(OPTION_KEY_INSTRUMENTATION_MODE)
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/DefaultPluginContextUtils.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.companionObject
@@ -47,6 +48,12 @@ class DefaultPluginContextUtils(
         packageName = kotlinPackageName,
         callableName = applyFunctionIdentifier
     )
+    private val acceptAllNavDestinationsClassId = ClassId(
+        datadogRumTrackingPackageName,
+        acceptAllNavDestinationsIdentifier
+    )
+    private val datadogClassId = ClassId(datadogCorePackageName, datadogIdentifier)
+    private val datadogGetInstanceCallableId = CallableId(datadogClassId, getInstanceIdentifier)
 
     override fun getModifierCompanionClass(): IrClassSymbol? {
         return getModifierClassSymbol()?.owner?.companionObject()?.symbol ?: warnNotFound(
@@ -111,6 +118,18 @@ class DefaultPluginContextUtils(
             .singleOrNull() ?: logSingleMatchError(callableId.callableName.asString(), isCritical)
     }
 
+    override fun getAcceptAllNavDestinationsConstructorSymbol(): IrConstructorSymbol? {
+        return pluginContext.referenceConstructors(acceptAllNavDestinationsClassId).firstOrNull()
+    }
+
+    override fun getDatadogGetInstanceFunctionSymbol(): IrSimpleFunctionSymbol? {
+        return referenceSingleFunction(datadogGetInstanceCallableId)
+    }
+
+    override fun getDatadogObjectClassSymbol(): IrClassSymbol? {
+        return pluginContext.referenceClass(datadogClassId)
+    }
+
     override fun isComposeInstrumentationTargetFunc(
         irFunction: IrFunction,
         annotationModeEnabled: Boolean
@@ -164,5 +183,10 @@ class DefaultPluginContextUtils(
         private val AsyncImageIdentifier = Name.identifier("AsyncImage")
         private val ComposeInstrumentationAnnotationName =
             FqName("com.datadog.android.compose.ComposeInstrumentation")
+        private val datadogRumTrackingPackageName = FqName("com.datadog.android.rum.tracking")
+        private val acceptAllNavDestinationsIdentifier = Name.identifier("AcceptAllNavDestinations")
+        private val datadogCorePackageName = FqName("com.datadog.android")
+        private val datadogIdentifier = Name.identifier("Datadog")
+        private val getInstanceIdentifier = Name.identifier("getInstance")
     }
 }

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/MessageCollectorExt.kt
@@ -70,3 +70,15 @@ const val ERROR_MISSING_COMPOSE_NAV =
  */
 const val ERROR_MISSING_KOTLIN_STDLIB =
     "Missing org.jetbrains.kotlin:kotlin-stdlib dependency."
+
+/**
+ * Error message of missing Datadog RUM tracking dependency (AcceptAllNavDestinations).
+ */
+const val ERROR_MISSING_DATADOG_RUM_TRACKING =
+    "Missing com.datadoghq:dd-sdk-android-rum dependency (AcceptAllNavDestinations not found)."
+
+/**
+ * Error message of missing Datadog core dependency (Datadog.getInstance).
+ */
+const val ERROR_MISSING_DATADOG_CORE =
+    "Missing com.datadoghq:dd-sdk-android dependency (Datadog.getInstance not found)."

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/main/kotlin/com/datadog/gradle/plugin/kcp/PluginContextUtils.kt
@@ -9,6 +9,7 @@ package com.datadog.gradle.plugin.kcp
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.name.CallableId
 
@@ -101,4 +102,22 @@ interface PluginContextUtils {
      * @suppress Internal use only.
      */
     fun isComposeInstrumentationTargetFunc(irFunction: IrFunction, annotationModeEnabled: Boolean): Boolean
+
+    /**
+     * Gets the primary constructor symbol of `AcceptAllNavDestinations`.
+     * @suppress Internal use only.
+     */
+    fun getAcceptAllNavDestinationsConstructorSymbol(): IrConstructorSymbol?
+
+    /**
+     * Gets the `Datadog.getInstance` function symbol.
+     * @suppress Internal use only.
+     */
+    fun getDatadogGetInstanceFunctionSymbol(): IrSimpleFunctionSymbol?
+
+    /**
+     * Gets the `Datadog` object class symbol.
+     * @suppress Internal use only.
+     */
+    fun getDatadogObjectClassSymbol(): IrClassSymbol?
 }

--- a/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTestSources.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/KotlinCompilerTestSources.kt
@@ -18,6 +18,10 @@ object KotlinCompilerTestSources {
     const val TRACKING_EFFECT_FILE_NAME = "Navigation.kt"
     const val DD_MODIFIER_CLASS_FILE_NAME = "DatadogModifier.kt"
     const val COMPOSE_INSTRUMENTATION_ANNOTATION_FILE_NAME = "ComposeInstrumentation.kt"
+    const val SDK_CORE_FILE_NAME = "SdkCore.kt"
+    const val COMPONENT_PREDICATE_FILE_NAME = "ComponentPredicate.kt"
+    const val ACCEPT_ALL_NAV_DESTINATIONS_FILE_NAME = "AcceptAllNavDestinations.kt"
+    const val DATADOG_FILE_NAME = "Datadog.kt"
 
     @Language("kotlin")
     val DD_MODIFIER_SOURCE_FILE_CONTENT =
@@ -55,14 +59,58 @@ object KotlinCompilerTestSources {
         import androidx.compose.runtime.Composable
         import androidx.navigation.NavController
         import androidx.navigation.NavDestination
+        import com.datadog.android.api.SdkCore
+        import com.datadog.android.Datadog
+        import com.datadog.android.rum.tracking.AcceptAllNavDestinations
+        import com.datadog.android.rum.tracking.ComponentPredicate
         import com.datadog.gradle.plugin.kcp.TestCallbackContainer
-
 
         @Composable
         fun InstrumentedNavigationViewTrackingEffect(
-            navController: NavController
+            navController: NavController,
+            trackArguments: Boolean = true,
+            destinationPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations(),
+            sdkCore: SdkCore = Datadog.getInstance()
         ) {
             TestCallbackContainer.invokeCallback()
+        }
+        """.trimIndent()
+
+    @Language("kotlin")
+    val SDK_CORE_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.api
+
+        open class SdkCore
+        """.trimIndent()
+
+    @Language("kotlin")
+    val COMPONENT_PREDICATE_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.rum.tracking
+
+        interface ComponentPredicate<T>
+        """.trimIndent()
+
+    @Language("kotlin")
+    val ACCEPT_ALL_NAV_DESTINATIONS_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android.rum.tracking
+
+        import androidx.navigation.NavDestination
+
+        class AcceptAllNavDestinations : ComponentPredicate<NavDestination>
+        """.trimIndent()
+
+    @Language("kotlin")
+    val DATADOG_SOURCE_FILE_CONTENT =
+        """
+        package com.datadog.android
+
+        import com.datadog.android.api.SdkCore
+
+        object Datadog {
+            fun getInstance(instanceName: String? = null): SdkCore = SdkCore()
         }
         """.trimIndent()
 
@@ -91,8 +139,26 @@ object KotlinCompilerTestSources {
         COMPOSE_INSTRUMENTATION_ANNOTATION_SOURCE_FILE_CONTENT
     )
 
+    val sdkCoreSourceFile = SourceFile.kotlin(SDK_CORE_FILE_NAME, SDK_CORE_SOURCE_FILE_CONTENT)
+
+    val componentPredicateSourceFile = SourceFile.kotlin(
+        COMPONENT_PREDICATE_FILE_NAME,
+        COMPONENT_PREDICATE_SOURCE_FILE_CONTENT
+    )
+
+    val acceptAllNavDestinationsSourceFile = SourceFile.kotlin(
+        ACCEPT_ALL_NAV_DESTINATIONS_FILE_NAME,
+        ACCEPT_ALL_NAV_DESTINATIONS_SOURCE_FILE_CONTENT
+    )
+
+    val datadogSourceFile = SourceFile.kotlin(DATADOG_FILE_NAME, DATADOG_SOURCE_FILE_CONTENT)
+
     // TODO RUM-8950: Dependency file should be separated in each file after the DSL configuration is introduced.
     val dependencyFiles = listOf(
+        sdkCoreSourceFile,
+        componentPredicateSourceFile,
+        acceptAllNavDestinationsSourceFile,
+        datadogSourceFile,
         trackingEffectSourceFile,
         datadogModifierSourceFile,
         composeInstrumentationAnnotationSourceFile

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension.kt
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+
+/**
+ * The extension registers [ComposeNavHostTransformer] into the plugin.
+ *
+ * Internal use only.
+ */
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+class ComposeNavHostExtension(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerNavHostTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerNavHostTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeNavHostTransformer(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostTransformer.kt
@@ -1,0 +1,214 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlock
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.builders.irTemporary
+import org.jetbrains.kotlin.ir.builders.irTrue
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.getClass
+import org.jetbrains.kotlin.ir.util.dumpKotlinLike
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * Transformer to instrument Jetpack Compose Navigation Host.
+ * Internal use only.
+ */
+@UnsafeDuringIrConstructionAPI
+@OptIn(DeprecatedForRemovalCompilerApi::class)
+class ComposeNavHostTransformer(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+
+    private lateinit var trackEffectFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var navHostControllerClassSymbol: IrClassSymbol
+    private var acceptAllNavDestinationsConstructorSymbol: IrConstructorSymbol? = null
+    private var datadogGetInstanceFunctionSymbol: IrSimpleFunctionSymbol? = null
+    private var datadogObjectClassSymbol: IrClassSymbol? = null
+
+    /**
+     * Initializes references to required symbols for the transformer.
+     */
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        trackEffectFunctionSymbol = pluginContextUtils.getDatadogTrackEffectSymbol() ?: run {
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+
+        navHostControllerClassSymbol = pluginContextUtils.getNavHostControllerClassSymbol() ?: run {
+            messageCollector.info(ERROR_MISSING_COMPOSE_NAV)
+            return false
+        }
+
+        // Resolve symbols needed to fill all default arguments of InstrumentedNavigationViewTrackingEffect.
+        // In Compose 2.4.0, @Composable functions no longer generate a $default static method,
+        // so the transformer must supply every argument explicitly to avoid null IR slots.
+        acceptAllNavDestinationsConstructorSymbol =
+            pluginContextUtils.getAcceptAllNavDestinationsConstructorSymbol()
+        if (acceptAllNavDestinationsConstructorSymbol == null) {
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_RUM_TRACKING)
+            return false
+        }
+
+        datadogObjectClassSymbol = pluginContextUtils.getDatadogObjectClassSymbol()
+        datadogGetInstanceFunctionSymbol = pluginContextUtils.getDatadogGetInstanceFunctionSymbol()
+        if (datadogGetInstanceFunctionSymbol == null) {
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_CORE)
+            return false
+        }
+
+        return true
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    @Suppress("ReturnCount")
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(expression)
+
+        val irSimpleFunction = expression.symbol.owner
+        if (pluginContextUtils.isNavHostCall(irSimpleFunction)) {
+            expression.logExpressionBeforeTransformation()
+
+            // Process children first so the navController argument and content lambda are
+            // fully transformed before we capture the navController value.
+            super.visitCall(expression)
+
+            val allParams = irSimpleFunction.symbol.owner.parameters
+            for (irValueParameter in allParams.filter {
+                it.kind == IrParameterKind.Regular || it.kind == IrParameterKind.Context
+            }) {
+                if (irValueParameter.type.getClass()?.symbol == navHostControllerClassSymbol) {
+                    val paramIdx = allParams.indexOf(irValueParameter)
+                    val navControllerArg = expression.arguments[paramIdx] ?: continue
+                    expression.logExpressionAfterTransformation()
+                    return appendTrackingEffect(navControllerArg, expression, paramIdx, builder)
+                }
+            }
+            expression.logExpressionAfterTransformation()
+            return expression
+        }
+        return super.visitCall(expression)
+    }
+
+    private fun appendTrackingEffect(
+        navControllerArg: IrExpression,
+        navHostCall: IrCall,
+        navControllerIdx: Int,
+        builder: DeclarationIrBuilder
+    ): IrExpression {
+        // Build the tracking effect call directly — NOT inside a lambda — so that the Compose
+        // compiler processes it in the composable calling context and adds $composer/$changed.
+        //
+        // All arguments must be set explicitly. In Compose 2.4.0, @Composable functions no
+        // longer generate a $default static method, so null IR argument slots (which normally
+        // trigger the $default mechanism) cause a NoSuchMethodError at runtime.
+        val trackEffectCall = builder.irCall(trackEffectFunctionSymbol)
+
+        return builder.irBlock(resultType = navHostCall.type) {
+            // Capture the navController once to avoid evaluating a potentially side-effectful
+            // expression twice (once for the tracking call, once for NavHost).
+            val tmpNavController = irTemporary(navControllerArg, nameHint = "navController")
+
+            trackEffectCall.arguments[0] = irGet(tmpNavController)
+            trackEffectCall.arguments[1] = irTrue()
+            acceptAllNavDestinationsConstructorSymbol?.let { constructor ->
+                trackEffectCall.arguments[2] = irCallConstructor(constructor, emptyList())
+            }
+            datadogGetInstanceFunctionSymbol?.let { getInstanceFunc ->
+                val getInstanceCall = irCall(getInstanceFunc)
+                datadogObjectClassSymbol?.let { datadogClass ->
+                    val dispatchReceiverIdx = getInstanceFunc.owner.parameters
+                        .indexOfFirst { it.kind == IrParameterKind.DispatchReceiver }
+                    if (dispatchReceiverIdx >= 0) {
+                        getInstanceCall.arguments[dispatchReceiverIdx] = irGetObject(datadogClass)
+                    }
+                }
+                trackEffectCall.arguments[TRACK_EFFECT_SDK_CORE_ARG_IDX] = getInstanceCall
+            }
+
+            navHostCall.arguments[navControllerIdx] = irGet(tmpNavController)
+            // InstrumentedNavigationViewTrackingEffect(navController, true, AcceptAllNavDestinations(), Datadog.getInstance())
+            +trackEffectCall
+            // NavHost(..., navController = navController, ...)
+            +navHostCall
+        }
+    }
+
+    private fun IrExpression.logExpressionBeforeTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression Before Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun IrExpression.logExpressionAfterTransformation() {
+        messageCollector.report(
+            CompilerMessageSeverity.LOGGING,
+            "Expression After Transformation:\n ${dumpKotlinLike()}"
+        )
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private companion object {
+        private const val TRACK_EFFECT_SDK_CORE_ARG_IDX = 3
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension.kt
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+
+/**
+ * The extension registers [ComposeTagTransformer] into the plugin.
+ *
+ * Internal use only
+ */
+class ComposeTagExtension(
+    private val messageCollector: MessageCollector,
+    private val annotationModeEnabled: Boolean
+) : IrGenerationExtension {
+
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+        registerTagTransformer(
+            pluginContext = pluginContext,
+            moduleFragment = moduleFragment,
+            annotationModeEnabled = annotationModeEnabled
+        )
+    }
+
+    private fun registerTagTransformer(
+        pluginContext: IrPluginContext,
+        moduleFragment: IrModuleFragment,
+        annotationModeEnabled: Boolean
+    ) {
+        ComposeTagTransformer(
+            messageCollector = messageCollector,
+            pluginContext = pluginContext,
+            annotationModeEnabled = annotationModeEnabled
+        ).apply {
+            if (initReferences()) {
+                moduleFragment.accept(this, null)
+            } else {
+                messageCollector.warnDependenciesError()
+            }
+        }
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -1,0 +1,244 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
+import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBoolean
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGetObjectValue
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrFunction
+import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.createType
+import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
+
+/**
+ * The extension registers [ComposeTagTransformer] into the plugin.
+ *
+ * Internal use only
+ */
+@OptIn(DeprecatedForRemovalCompilerApi::class, UnsafeDuringIrConstructionAPI::class)
+class ComposeTagTransformer(
+    private val messageCollector: MessageCollector,
+    private val pluginContext: IrPluginContext,
+    private val annotationModeEnabled: Boolean,
+    private val pluginContextUtils: PluginContextUtils = DefaultPluginContextUtils(
+        pluginContext,
+        messageCollector
+    )
+) : IrElementTransformerVoidWithContext() {
+
+    private val visitedFunctions = ArrayDeque<String?>()
+    private val visitedBuilders = ArrayDeque<DeclarationIrBuilder?>()
+    private lateinit var datadogTagFunctionSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierClass: IrClassSymbol
+    private lateinit var modifierThenSymbol: IrSimpleFunctionSymbol
+    private lateinit var modifierCompanionClassSymbol: IrClassSymbol
+
+    /**
+     * Initializes references to required symbols for the transformer.
+     */
+    @OptIn(UnsafeDuringIrConstructionAPI::class)
+    @Suppress("ReturnCount")
+    fun initReferences(): Boolean {
+        datadogTagFunctionSymbol = pluginContextUtils.getDatadogModifierSymbol() ?: run {
+            messageCollector.strongWarning(ERROR_MISSING_DATADOG_COMPOSE_INTEGRATION)
+            return false
+        }
+        modifierClass = pluginContextUtils.getModifierClassSymbol() ?: run {
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierThenSymbol = pluginContextUtils.getModifierThen() ?: run {
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        modifierCompanionClassSymbol = pluginContextUtils.getModifierCompanionClass() ?: run {
+            messageCollector.strongWarning(ERROR_MISSING_COMPOSE_UI)
+            return false
+        }
+        return true
+    }
+
+    override fun visitFunctionNew(declaration: IrFunction): IrStatement {
+        val declarationName = declaration.name
+        val functionName = if (!isAnonymousFunction(declarationName)) {
+            declarationName.toString()
+        } else {
+            visitedFunctions.lastOrNull() ?: declarationName.toString()
+        }
+
+        if (pluginContextUtils.isComposeInstrumentationTargetFunc(declaration, annotationModeEnabled)) {
+            visitedFunctions.add(functionName)
+            visitedBuilders.add(DeclarationIrBuilder(pluginContext, declaration.symbol))
+            val irStatement = super.visitFunctionNew(declaration)
+            visitedFunctions.removeLast()
+            visitedBuilders.removeLast()
+            return irStatement
+        } else {
+            return declaration
+        }
+    }
+
+    override fun visitFunctionExpression(expression: IrFunctionExpression): IrExpression {
+        // We should visit Jetpack Compose content lambda body as function for instrumentation.
+        expression.function.body?.accept(this, null)
+        return super.visitFunctionExpression(expression)
+    }
+
+    @Suppress("ReturnCount")
+    override fun visitCall(expression: IrCall): IrExpression {
+        val builder = visitedBuilders.lastOrNull() ?: return super.visitCall(
+            expression
+        )
+        val dispatchReceiver = expression.dispatchReceiver
+        // Chained function call should be skipped
+        if (dispatchReceiver is IrCall) {
+            return super.visitCall(expression)
+        }
+        val allParams = expression.symbol.owner.parameters
+        allParams
+            .filter { it.kind == IrParameterKind.Regular || it.kind == IrParameterKind.Context }
+            .forEach { irValueParameter ->
+                // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
+                // Use the parameter's index in the FULL parameters list (not the filtered-list position),
+                // because in 2.4.0 arguments[] is unified (dispatch + extension + regular) so filtered-list
+                // position 0 would hit the dispatch receiver, not the first regular parameter.
+                if (irValueParameter.type.classFqName == modifierClassFqName) {
+                    val paramIdx = allParams.indexOf(irValueParameter)
+                    val irExpression = buildIrExpression(
+                        expression = expression.arguments[paramIdx],
+                        builder = builder,
+                        functionName = expression.symbol.owner.name.asString(),
+                        isImageComposableFunction = isImageComposableFunction(expression)
+                    )
+                    expression.arguments[paramIdx] = irExpression
+                }
+            }
+        return super.visitCall(expression)
+    }
+
+    @Suppress("ReturnCount")
+    private fun isImageComposableFunction(irExpression: IrExpression): Boolean {
+        if (irExpression !is IrCall) {
+            return false
+        }
+        val function = irExpression.symbol.owner
+
+        // Look up the parents until the package level.
+        var parent = function.parent
+        while (parent !is IrPackageFragment && parent is IrDeclaration) {
+            parent = parent.parent
+        }
+        if (parent !is IrPackageFragment) {
+            return false
+        }
+        pluginContextUtils.apply {
+            return isFoundationImage(function, parent) ||
+                isMaterialIcon(function, parent) ||
+                isCoilAsyncImage(function, parent)
+        }
+    }
+
+    private fun buildIrExpression(
+        expression: IrExpression?,
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean
+    ): IrExpression {
+        val datadogTagModifier = buildDatadogTagModifierCall(
+            builder = builder,
+            functionName = functionName,
+            isImageComposableFunction = isImageComposableFunction
+        )
+        // A Column(){} will be transformed into following code during FIR:
+        // Column(modifier = // COMPOSITE {
+        //    null
+        // }, verticalArrangement = // COMPOSITE {
+        //    null
+        // }, horizontalAlignment = // COMPOSITE {
+        //    null
+        // }, content = @Composable
+        // checking if the argument is the type of `COMPOSITE`
+        // allows us to know if the modifier is absent in source code.
+        val overwriteModifier = expression == null ||
+            (expression is IrComposite && expression.type.classFqName == kotlinNothingFqName)
+        if (overwriteModifier) {
+            return datadogTagModifier
+        } else {
+            // Modifier.then()
+            val thenCall = builder.irCall(
+                modifierThenSymbol,
+                modifierClass.owner.defaultType
+            )
+            // In 2.4.0, arguments[0] is the dispatch receiver; the `other` regular parameter
+            // follows at the first Regular-kind index. Use dispatchReceiver convenience setter
+            // for the receiver and find the Regular index explicitly for `other`.
+            thenCall.dispatchReceiver = datadogTagModifier
+            val otherIdx = thenCall.symbol.owner.parameters.indexOfFirst { it.kind == IrParameterKind.Regular }
+            thenCall.arguments[otherIdx] = expression
+            return thenCall
+        }
+    }
+
+    private fun buildDatadogTagModifierCall(
+        builder: DeclarationIrBuilder,
+        functionName: String,
+        isImageComposableFunction: Boolean = false
+    ): IrCall {
+        val datadogTagIrCall = builder.irCall(
+            datadogTagFunctionSymbol,
+            modifierClass.owner.defaultType
+        ).also {
+            val params = it.symbol.owner.parameters
+            // Modifier
+            // ExtensionReceiver argument
+            it.arguments[
+                params.indexOfFirst { argument ->
+                    argument.kind == IrParameterKind.ExtensionReceiver
+                }
+            ] = builder.irGetObjectValue(
+                type = modifierCompanionClassSymbol.createType(false, emptyList()),
+                classSymbol = modifierCompanionClassSymbol
+            )
+            // In 2.4.0, arguments is unified (dispatch + extension + regular); regular params
+            // start after any receivers rather than at index 0.
+            val firstRegularIdx = params.indexOfFirst { p -> p.kind == IrParameterKind.Regular }
+            it.arguments[firstRegularIdx] = builder.irString(functionName)
+
+            // For the images, Role.Image must be assigned to Semantics.Role to ensure that
+            // Session Replay is able to resolve the role.
+            it.arguments[firstRegularIdx + 1] = builder.irBoolean(isImageComposableFunction)
+        }
+        return datadogTagIrCall
+    }
+
+    private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS
+
+    private companion object {
+        private val modifierClassFqName = FqName("androidx.compose.ui.Modifier")
+        private val kotlinNothingFqName = FqName("kotlin.Nothing")
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrarImpl.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogPluginRegistrarImpl.kt
@@ -6,7 +6,60 @@
 
 package com.datadog.gradle.plugin.kcp
 
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.google.auto.service.AutoService
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
 /**
- * Place holder for later implementation.
+ * Implementation of [CompilerPluginRegistrar] with Kotlin 2.4.x support.
+ *
+ * Uses [CompilerPluginRegistrar] instead of [ComponentRegistrar] because
+ * [IrGenerationExtension.extensionPointName] was removed in Kotlin 2.4.0.
+ * Plugin ordering (Datadog before Compose) is enforced via -Xcompiler-plugin-order,
+ * injected by [DatadogKotlinCompilerPluginSupport].
  */
-class DatadogPluginRegistrarImpl
+@OptIn(ExperimentalCompilerApi::class)
+@AutoService(CompilerPluginRegistrar::class)
+class DatadogPluginRegistrarImpl(
+    private val overrideInstrumentationMode: InstrumentationMode? = null
+) : CompilerPluginRegistrar() {
+
+    override val supportsK2: Boolean = true
+
+    // Required in Kotlin 2.3.0+ to enable -Xcompiler-plugin-order; must match
+    // DatadogKotlinCompilerPluginCommandLineProcessor.pluginId.
+    override val pluginId: String = "com.datadoghq.kotlin.compiler"
+
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        val messageCollector =
+            configuration[CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE]
+        val instrumentationMode =
+            overrideInstrumentationMode ?: resolveConfiguration(configuration)
+
+        if (instrumentationMode != InstrumentationMode.DISABLE) {
+            IrGenerationExtension.registerExtension(
+                ComposeNavHostExtension(
+                    messageCollector = messageCollector,
+                    annotationModeEnabled = instrumentationMode == InstrumentationMode.ANNOTATION
+                )
+            )
+            IrGenerationExtension.registerExtension(
+                ComposeTagExtension(
+                    messageCollector = messageCollector,
+                    annotationModeEnabled = instrumentationMode == InstrumentationMode.ANNOTATION
+                )
+            )
+        }
+    }
+
+    private fun resolveConfiguration(configuration: CompilerConfiguration): InstrumentationMode {
+        return configuration[DatadogPluginRegistrar.CONFIG_INSTRUMENTATION_MODE]
+            ?.let { InstrumentationMode.from(it) }
+            ?: InstrumentationMode.DISABLE
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation24Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostCompilation24Test.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+@OptIn(ExperimentalCompilerApi::class)
+class ComposeNavHostCompilation24Test : ComposeNavHostCompilationTest() {
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.compilerPluginRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension24Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeNavHostExtension24Test.kt
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.name.ClassId
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(FirIncompatiblePluginAPI::class, UnsafeDuringIrConstructionAPI::class)
+internal class ComposeNavHostExtension24Test : ComposeNavHostExtensionTest() {
+
+    @Mock
+    private lateinit var mockIrConstructorSymbol: IrConstructorSymbol
+
+    @BeforeEach
+    fun setUpNavHostSymbols() {
+        whenever(mockPluginContext.referenceConstructors(any<ClassId>())) doReturn listOf(mockIrConstructorSymbol)
+    }
+
+    override fun verifyTransformerAccepted(annotationModeEnabled: Boolean) {
+        val composeNavHostExtension = ComposeNavHostExtension(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        composeNavHostExtension.generate(mockModuleFragment, mockPluginContext)
+
+        verify(mockModuleFragment).accept(any<ComposeNavHostTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M accept ComposeNavHostTransformer W generate with annotation mode disabled`() {
+        verifyTransformerAccepted(false)
+    }
+
+    @Test
+    fun `M accept ComposeNavHostTransformer W generate with annotation mode enabled`() {
+        verifyTransformerAccepted(true)
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation24Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagCompilation24Test.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import com.datadog.gradle.plugin.InstrumentationMode
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+@OptIn(ExperimentalCompilerApi::class)
+class ComposeTagCompilation24Test : ComposeTagCompilationTest() {
+    override fun registerDatadogPluginRegistrar(
+        compilation: KotlinCompilation,
+        instrumentationMode: InstrumentationMode
+    ) {
+        compilation.compilerPluginRegistrars = listOf(DatadogPluginRegistrarImpl(instrumentationMode))
+    }
+}

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension24Test.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/test/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagExtension24Test.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2020-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.kcp
+
+import org.jetbrains.kotlin.backend.common.extensions.FirIncompatiblePluginAPI
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+
+@OptIn(FirIncompatiblePluginAPI::class, UnsafeDuringIrConstructionAPI::class)
+internal class ComposeTagExtension24Test : ComposeTagExtensionTest() {
+
+    override fun verifyTransformerAccepted(annotationModeEnabled: Boolean) {
+        val composeTagExtension = ComposeTagExtension(
+            messageCollector = mockMessageCollector,
+            annotationModeEnabled = annotationModeEnabled
+        )
+
+        composeTagExtension.generate(mockModuleFragment, mockPluginContext)
+
+        verify(mockModuleFragment).accept(any<ComposeTagTransformer>(), eq(null))
+    }
+
+    @Test
+    fun `M accept ComposeTagTransformer W generate with annotation mode disabled`() {
+        verifyTransformerAccepted(false)
+    }
+
+    @Test
+    fun `M accept ComposeTagTransformer W generate with annotation mode enabled`() {
+        verifyTransformerAccepted(true)
+    }
+}

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/DatadogKotlinCompilerPluginSupport.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
  * This class implements [KotlinCompilerPluginSupportPlugin] to properly integrate with the
  * Kotlin Gradle Plugin and target the correct version-specific sub-plugin.
  *
- * The plugin points to different sub-plugin based on kotlin compiler version (kotlin20, kotlin21, kotlin22).
+ * The plugin points to different sub-plugin based on kotlin compiler version (kotlin20, kotlin21, kotlin22, kotlin24).
  *
  */
 class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
@@ -64,6 +64,19 @@ class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
         val ddExtension = project.extensions.getByType(DdExtension::class.java)
         val composeInstrumentation = ddExtension.composeInstrumentation
+
+        // For Kotlin 2.4.0+, CompilerPluginRegistrar does not support LoadingOrder.FIRST,
+        // so we use -Xcompiler-plugin-order to guarantee Datadog runs before Compose.
+        // Use compileTaskProvider (KGP 2.0+ stable API) instead of the deprecated
+        // kotlinOptions.freeCompilerArgs which does not propagate reliably in KGP 2.4.0.
+        if (kotlinVersion == KotlinVersion.KOTLIN24) {
+            kotlinCompilation.compileTaskProvider.configure { task ->
+                task.compilerOptions.freeCompilerArgs.add(
+                    "-Xcompiler-plugin-order=$PLUGIN_ID>$COMPOSE_PLUGIN_ID"
+                )
+            }
+        }
+
         return project.provider {
             listOf(
                 SubpluginOption(
@@ -93,6 +106,7 @@ class DatadogKotlinCompilerPluginSupport : KotlinCompilerPluginSupportPlugin {
 
     private companion object {
         private const val PLUGIN_ID = "com.datadoghq.kotlin.compiler"
+        private const val COMPOSE_PLUGIN_ID = "androidx.compose.compiler.plugins.kotlin"
         private const val GROUP_ID = "com.datadoghq"
         private const val PLUGIN_ARTIFACT_ID_PREFIX = "dd-sdk-android-gradle-plugin-kcp"
         private const val INSTRUMENTATION_MODE = "INSTRUMENTATION_MODE"


### PR DESCRIPTION
### What does this PR do?

Implements the `dd-sdk-android-gradle-plugin-kcp-kotlin24` module for Compose instrumentation (NavHost tracking + semantic tag injection) on Kotlin 2.4.x projects. Follows the same per-version sub-plugin pattern as kotlin20/21/22 but required rework due to three breaking API changes in Kotlin 2.4.

Key differences from kotlin20–22

1. `ComponentRegistrar` → `CompilerPluginRegistrar`
Kotlin 2.4 removed `IrGenerationExtension.extensionPointName`, breaking `ComponentRegistrar`-based plugins silently. The kotlin24 `DatadogPluginRegistrarImpl` extends `CompilerPluginRegistrar` directly instead of the shared `DatadogPluginRegistrar` base class.

2. Plugin ordering: LoadingOrder.FIRST → -Xcompiler-plugin-order
CompilerPluginRegistrar doesn't support LoadingOrder. Without ordering, Compose runs first and Datadog produces invalid IR. DatadogKotlinCompilerPluginSupport now injects -Xcompiler-plugin-order=com.datadoghq.kotlin.compiler>androidx.compose.compiler.plugins.kotlin for Kotlin 2.4 compilations.

3. `NavHost` tracking: `apply` lambda → inline `irBlock` with all args explicit
Compose 2.4 no longer generates `$default` static overloads for `@Composable` functions — null IR argument slots that previously triggered default-filling now cause `NoSuchMethodError` at runtime. The `kotlin22` approach injects `navController.apply { InstrumentedNavigationViewTrackingEffect(this) }` with one arg. The kotlin24 transformer emits an inline `irBlock` with all four arguments set explicitly, and guards `initReferences()` to abort with a clear warning if any required symbol (`AcceptAllNavDestinations`, `Datadog.getInstance()`) is unresolvable.

4. Argument indexing: `putValueArgument(valueIndex)` → `arguments[unifiedIndex]`
Kotlin 2.4 unifies dispatch receiver, extension receiver, and regular parameters into a single arguments[] array. Both transformers use `indexOfFirst { it.kind == ... }` on the full parameters list instead of the deprecated `putValueArgument(i)` / `getValueArgument(i)` APIs.

Also changed

- `InstrumentationMode.from()` and `DatadogPluginRegistrar.CONFIG_INSTRUMENTATION_MODE` made public so the `kotlin24` registrar (which doesn't extend the base class) can access them.
- `KotlinCompilerTestSources` updated with the real 4-parameter signature of `InstrumentedNavigationViewTrackingEffect` and stub source files for `SdkCore`, `AcceptAllNavDestinations`, and `Datadog`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

