### PR TITLE
RUM-16787: Preserve callee Modifier default when argument is omitted

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/ComposeTagCompilationTest.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/src/testFixtures/kotlin/com.datadog.gradle.plugin/kcp/ComposeTagCompilationTest.kt
@@ -267,6 +267,87 @@ abstract class ComposeTagCompilationTest : KotlinCompilerTest() {
     }
 
     @Test
+    fun `M preserve callee default W modifier arg omitted and callee default is not bare Modifier`() {
+        // Given
+        val nullableModifierTestCaseSource = SourceFile.kotlin(
+            NULLABLE_MODIFIER_TEST_CASE_FILE_NAME,
+            NULLABLE_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = nullableModifierTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.NullableModifierTestCase",
+            "NullableModifierTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
+    fun `M inject dd modifier W modifier omitted on dependency composable with deserialized default`() {
+        // Given
+        val dependencyDefaultModifierTestCaseSource = SourceFile.kotlin(
+            DEPENDENCY_DEFAULT_MODIFIER_TEST_CASE_FILE_NAME,
+            DEPENDENCY_DEFAULT_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = dependencyDefaultModifierTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.DependencyDefaultModifierTestCase",
+            "DependencyDefaultModifierTestCase",
+            listOf()
+        )
+
+        // Then
+        // The callee comes from a dependency, so its `modifier: Modifier = Modifier` default deserializes
+        // as a placeholder (IrErrorExpression), not a bare companion. It must still be instrumented rather
+        // than wrongly preserved/skipped. See #575.
+        // `Image` is also an image-role composable, hence the callback is invoked with `true`.
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCallback).invoke(true)
+    }
+
+    @Test
+    fun `M preserve callee default W modifier arg omitted and callee default is a sizing Modifier`() {
+        // Given
+        val sizingDefaultModifierTestCaseSource = SourceFile.kotlin(
+            SIZING_DEFAULT_MODIFIER_TEST_CASE_FILE_NAME,
+            SIZING_DEFAULT_MODIFIER_SOURCE_FILE_CONTENT
+        )
+
+        // When
+        val result = compileFile(
+            target = sizingDefaultModifierTestCaseSource,
+            deps = dependencyFiles
+        )
+        executeClassFile(
+            result.classLoader,
+            "com.datadog.kcp.SizingDefaultModifierTestCase",
+            "SizingDefaultModifierTestCase",
+            listOf(mockCustomModifierCallback)
+        )
+
+        // Then
+        // The omitted `iconModifier` argument must keep its `Modifier.stubModifier(...)` default rather than
+        // being overwritten with `Modifier.instrumentedDatadog(...)`. See #575.
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        verify(mockCustomModifierCallback).invoke()
+    }
+
+    @Test
     fun `M match given instrumentation mode W instrument annotated function`(
         @Forgery instrumentationMode: InstrumentationMode
     ) {
@@ -341,6 +422,10 @@ abstract class ComposeTagCompilationTest : KotlinCompilerTest() {
         private const val DEFAULT_MODIFIER_WITH_ANNOTATION_TEST_CASE_FILE_NAME =
             "DefaultModifierWithAnnotationTestCase.kt"
         private const val NESTED_COMPOSABLE_TEST_CASE_FILE_NAME = "NestedComposableTestCase.kt"
+        private const val NULLABLE_MODIFIER_TEST_CASE_FILE_NAME = "NullableModifierTestCase.kt"
+        private const val DEPENDENCY_DEFAULT_MODIFIER_TEST_CASE_FILE_NAME =
+            "DependencyDefaultModifierTestCase.kt"
+        private const val SIZING_DEFAULT_MODIFIER_TEST_CASE_FILE_NAME = "SizingDefaultModifierTestCase.kt"
 
         @Language("kotlin")
         private val NO_MODIFIER_SOURCE_FILE_CONTENT =
@@ -530,6 +615,100 @@ abstract class ComposeTagCompilationTest : KotlinCompilerTest() {
 
             }
             
+        """.trimIndent()
+
+    @Language("kotlin")
+    private val NULLABLE_MODIFIER_SOURCE_FILE_CONTENT =
+        """
+            package com.datadog.kcp
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+
+            class NullableModifierTestCase{
+                @Composable
+                fun NullableModifierTestCase(fallbackCallback : () -> Unit) {
+                    // iconModifier is omitted, so the callee relies on its `null` default.
+                    IconRow(fallbackCallback = fallbackCallback)
+                }
+
+                @Composable
+                fun IconRow(iconModifier : Modifier? = null, fallbackCallback : () -> Unit){
+                    CustomComposable(
+                        modifier = iconModifier ?: Modifier.stubModifier(fallbackCallback)
+                    )
+                }
+
+                @Composable
+                fun CustomComposable(modifier : Modifier = Modifier){
+                    // do nothing
+                }
+
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+
+        """.trimIndent()
+
+    @Language("kotlin")
+    private val DEPENDENCY_DEFAULT_MODIFIER_SOURCE_FILE_CONTENT =
+        """
+            package com.datadog.kcp
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.foundation.Image
+
+            class DependencyDefaultModifierTestCase{
+                @Composable
+                fun DependencyDefaultModifierTestCase() {
+                    // Image is compiled in a dependency, so its `modifier: Modifier = Modifier` default is
+                    // deserialized as a placeholder rather than a bare companion. It must still be tagged.
+                    Image()
+                }
+            }
+
+        """.trimIndent()
+
+    @Language("kotlin")
+    private val SIZING_DEFAULT_MODIFIER_SOURCE_FILE_CONTENT =
+        """
+            package com.datadog.kcp
+
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+
+            class SizingDefaultModifierTestCase{
+                @Composable
+                fun SizingDefaultModifierTestCase(fallbackCallback : () -> Unit) {
+                    // iconModifier is omitted, so the callee relies on its non-null default.
+                    IconRow(fallbackCallback = fallbackCallback)
+                }
+
+                @Composable
+                fun IconRow(
+                    fallbackCallback : () -> Unit,
+                    iconModifier : Modifier = Modifier.stubModifier(fallbackCallback)
+                ){
+                    CustomComposable(modifier = iconModifier)
+                }
+
+                @Composable
+                fun CustomComposable(modifier : Modifier = Modifier){
+                    // do nothing
+                }
+
+                @Composable
+                fun Modifier.stubModifier(customCallback: () -> Unit): Modifier{
+                    customCallback.invoke()
+                    return Modifier
+                }
+
+            }
+
         """.trimIndent()
 
     @Language("kotlin")

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -18,8 +18,10 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -121,8 +123,15 @@ constructor(
         expression.symbol.owner.valueParameters.forEachIndexed { index, irValueParameter ->
             // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
             if (irValueParameter.type.classFqName == modifierClassFqName) {
+                val argument = expression.getValueArgument(index)
+                // Skip instrumenting an omitted argument whose callee default carries behavior
+                // (e.g. `Modifier.size(...)` or `null` consumed via an elvis). Overwriting it would
+                // discard that default and corrupt the layout. See #575.
+                if (shouldPreserveCalleeDefault(irValueParameter, argument)) {
+                    return@forEachIndexed
+                }
                 val irExpression = buildIrExpression(
-                    expression = expression.getValueArgument(index),
+                    expression = argument,
                     builder = builder,
                     functionName = expression.symbol.owner.name.asString(),
                     isImageComposableFunction = isImageComposableFunction(expression)
@@ -215,6 +224,28 @@ constructor(
             it.putValueArgument(1, builder.irBoolean(isImageComposableFunction))
         }
         return datadogTagIrCall
+    }
+
+    private fun shouldPreserveCalleeDefault(
+        irValueParameter: IrValueParameter,
+        argument: IrExpression?
+    ): Boolean {
+        val isArgumentAbsent = argument == null ||
+            (argument is IrComposite && argument.type.classFqName == kotlinNothingFqName)
+        if (!isArgumentAbsent) {
+            return false
+        }
+        // Only preserve the callee default when we can positively identify it as a value that carries
+        // behavior. A bare `Modifier` companion (`= Modifier`) is an IrGetObjectValue and is safe to
+        // overwrite; defaults deserialized from dependencies arrive as IrErrorExpression placeholders and
+        // must also be instrumented. Both fall through to `false` here. See #575.
+        return when (irValueParameter.defaultValue?.expression) {
+            // e.g. `Modifier? = null`, consumed via an `iconModifier ?: <fallback>` elvis in the body.
+            is IrConst<*> -> true
+            // e.g. `Modifier.size(40.dp)`.
+            is IrCall -> true
+            else -> false
+        }
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -18,8 +18,10 @@ import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -121,8 +123,15 @@ constructor(
         expression.symbol.owner.valueParameters.forEachIndexed { index, irValueParameter ->
             // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
             if (irValueParameter.type.classFqName == modifierClassFqName) {
+                val argument = expression.getValueArgument(index)
+                // Skip instrumenting an omitted argument whose callee default carries behavior
+                // (e.g. `Modifier.size(...)` or `null` consumed via an elvis). Overwriting it would
+                // discard that default and corrupt the layout. See #575.
+                if (shouldPreserveCalleeDefault(irValueParameter, argument)) {
+                    return@forEachIndexed
+                }
                 val irExpression = buildIrExpression(
-                    expression = expression.getValueArgument(index),
+                    expression = argument,
                     builder = builder,
                     functionName = expression.symbol.owner.name.asString(),
                     isImageComposableFunction = isImageComposableFunction(expression)
@@ -215,6 +224,28 @@ constructor(
             it.putValueArgument(1, builder.irBoolean(isImageComposableFunction))
         }
         return datadogTagIrCall
+    }
+
+    private fun shouldPreserveCalleeDefault(
+        irValueParameter: IrValueParameter,
+        argument: IrExpression?
+    ): Boolean {
+        val isArgumentAbsent = argument == null ||
+            (argument is IrComposite && argument.type.classFqName == kotlinNothingFqName)
+        if (!isArgumentAbsent) {
+            return false
+        }
+        // Only preserve the callee default when we can positively identify it as a value that carries
+        // behavior. A bare `Modifier` companion (`= Modifier`) is an IrGetObjectValue and is safe to
+        // overwrite; defaults deserialized from dependencies arrive as IrErrorExpression placeholders and
+        // must also be instrumented. Both fall through to `false` here. See #575.
+        return when (irValueParameter.defaultValue?.expression) {
+            // e.g. `Modifier? = null`, consumed via an `iconModifier ?: <fallback>` elvis in the body.
+            is IrConst -> true
+            // e.g. `Modifier.size(40.dp)`.
+            is IrCall -> true
+            else -> false
+        }
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -20,8 +20,10 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -123,8 +125,15 @@ class ComposeTagTransformer(
             .forEachIndexed { index, irValueParameter ->
                 // Locate where Modifier is accepted in the parameter list and replace it with the new expression.
                 if (irValueParameter.type.classFqName == modifierClassFqName) {
+                    val argument = expression.getValueArgument(index)
+                    // Skip instrumenting an omitted argument whose callee default carries behavior
+                    // (e.g. `Modifier.size(...)` or `null` consumed via an elvis). Overwriting it would
+                    // discard that default and corrupt the layout. See #575.
+                    if (shouldPreserveCalleeDefault(irValueParameter, argument)) {
+                        return@forEachIndexed
+                    }
                     val irExpression = buildIrExpression(
-                        expression = expression.getValueArgument(index),
+                        expression = argument,
                         builder = builder,
                         functionName = expression.symbol.owner.name.asString(),
                         isImageComposableFunction = isImageComposableFunction(expression)
@@ -220,6 +229,28 @@ class ComposeTagTransformer(
             it.putValueArgument(1, builder.irBoolean(isImageComposableFunction))
         }
         return datadogTagIrCall
+    }
+
+    private fun shouldPreserveCalleeDefault(
+        irValueParameter: IrValueParameter,
+        argument: IrExpression?
+    ): Boolean {
+        val isArgumentAbsent = argument == null ||
+            (argument is IrComposite && argument.type.classFqName == kotlinNothingFqName)
+        if (!isArgumentAbsent) {
+            return false
+        }
+        // Only preserve the callee default when we can positively identify it as a value that carries
+        // behavior. A bare `Modifier` companion (`= Modifier`) is an IrGetObjectValue and is safe to
+        // overwrite; defaults deserialized from dependencies arrive as IrErrorExpression placeholders and
+        // must also be instrumented. Both fall through to `false` here. See #575.
+        return when (irValueParameter.defaultValue?.expression) {
+            // e.g. `Modifier? = null`, consumed via an `iconModifier ?: <fallback>` elvis in the body.
+            is IrConst -> true
+            // e.g. `Modifier.size(40.dp)`.
+            is IrCall -> true
+            else -> false
+        }
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/src/main/kotlin/com/datadog/gradle/plugin/kcp/ComposeTagTransformer.kt
@@ -20,8 +20,10 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrPackageFragment
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrComposite
+import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -128,8 +130,15 @@ class ComposeTagTransformer(
                 // position 0 would hit the dispatch receiver, not the first regular parameter.
                 if (irValueParameter.type.classFqName == modifierClassFqName) {
                     val paramIdx = allParams.indexOf(irValueParameter)
+                    val argument = expression.arguments[paramIdx]
+                    // Skip instrumenting an omitted argument whose callee default carries behavior
+                    // (e.g. `Modifier.size(...)` or `null` consumed via an elvis). Overwriting it would
+                    // discard that default and corrupt the layout. See #575.
+                    if (shouldPreserveCalleeDefault(irValueParameter, argument)) {
+                        return@forEach
+                    }
                     val irExpression = buildIrExpression(
-                        expression = expression.arguments[paramIdx],
+                        expression = argument,
                         builder = builder,
                         functionName = expression.symbol.owner.name.asString(),
                         isImageComposableFunction = isImageComposableFunction(expression)
@@ -233,6 +242,28 @@ class ComposeTagTransformer(
             it.arguments[firstRegularIdx + 1] = builder.irBoolean(isImageComposableFunction)
         }
         return datadogTagIrCall
+    }
+
+    private fun shouldPreserveCalleeDefault(
+        irValueParameter: IrValueParameter,
+        argument: IrExpression?
+    ): Boolean {
+        val isArgumentAbsent = argument == null ||
+            (argument is IrComposite && argument.type.classFqName == kotlinNothingFqName)
+        if (!isArgumentAbsent) {
+            return false
+        }
+        // Only preserve the callee default when we can positively identify it as a value that carries
+        // behavior. A bare `Modifier` companion (`= Modifier`) is an IrGetObjectValue and is safe to
+        // overwrite; defaults deserialized from dependencies arrive as IrErrorExpression placeholders and
+        // must also be instrumented. Both fall through to `false` here. See #575.
+        return when (irValueParameter.defaultValue?.expression) {
+            // e.g. `Modifier? = null`, consumed via an `iconModifier ?: <fallback>` elvis in the body.
+            is IrConst -> true
+            // e.g. `Modifier.size(40.dp)`.
+            is IrCall -> true
+            else -> false
+        }
     }
 
     private fun isAnonymousFunction(name: Name): Boolean = name == SpecialNames.ANONYMOUS

--- a/instrumented/src/androidTest/java/com/datadog/android/instrumented/SemanticsTest.kt
+++ b/instrumented/src/androidTest/java/com/datadog/android/instrumented/SemanticsTest.kt
@@ -3,6 +3,7 @@ package com.datadog.android.instrumented
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.Rule
 import org.junit.Test
@@ -53,6 +54,33 @@ class SemanticsTest {
         composeTestRule.onAllNodes(textSemanticsMatcher).assertCountEquals(1)
         val columnSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Column")
         composeTestRule.onAllNodes(columnSemanticsMatcher).assertCountEquals(1)
+    }
+
+    @Test
+    fun `M preserve callee default W modifier omitted and default is nullable consumed via elvis`() {
+        composeTestRule.setContent {
+            ScreenWithNullableModifierDefault()
+        }
+
+        // The omitted nullable `iconModifier` keeps its `null` default, so the elvis fallback applies and the
+        // testTag survives. If the transform had overwritten the argument, this node would be absent. See #575.
+        composeTestRule.onAllNodesWithTag(NULLABLE_DEFAULT_TAG).assertCountEquals(1)
+        // The inner Box still receives the datadog tag (its modifier argument is present).
+        val boxSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Box")
+        composeTestRule.onAllNodes(boxSemanticsMatcher).assertCountEquals(1)
+    }
+
+    @Test
+    fun `M preserve callee default W modifier omitted and default is a behavior carrying Modifier`() {
+        composeTestRule.setContent {
+            ScreenWithSizingModifierDefault()
+        }
+
+        // The omitted `iconModifier` keeps its `Modifier.testTag(...).size(...)` default rather than being
+        // overwritten with the datadog modifier, so the testTag survives. See #575.
+        composeTestRule.onAllNodesWithTag(SIZING_DEFAULT_TAG).assertCountEquals(1)
+        val boxSemanticsMatcher = hasSemanticsValue(DD_SEMANTICS_KEY_NAME, "Box")
+        composeTestRule.onAllNodes(boxSemanticsMatcher).assertCountEquals(1)
     }
 
     private fun <T> hasSemanticsValue(

--- a/instrumented/src/main/java/com/datadog/android/instrumented/TagTestScreen.kt
+++ b/instrumented/src/main/java/com/datadog/android/instrumented/TagTestScreen.kt
@@ -1,13 +1,17 @@
 package com.datadog.android.instrumented
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun ScreenWithoutModifier() {
@@ -41,3 +45,45 @@ internal fun ScreenWithCustomModifier() {
         )
     }
 }
+
+/**
+ * Reproduces issue #575 for a nullable Modifier default consumed via an elvis fallback.
+ *
+ * [BoxWithNullableModifierDefault] is called without [Modifier], so it relies on its `null` default. The
+ * instrumentation must NOT overwrite that omitted argument: if it did, `iconModifier` would become non-null,
+ * the elvis would short-circuit, and the fallback [Modifier.testTag] would be dropped. The presence of the
+ * [NULLABLE_DEFAULT_TAG] node proves the default is preserved.
+ */
+@Composable
+internal fun ScreenWithNullableModifierDefault() {
+    BoxWithNullableModifierDefault()
+}
+
+@Composable
+private fun BoxWithNullableModifierDefault(iconModifier: Modifier? = null) {
+    Box(
+        modifier = (iconModifier ?: Modifier.testTag(NULLABLE_DEFAULT_TAG)).size(40.dp)
+    ) {}
+}
+
+/**
+ * Reproduces issue #575 for a non-null, behavior-carrying Modifier default.
+ *
+ * [BoxWithSizingModifierDefault] is called without [Modifier], so it relies on its
+ * `Modifier.testTag(...).size(...)` default. The instrumentation must NOT overwrite that omitted argument,
+ * otherwise the sizing/tag default is discarded. The presence of the [SIZING_DEFAULT_TAG] node proves it.
+ */
+@Composable
+internal fun ScreenWithSizingModifierDefault() {
+    BoxWithSizingModifierDefault()
+}
+
+@Composable
+private fun BoxWithSizingModifierDefault(
+    iconModifier: Modifier = Modifier.testTag(SIZING_DEFAULT_TAG).size(40.dp)
+) {
+    Box(modifier = iconModifier) {}
+}
+
+internal const val NULLABLE_DEFAULT_TAG = "nullable_default_preserved"
+internal const val SIZING_DEFAULT_TAG = "sizing_default_preserved"


### PR DESCRIPTION
### What does this PR do?

Fixes a Compose instrumentation bug (#575) where the `ComposeTagTransformer` could **silently corrupt layouts** by discarding a composable's default `Modifier`.

This PR makes the transformer preserve the callee's default in those cases: it only overwrites an omitted `Modifier` argument when the default is a bare companion (or a deserialized placeholder from a dependency). Otherwise it leaves the call site untouched so the real default applies. The change is applied across the
`kotlin20/21/22/24` KCP transformers.

### In which use cases it didn't work (now fixed)

**1. Nullable `Modifier?` default consumed via an elvis fallback** — the real-world trigger from the report:

```kotlin
@Composable
fun IconRow(text: String, iconModifier: Modifier? = null) {
    Box(modifier = (iconModifier ?: Modifier.size(40.dp)).background(Color.Red))
}

// caller omits iconModifier:
IconRow(text = "…")
```

- **Before:** the transformer injected `Modifier.datadog("IconRow")` into the omitted
  `iconModifier`, making it **non-null**. The `?:` elvis short-circuited to the left,
  so `Modifier.size(40.dp)` was never applied — the `Box` collapsed to 0×0 and the
  background disappeared.
- **After:** `iconModifier` stays `null`, the elvis falls back to `Modifier.size(40.dp)`,
  and the layout renders correctly.

**2. Non-null, behavior-carrying default** (e.g. a sizing modifier):

```kotlin
@Composable
fun IconRow(text: String, iconModifier: Modifier = Modifier.size(40.dp)) {
    Box(modifier = iconModifier.background(Color.Red))
}

IconRow(text = "…") // iconModifier omitted
```

- **Before:** the `Modifier.size(40.dp)` default was overwritten with
  `Modifier.datadog(...)`, dropping the size.
- **After:** the `Modifier.size(40.dp)` default is preserved.

Both reproduced on Kotlin 2.2, 2.3, and 2.4 (kotlin22 and kotlin24 KCP modules), so this is a transform-level issue, not a compiler-version skew.

### Trade-off

A user composable that opts into a non-bare modifier default (e.g. `Modifier? = null`) and is called without a modifier no longer receives an auto-tag on **that** parameter slot. Its contents are still tagged (nested calls with present/companion-default modifiers are unaffected). This is the necessary trade to keep the layout correct.

### Motivation

RUM-16787 / #575

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

### Tests

- **KCP compilation tests** (run per version, kotlin20/21/22/24) — compile and execute the
  transformed bytecode:
  - omitted nullable default consumed via an elvis → fallback preserved;
  - omitted non-null sizing default → default preserved;
  - omitted modifier on a **dependency** composable (deserialized default) → still instrumented (regression guard);
  - existing cases (bare companion / explicit / custom modifier) unchanged.
- **Instrumented (on-device) tests** in `:instrumented` — real Compose + plugin in AUTO mode,
  asserting via Compose semantics that the preserved default's `testTag` survives while the
  inner `Box` still carries the `_dd_semantics` tag.
