### PR TITLE
Treat Kotlin 2.3 as unsupported for Compose instrumentation to prevent silent IR corruption

### DIFF
--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersion.kt
@@ -37,7 +37,7 @@ internal enum class KotlinVersion {
                 major == 1 && minor == 9 && patch >= 23 -> KOTLIN19
                 major == 2 && minor == 0 -> KOTLIN20
                 major == 2 && minor == 1 -> KOTLIN21
-                major == 2 && minor in 2..3 -> KOTLIN22
+                major == 2 && minor == 2 -> KOTLIN22
                 major > 2 || (major == 2 && minor >= 4) -> KOTLIN24
                 else -> UNSUPPORTED
             }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/kcp/KotlinVersionTest.kt
@@ -12,14 +12,19 @@ import org.junit.Test
 class KotlinVersionTest {
 
     @Test
-    fun `M return KOTLIN22 W give version 2_2_x and 2_3_x`() {
+    fun `M return KOTLIN22 W give version 2_2_x`() {
         assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.0"))
         assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.2.10"))
-        assertEquals(KotlinVersion.KOTLIN22, KotlinVersion.from("2.3.0"))
         assertEquals(
             KotlinVersion.KOTLIN22,
             KotlinVersion.from("2.2.0-alpha")
         ) // Suffixes should be handled
+    }
+
+    @Test
+    fun `M return UNSUPPORTED W give version 2_3_x`() {
+        assertEquals(KotlinVersion.UNSUPPORTED, KotlinVersion.from("2.3.0"))
+        assertEquals(KotlinVersion.UNSUPPORTED, KotlinVersion.from("2.3.20"))
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Stops mapping Kotlin 2.3 to the kotlin22 Kotlin Compiler Plugin. The kotlin22 KCP is compiled against `kotlinCompilerEmbeddable22`; when loaded into the Kotlin 2.3 compiler it compiles successfully but injects IR that corrupts the first composition of instrumented composables (text field values render empty, layouts collapse). Reported with full root cause and reproduction, including reproduction on a physical device, in #575.

With this change Kotlin 2.3 resolves to `UNSUPPORTED`, so `isApplicable()` returns false and instrumentation no-ops with a debug log, the same code path as `InstrumentationMode.DISABLE`. This is a stopgap: the proper fix is a dedicated kotlin23 KCP artifact.

### Validation

Verified the equivalent patch against a production app (Kotlin 2.3.20, Compose BOM 2026.03.01): with AUTO requested, compilation contains zero injected calls and all 62 previously failing Paparazzi screenshot goldens pass. `KotlinVersionTest` updated and passing.
