### PR TITLE
ci: pin test:instrumented to dedicated project runner

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -246,7 +246,7 @@ test:build-config:
       junit: tools/build-config/build/test-results/test/TEST-*.xml
 
 test:instrumented:
-  tags: [ "macos:sonoma" ]
+  tags: [ "macos:sonoma", "specific:true" ]
   stage: test
   timeout: 1h
   script:


### PR DESCRIPTION
## Summary
- Adds `specific:true` alongside `macos:sonoma` on `test:instrumented` so this job routes to a dedicated bare-metal ASG instead of DataDog's shared `macos:sonoma` runner pool.

## Why
The shared `macos:sonoma`/`macos:sonoma-arm64` runner pool is being deprecated— all jobs on it are being migrated to Tart VM runners instead. `test:instrumented` here runs the Android emulator, which needs virtualization; Tart VMs don't support nested virtualization, so this job can't move there like everything else. A dedicated bare-metal project runner is the fallback for repos in this situation, and moving this job off the shared pool is one of the last dependencies blocking that pool's deprecation.

## Context
The dedicated ASG for `dd-sdk-android-gradle-plugin` is provisioned in [DataDog/cloud-inventory#65427](https://github.com/DataDog/cloud-inventory/pull/65427), built from the AMI produced by [ddoghq/ci-platform-machine-images#836](https://github.com/ddoghq/ci-platform-machine-images/pull/836).

## Test plan
- [x] Merge cloud-inventory#65427 first so the dedicated runner is registered and online
- [x] Confirm `test:instrumented` picks up a job on the dedicated runner (not the shared pool) once this merges