### PR TITLE
RUM-17794: Drop support of AGP versions below 8

### DIFF
--- a/dd-sdk-android-gradle-plugin-kcp-common/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-common/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin-kcp-common/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-common/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 datadogBuildConfig {

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin20/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin20/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 datadogBuildConfig {

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin21/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin21/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 datadogBuildConfig {

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin22/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin22/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 datadogBuildConfig {

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin-kcp-kotlin24/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin-kcp-kotlin24/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 datadogBuildConfig {

--- a/dd-sdk-android-gradle-plugin/api/compiler-meta.txt
+++ b/dd-sdk-android-gradle-plugin/api/compiler-meta.txt
@@ -1,2 +1,2 @@
 kotlin_abi_version=2.3.0
-jvm_bytecode_version=11
+jvm_bytecode_version=17

--- a/dd-sdk-android-gradle-plugin/build.gradle.kts
+++ b/dd-sdk-android-gradle-plugin/build.gradle.kts
@@ -80,9 +80,8 @@ gradlePlugin {
     }
 }
 
-// TODO RUMM-3257 Target Java 17 bytecode at some point
 java {
-    targetCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType<Test> {

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -48,6 +48,10 @@ class DdAndroidGradlePlugin @Inject constructor(
 
     /** @inheritdoc */
     override fun apply(target: Project) {
+        check(CurrentAgpVersion.CAN_USE_PLUGIN) {
+            "Minimum supported AGP version is 8.0.0, Datadog Gradle Plugin cannot be applied."
+        }
+
         val extension = target.extensions.create(EXT_NAME, DdExtension::class.java)
         val apiKeyProvider = resolveApiKey(target)
         // need to use withPlugin instead of afterEvaluate, because otherwise generated assets

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/CurrentAgpVersion.kt
@@ -11,18 +11,12 @@ import com.datadog.gradle.plugin.TaskUtils
 @Suppress("MagicNumber")
 internal object CurrentAgpVersion {
 
+    val CAN_USE_PLUGIN: Boolean
+        get() = TaskUtils.isAgpEqualOrAbove(major = 8, minor = 0, patch = 0)
+
     // can work probably even with lower versions, but legacy Variant API is working fine there as well
     val CAN_ENABLE_NEW_VARIANT_API: Boolean
         get() = TaskUtils.isAgpEqualOrAbove(major = 8, minor = 4, patch = 0)
-
-    val SUPPORTS_KOTLIN_DIRECTORIES_SOURCE_PROVIDER: Boolean
-        get() = TaskUtils.isAgpEqualOrAbove(major = 7, minor = 0, patch = 0)
-
-    val EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC: Boolean
-        get() = TaskUtils.isAgpEqualOrAbove(major = 8, minor = 0, patch = 0)
-
-    val CAN_QUERY_MAPPING_FILE_PROVIDER: Boolean
-        get() = TaskUtils.isAgpEqualOrAbove(major = 7, minor = 0, patch = 0)
 
     val IMPLEMENTS_BUILT_IN_KOTLIN: Boolean
         get() = TaskUtils.isAgpEqualOrAbove(major = 9, minor = 0, patch = 0)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/TaskExt.kt
@@ -7,28 +7,14 @@
 package com.datadog.gradle.plugin.internal
 
 import com.android.build.gradle.tasks.ExternalNativeBuildTask
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
-import kotlin.reflect.full.memberProperties
 
-internal fun TaskProvider<ExternalNativeBuildTask>.getSearchObjDirs(providerFactory: ProviderFactory): Provider<File> {
-    return flatMap { task -> task.getSearchObjDirs(providerFactory) }
+internal fun TaskProvider<ExternalNativeBuildTask>.getSearchObjDirs(): Provider<File> {
+    return flatMap { task -> task.getSearchObjDirs() }
 }
 
-internal fun ExternalNativeBuildTask.getSearchObjDirs(providerFactory: ProviderFactory): Provider<File> {
-    return if (CurrentAgpVersion.EXTERNAL_NATIVE_BUILD_SOFOLDER_IS_PUBLIC) {
-        soFolder.map { it.asFile }
-    } else {
-        val soFolder = ExternalNativeBuildTask::class.memberProperties.find {
-            it.name == "objFolder"
-        }?.get(this)
-        when (soFolder) {
-            is File -> providerFactory.provider { soFolder }
-            is DirectoryProperty -> soFolder.map { it.asFile }
-            else -> providerFactory.provider { null }
-        }
-    }
+internal fun ExternalNativeBuildTask.getSearchObjDirs(): Provider<File> {
+    return soFolder.map { it.asFile }
 }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/LegacyApiAppVariant.kt
@@ -12,7 +12,6 @@ import com.datadog.gradle.plugin.DdAndroidGradlePlugin
 import com.datadog.gradle.plugin.GenerateBuildIdTask
 import com.datadog.gradle.plugin.MappingFileUploadTask
 import com.datadog.gradle.plugin.NdkSymbolFileUploadTask
-import com.datadog.gradle.plugin.internal.CurrentAgpVersion
 import com.datadog.gradle.plugin.internal.getSearchObjDirs
 import com.datadog.gradle.plugin.internal.utils.capitalizeChar
 import org.gradle.api.Project
@@ -55,24 +54,20 @@ internal class LegacyApiAppVariant(
     override val flavors: List<String>
         get() = variant.productFlavors.map { it.name }
     override val mappingFile: Provider<RegularFile>
-        get() = if (CurrentAgpVersion.CAN_QUERY_MAPPING_FILE_PROVIDER) {
-            variant.mappingFileProvider
-                .flatMap {
-                    providerFactory.provider {
-                        try {
-                            projectLayout.projectDirectory.file(it.singleFile.absolutePath)
-                        } catch (e: IllegalStateException) {
-                            DdAndroidGradlePlugin.LOGGER.info(
-                                "Mapping FileCollection is empty or contains multiple files",
-                                e
-                            )
-                            null
-                        }
-                    }.orElse(legacyMappingFileProvider)
-                }
-        } else {
-            legacyMappingFileProvider
-        }
+        get() = variant.mappingFileProvider
+            .flatMap {
+                providerFactory.provider {
+                    try {
+                        projectLayout.projectDirectory.file(it.singleFile.absolutePath)
+                    } catch (e: IllegalStateException) {
+                        DdAndroidGradlePlugin.LOGGER.info(
+                            "Mapping FileCollection is empty or contains multiple files",
+                            e
+                        )
+                        null
+                    }
+                }.orElse(legacyMappingFileProvider)
+            }
 
     private val legacyMappingFileProvider: Provider<RegularFile>
         get() = projectLayout.buildDirectory.file(legacyMappingFilePath.toString())
@@ -84,9 +79,7 @@ internal class LegacyApiAppVariant(
         val roots = mutableListOf<File>()
         variant.sourceSets.forEach {
             roots.addAll(it.javaDirectories)
-            if (CurrentAgpVersion.SUPPORTS_KOTLIN_DIRECTORIES_SOURCE_PROVIDER) {
-                roots.addAll(it.kotlinDirectories)
-            }
+            roots.addAll(it.kotlinDirectories)
         }
         return providerFactory.provider { roots }
     }
@@ -94,7 +87,7 @@ internal class LegacyApiAppVariant(
     override fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask) {
         val nativeBuildProviders = variant.externalNativeBuildProviders
         nativeBuildProviders.forEach { buildTask ->
-            val searchFiles = buildTask.getSearchObjDirs(providerFactory)
+            val searchFiles = buildTask.getSearchObjDirs()
 
             ndkUploadTask.searchDirectories.from(searchFiles)
             ndkUploadTask.dependsOn(buildTask)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/variant/NewApiAppVariant.kt
@@ -74,7 +74,7 @@ internal class NewApiAppVariant(
 
     override fun bindWith(ndkUploadTask: NdkSymbolFileUploadTask) {
         target.tasks.withType(ExternalNativeBuildTask::class.java).forEach {
-            val searchFiles = it.getSearchObjDirs(providerFactory)
+            val searchFiles = it.getSearchObjDirs()
             ndkUploadTask.searchDirectories.from(searchFiles)
             ndkUploadTask.dependsOn(it)
         }

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -490,18 +490,15 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "build_with_datadog_dep.gradle",
             appBuildGradleFile
         )
-        val runArguments = mutableListOf(
-            "--stacktrace",
-            ":samples:app:assembleRelease"
-        ).apply {
-            // https://issuetracker.google.com/issues/231997838
-            if (buildVersionConfig.isAgpAboveOrEqual730()) {
-                add("--configuration-cache")
-            }
-        }
 
         // When
-        val result = gradleRunner { withArguments(runArguments) }
+        val result = gradleRunner {
+            withArguments(
+                "--stacktrace",
+                ":samples:app:assembleRelease",
+                "--configuration-cache"
+            )
+        }
             .build()
 
         // Then
@@ -536,18 +533,15 @@ internal class DdAndroidGradlePluginFunctionalTest {
             "build_with_datadog_dep.gradle",
             appBuildGradleFile
         )
-        val runArguments = mutableListOf(
-            "--stacktrace",
-            ":samples:app:bundleRelease"
-        ).apply {
-            // https://issuetracker.google.com/issues/231997838
-            if (buildVersionConfig.isAgpAboveOrEqual730()) {
-                add("--configuration-cache")
-            }
-        }
 
         // When
-        val result = gradleRunner { withArguments(runArguments) }
+        val result = gradleRunner {
+            withArguments(
+                "--stacktrace",
+                ":samples:app:bundleRelease",
+                "--configuration-cache"
+            )
+        }
             .build()
 
         // Then
@@ -1541,17 +1535,6 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .readText()
     }
 
-    @Suppress("ReturnCount")
-    private fun BuildVersionConfig.isAgpAboveOrEqual730(): Boolean {
-        val groups = agpVersion.split(".")
-        if (groups.size < 3) return false
-        val major = groups[0].toIntOrNull()
-        val minor = groups[1].toIntOrNull()
-        val patch = groups[2].substringBefore("-").toIntOrNull()
-        if (major == null || minor == null || patch == null) return false
-        return major >= 7 && minor >= 3 && patch >= 0
-    }
-
     // endregion
 
     companion object {
@@ -1706,12 +1689,12 @@ internal class DdAndroidGradlePluginFunctionalTest {
         // While work with Gradle with higher major version is possible, it is not guaranteed.
         val TESTED_CONFIGURATIONS = listOf(
             BuildVersionConfig(
-                agpVersion = "7.0.4",
-                gradleVersion = "7.4",
+                agpVersion = "8.0.0",
+                gradleVersion = "8.0",
                 buildToolsVersion = "31.0.0",
                 targetSdkVersion = "31",
-                kotlinVersion = "1.6.10",
-                jvmTarget = JavaVersion.VERSION_11.toString()
+                kotlinVersion = "1.7.20",
+                jvmTarget = JavaVersion.VERSION_17.toString()
             ),
             LATEST_VERSIONS_TEST_CONFIGURATION
         )

--- a/instrumented/build.gradle.kts
+++ b/instrumented/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     buildFeatures {
         compose = true
@@ -59,7 +59,7 @@ android {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        jvmTarget = JvmTarget.JVM_17
         freeCompilerArgs.addAll(
             listOf(
                 "-P",

--- a/tools/build-config/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/tools/build-config/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -13,8 +13,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 internal fun Project.kotlinConfig() {
     taskConfig<KotlinCompile> {
         compilerOptions {
-            // TODO RUMM-3257 Target Java 17 bytecode at some point
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

[AGP 8.0](https://developer.android.com/build/releases/agp-8-0-0-release-notes) was released more than 3 years ago, so we can safely drop support of the versions below.

AGP 8.0 requires also having JVM bytecode version 17, so bumping it as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

