### PR TITLE
[RUM-16312] Support gzip-compressed JVM mapping file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Similarly, to upload NDK symbols, run the `uploadNdkSymbolFiles[Variant]` task i
 #### Compressing the mapping file upload
 
 If your mapping file is large enough to hit the upload size limit, you can opt in to gzip-compressing
-it before upload by setting the `dd-compress-mapping-file` Gradle property, either in `gradle.properties`:
+it before upload by setting the `dd-compress-mapping-file` Gradle property.
+
+Set it in `gradle.properties`:
 
 ```properties
 dd-compress-mapping-file=true
 ```
 
-or on the command line when running the upload task:
+Alternatively, set it on the command line when running the upload task:
 
 ```bash
 ./gradlew uploadMappingRelease -Pdd-compress-mapping-file

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ Similarly, to upload NDK symbols, run the `uploadNdkSymbolFiles[Variant]` task i
 ./gradlew uploadNdkSymbolFilesRelease
 ```
 
+#### Compressing the mapping file upload
+
+If your mapping file is large enough to hit the upload size limit, you can opt in to gzip-compressing
+it before upload by setting the `dd-compress-mapping-file` Gradle property, either in `gradle.properties`:
+
+```properties
+dd-compress-mapping-file=true
+```
+
+or on the command line when running the upload task:
+
+```bash
+./gradlew uploadMappingRelease -Pdd-compress-mapping-file
+```
+
+This is opt-in (not enabled by default) since it requires your Datadog site to support decompressing
+gzip-compressed mapping files.
+
 ### Configuration
 
 You can configure the plugin by adding the following block at the end of your `build.gradle` file.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ or on the command line when running the upload task:
 ./gradlew uploadMappingRelease -Pdd-compress-mapping-file
 ```
 
-This is opt-in (not enabled by default) since it requires your Datadog site to support decompressing
-gzip-compressed mapping files.
+This is opt-in, not enabled by default.
 
 This property is independent of the transport-level compression that uploads already use by default
 (`Content-Encoding: gzip`, turned off with `dd-disable-gzip`). Uploads are therefore already

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ or on the command line when running the upload task:
 This is opt-in (not enabled by default) since it requires your Datadog site to support decompressing
 gzip-compressed mapping files.
 
+This property is independent of the transport-level compression that uploads already use by default
+(`Content-Encoding: gzip`, turned off with `dd-disable-gzip`). Uploads are therefore already
+compressed in transit without it; what this property changes is that the mapping file itself arrives
+compressed, rather than only the connection carrying it being compressed.
+
 ### Configuration
 
 You can configure the plugin by adding the following block at the end of your `build.gradle` file.

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
@@ -59,6 +59,19 @@ abstract class FileUploadTask @Inject constructor(
     private val disableGzipOption: Provider<String> =
         providerFactory.gradleProperty(DISABLE_GZIP_GRADLE_PROPERTY)
 
+    // TODO RUM-16312 Remove this opt-in gate and enable by default once all Datadog sites support
+    //  decompressing gzip-compressed JVM mapping files.
+    private val compressMappingFileOption: Provider<String> =
+        providerFactory.gradleProperty(COMPRESS_MAPPING_FILE_GRADLE_PROPERTY)
+
+    /**
+     * Whether the JVM/Android mapping file content should be gzip-compressed before upload.
+     * Opt-in via the [COMPRESS_MAPPING_FILE_GRADLE_PROPERTY] Gradle property.
+     */
+    @get:Internal
+    protected val compressMappingFile: Boolean
+        get() = compressMappingFileOption.isPresent
+
     // needed for functional tests, because we don't have real API key
     private val emulateNetworkCall: Provider<String> =
         providerFactory.gradleProperty(EMULATE_UPLOAD_NETWORK_CALL)
@@ -287,6 +300,7 @@ abstract class FileUploadTask @Inject constructor(
         internal val LOGGER = Logging.getLogger("DdFileUploadTask")
 
         const val DISABLE_GZIP_GRADLE_PROPERTY = "dd-disable-gzip"
+        const val COMPRESS_MAPPING_FILE_GRADLE_PROPERTY = "dd-compress-mapping-file"
         const val EMULATE_UPLOAD_NETWORK_CALL = "dd-emulate-upload-call"
 
         const val API_KEY_MISSING_ERROR = "Make sure you define an API KEY to upload your mapping files to Datadog. " +

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
@@ -59,17 +59,6 @@ abstract class FileUploadTask @Inject constructor(
     private val disableGzipOption: Provider<String> =
         providerFactory.gradleProperty(DISABLE_GZIP_GRADLE_PROPERTY)
 
-    private val compressMappingFileOption: Provider<String> =
-        providerFactory.gradleProperty(COMPRESS_MAPPING_FILE_GRADLE_PROPERTY)
-
-    /**
-     * Whether the JVM/Android mapping file content should be gzip-compressed before upload.
-     * Opt-in via the [COMPRESS_MAPPING_FILE_GRADLE_PROPERTY] Gradle property.
-     */
-    @get:Internal
-    protected val compressMappingFile: Boolean
-        get() = compressMappingFileOption.isPresent
-
     // needed for functional tests, because we don't have real API key
     private val emulateNetworkCall: Provider<String> =
         providerFactory.gradleProperty(EMULATE_UPLOAD_NETWORK_CALL)
@@ -298,7 +287,6 @@ abstract class FileUploadTask @Inject constructor(
         internal val LOGGER = Logging.getLogger("DdFileUploadTask")
 
         const val DISABLE_GZIP_GRADLE_PROPERTY = "dd-disable-gzip"
-        const val COMPRESS_MAPPING_FILE_GRADLE_PROPERTY = "dd-compress-mapping-file"
         const val EMULATE_UPLOAD_NETWORK_CALL = "dd-emulate-upload-call"
 
         const val API_KEY_MISSING_ERROR = "Make sure you define an API KEY to upload your mapping files to Datadog. " +

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/FileUploadTask.kt
@@ -59,8 +59,6 @@ abstract class FileUploadTask @Inject constructor(
     private val disableGzipOption: Provider<String> =
         providerFactory.gradleProperty(DISABLE_GZIP_GRADLE_PROPERTY)
 
-    // TODO RUM-16312 Remove this opt-in gate and enable by default once all Datadog sites support
-    //  decompressing gzip-compressed JVM mapping files.
     private val compressMappingFileOption: Provider<String> =
         providerFactory.gradleProperty(COMPRESS_MAPPING_FILE_GRADLE_PROPERTY)
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
@@ -9,6 +9,7 @@ package com.datadog.gradle.plugin
 import com.datadog.gradle.plugin.internal.Uploader
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -49,6 +50,13 @@ abstract class MappingFileUploadTask
      */
     @get:Input
     abstract val applicationId: Property<String>
+
+    private val compressMappingFileOption: Provider<String> =
+        providerFactory.gradleProperty(COMPRESS_MAPPING_FILE_GRADLE_PROPERTY)
+
+    // whether the mapping file content should be gzip-compressed before upload
+    private val compressMappingFile: Boolean
+        get() = compressMappingFileOption.isPresent
 
     init {
         group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
@@ -186,6 +194,8 @@ abstract class MappingFileUploadTask
     // endregion
 
     internal companion object {
+        const val COMPRESS_MAPPING_FILE_GRADLE_PROPERTY = "dd-compress-mapping-file"
+
         internal const val TYPE_JVM_MAPPING_FILE = "jvm_mapping_file"
         internal const val KEY_JVM_MAPPING_FILE = "jvm_mapping_file"
         internal const val KEY_JVM_MAPPING_FILE_NAME = "jvm_mapping"

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
@@ -14,6 +14,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import java.io.File
+import java.util.Locale
 import javax.inject.Inject
 
 /**
@@ -54,9 +55,18 @@ abstract class MappingFileUploadTask
     private val compressMappingFileOption: Provider<String> =
         providerFactory.gradleProperty(COMPRESS_MAPPING_FILE_GRADLE_PROPERTY)
 
-    // whether the mapping file content should be gzip-compressed before upload
+    // whether the mapping file content should be gzip-compressed before upload. A bare
+    // `-Pdd-compress-mapping-file` means enabled; an explicit value has to parse as a boolean,
+    // so that `=false` disables instead of silently enabling.
     private val compressMappingFile: Boolean
-        get() = compressMappingFileOption.isPresent
+        get() {
+            val value = compressMappingFileOption.orNull ?: return false
+            if (value.isBlank()) return true
+            return value.toBooleanStrictOrNull() ?: run {
+                LOGGER.warn(INVALID_COMPRESS_MAPPING_FILE_VALUE_WARNING.format(Locale.US, value))
+                false
+            }
+        }
 
     init {
         group = DdAndroidGradlePlugin.DATADOG_TASK_GROUP
@@ -195,6 +205,9 @@ abstract class MappingFileUploadTask
 
     internal companion object {
         const val COMPRESS_MAPPING_FILE_GRADLE_PROPERTY = "dd-compress-mapping-file"
+        internal const val INVALID_COMPRESS_MAPPING_FILE_VALUE_WARNING =
+            "Unrecognized value \"%s\" for the $COMPRESS_MAPPING_FILE_GRADLE_PROPERTY Gradle" +
+                " property, expected \"true\" or \"false\"; mapping file compression stays disabled."
 
         internal const val TYPE_JVM_MAPPING_FILE = "jvm_mapping_file"
         internal const val KEY_JVM_MAPPING_FILE = "jvm_mapping_file"

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/MappingFileUploadTask.kt
@@ -72,7 +72,8 @@ abstract class MappingFileUploadTask
                 file = mappingFile,
                 encoding = MEDIA_TYPE_TXT,
                 fileType = TYPE_JVM_MAPPING_FILE,
-                fileName = KEY_JVM_MAPPING_FILE_NAME
+                fileName = KEY_JVM_MAPPING_FILE_NAME,
+                compressed = compressMappingFile
             )
         )
     }

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -283,6 +283,8 @@ internal class OkHttpUploader : Uploader {
         }
     }
 
+    // Prevents GzipSink#close() from closing the delegate sink, which would otherwise break the
+    // rest of a MultipartBody write when gzip wraps just one of its parts.
     private class NonClosingSink(delegate: Sink) : ForwardingSink(delegate) {
         override fun close() {
             // intentionally not propagated: the delegate's lifecycle is owned by the caller

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -19,11 +19,11 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okio.Buffer
 import okio.BufferedSink
+import okio.ForwardingSink
 import okio.GzipSink
+import okio.Sink
 import okio.buffer
-import okio.use
 import org.json.JSONException
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -112,10 +112,12 @@ internal class OkHttpUploader : Uploader {
         repositoryFile: File?,
         repositoryInfo: RepositoryInfo?
     ): MultipartBody {
+        val fileBody = fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
         val mappingFileBody = if (fileInfo.compressed) {
-            gzip(fileInfo.file.readBytes()).toRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+            // stream-compressed, so the whole file is never held in memory at once
+            fileBody.gzip()
         } else {
-            fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+            fileBody
         }
 
         val eventJson = JSONObject()
@@ -253,12 +255,6 @@ internal class OkHttpUploader : Uploader {
 
     // endregion
 
-    private fun gzip(bytes: ByteArray): ByteArray {
-        val buffer = Buffer()
-        GzipSink(buffer).buffer().use { it.write(bytes) }
-        return buffer.readByteArray()
-    }
-
     private fun RequestBody.gzip(): RequestBody {
         val uncompressedBody = this
         return object : RequestBody() {
@@ -272,7 +268,11 @@ internal class OkHttpUploader : Uploader {
 
             @Throws(IOException::class)
             override fun writeTo(sink: BufferedSink) {
-                val gzipSink = GzipSink(sink).buffer()
+                // GzipSink#close() finishes the gzip stream (writes the trailer) but also closes
+                // its delegate; when this body is just one part of a MultipartBody, the delegate
+                // sink is shared with the other parts, so closing it here would break the rest of
+                // the multipart write. Wrap it so only the gzip stream itself gets closed.
+                val gzipSink = GzipSink(NonClosingSink(sink)).buffer()
                 uncompressedBody.writeTo(gzipSink)
                 gzipSink.close()
             }
@@ -280,6 +280,12 @@ internal class OkHttpUploader : Uploader {
             override fun isOneShot(): Boolean {
                 return uncompressedBody.isOneShot()
             }
+        }
+    }
+
+    private class NonClosingSink(delegate: Sink) : ForwardingSink(delegate) {
+        override fun close() {
+            // intentionally not propagated: the delegate's lifecycle is owned by the caller
         }
     }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -119,6 +119,10 @@ internal class OkHttpUploader : Uploader {
             LOGGER.info(
                 "Compressing ${fileInfo.fileName} content with GZIP ($uncompressedSize bytes uncompressed)."
             )
+            // Independent of the transport-level `Content-Encoding: gzip` (see `useGzip`), which
+            // already compresses uploads in transit by default: this layer is what makes the
+            // mapping file reach the backend compressed. When both are on the part is gzipped
+            // twice, which is expected -- the second pass runs over the small compressed output.
             // stream-compressed, so the whole file is never held in memory at once
             fileBody.gzip { compressedSize ->
                 LOGGER.info(

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -292,8 +292,11 @@ internal class OkHttpUploader : Uploader {
                 // the multipart write. Wrap it so only the gzip stream itself gets closed.
                 val countingSink = ByteCountingSink(NonClosingSink(sink))
                 val gzipSink = GzipSink(countingSink).buffer()
-                uncompressedBody.writeTo(gzipSink)
-                gzipSink.close()
+                try {
+                    uncompressedBody.writeTo(gzipSink)
+                } finally {
+                    gzipSink.close()
+                }
                 onCompressedSize?.invoke(countingSink.byteCount)
             }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -329,6 +329,9 @@ internal class OkHttpUploader : Uploader {
         internal const val HEADER_EVP_ORIGIN_VERSION = "DD-EVP-ORIGIN-VERSION"
         internal const val HEADER_REQUEST_ID = "DD-REQUEST-ID"
         internal const val HEADER_CONTENT_ENCODING = "Content-Encoding"
+        // Deliberately two constants with the same value: ENCODING_GZIP is the HTTP
+        // `Content-Encoding` of the request, COMPRESSION_GZIP is the `compression` value in the
+        // event metadata. They are separate contracts and can change independently.
         internal const val ENCODING_GZIP = "gzip"
         internal const val COMPRESSION_GZIP = "gzip"
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -144,7 +144,9 @@ internal class OkHttpUploader : Uploader {
         eventJson.put("version_code", identifier.versionCode)
         eventJson.put("type", fileInfo.fileType)
         if (fileInfo.compressed) {
-            eventJson.put("compression", COMPRESSION_GZIP)
+            // Named specifically for the mapping file, not the request as a whole: the `event`
+            // metadata and `repository` git info parts are never compressed by this flag.
+            eventJson.put("mapping_compression", COMPRESSION_GZIP)
         }
         fileInfo.extraAttributes.forEach { (key, value) ->
             eventJson.put(key, value)
@@ -333,8 +335,8 @@ internal class OkHttpUploader : Uploader {
         internal const val HEADER_CONTENT_ENCODING = "Content-Encoding"
 
         // Deliberately two constants with the same value: ENCODING_GZIP is the HTTP
-        // `Content-Encoding` of the request, COMPRESSION_GZIP is the `compression` value in the
-        // event metadata. They are separate contracts and can change independently.
+        // `Content-Encoding` of the request, COMPRESSION_GZIP is the `mapping_compression` value
+        // in the event metadata. They are separate contracts and can change independently.
         internal const val ENCODING_GZIP = "gzip"
         internal const val COMPRESSION_GZIP = "gzip"
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -107,32 +107,34 @@ internal class OkHttpUploader : Uploader {
 
     // region Internal
 
+    private fun createFileBody(fileInfo: Uploader.UploadFileInfo): RequestBody {
+        val fileBody = fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+        if (!fileInfo.compressed) return fileBody
+
+        val uncompressedSize = fileInfo.file.length()
+        LOGGER.info(
+            "Compressing ${fileInfo.fileName} content with GZIP ($uncompressedSize bytes uncompressed)."
+        )
+        // Independent of the transport-level `Content-Encoding: gzip` (see `useGzip`), which
+        // already compresses uploads in transit by default: this layer is what makes the mapping
+        // file reach the backend compressed. When both are on the part is gzipped twice, which is
+        // expected -- the second pass runs over the small compressed output.
+        // stream-compressed, so the whole file is never held in memory at once
+        return fileBody.gzip { compressedSize ->
+            LOGGER.info(
+                "Compressed ${fileInfo.fileName} content from $uncompressedSize" +
+                    " to $compressedSize bytes with GZIP."
+            )
+        }
+    }
+
     private fun createBody(
         identifier: DdAppIdentifier,
         fileInfo: Uploader.UploadFileInfo,
         repositoryFile: File?,
         repositoryInfo: RepositoryInfo?
     ): MultipartBody {
-        val fileBody = fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
-        val mappingFileBody = if (fileInfo.compressed) {
-            val uncompressedSize = fileInfo.file.length()
-            LOGGER.info(
-                "Compressing ${fileInfo.fileName} content with GZIP ($uncompressedSize bytes uncompressed)."
-            )
-            // Independent of the transport-level `Content-Encoding: gzip` (see `useGzip`), which
-            // already compresses uploads in transit by default: this layer is what makes the
-            // mapping file reach the backend compressed. When both are on the part is gzipped
-            // twice, which is expected -- the second pass runs over the small compressed output.
-            // stream-compressed, so the whole file is never held in memory at once
-            fileBody.gzip { compressedSize ->
-                LOGGER.info(
-                    "Compressed ${fileInfo.fileName} content from $uncompressedSize" +
-                        " to $compressedSize bytes with GZIP."
-                )
-            }
-        } else {
-            fileBody
-        }
+        val mappingFileBody = createFileBody(fileInfo)
 
         val eventJson = JSONObject()
         eventJson.put("version", identifier.version)

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -331,6 +331,7 @@ internal class OkHttpUploader : Uploader {
         internal const val HEADER_EVP_ORIGIN_VERSION = "DD-EVP-ORIGIN-VERSION"
         internal const val HEADER_REQUEST_ID = "DD-REQUEST-ID"
         internal const val HEADER_CONTENT_ENCODING = "Content-Encoding"
+
         // Deliberately two constants with the same value: ENCODING_GZIP is the HTTP
         // `Content-Encoding` of the request, COMPRESSION_GZIP is the `compression` value in the
         // event metadata. They are separate contracts and can change independently.

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -19,6 +19,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okio.Buffer
 import okio.BufferedSink
 import okio.GzipSink
 import okio.buffer
@@ -111,7 +112,11 @@ internal class OkHttpUploader : Uploader {
         repositoryFile: File?,
         repositoryInfo: RepositoryInfo?
     ): MultipartBody {
-        val mappingFileBody = fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+        val mappingFileBody = if (fileInfo.compressed) {
+            gzip(fileInfo.file.readBytes()).toRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+        } else {
+            fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
+        }
 
         val eventJson = JSONObject()
         eventJson.put("version", identifier.version)
@@ -120,6 +125,9 @@ internal class OkHttpUploader : Uploader {
         eventJson.put("build_id", identifier.buildId)
         eventJson.put("version_code", identifier.versionCode)
         eventJson.put("type", fileInfo.fileType)
+        if (fileInfo.compressed) {
+            eventJson.put("compression", COMPRESSION_GZIP)
+        }
         fileInfo.extraAttributes.forEach { (key, value) ->
             eventJson.put(key, value)
         }
@@ -245,6 +253,12 @@ internal class OkHttpUploader : Uploader {
 
     // endregion
 
+    private fun gzip(bytes: ByteArray): ByteArray {
+        val buffer = Buffer()
+        GzipSink(buffer).buffer().use { it.write(bytes) }
+        return buffer.readByteArray()
+    }
+
     private fun RequestBody.gzip(): RequestBody {
         val uncompressedBody = this
         return object : RequestBody() {
@@ -280,6 +294,7 @@ internal class OkHttpUploader : Uploader {
         internal const val HEADER_REQUEST_ID = "DD-REQUEST-ID"
         internal const val HEADER_CONTENT_ENCODING = "Content-Encoding"
         internal const val ENCODING_GZIP = "gzip"
+        internal const val COMPRESSION_GZIP = "gzip"
 
         internal const val KEY_EVENT = "event"
         internal const val KEY_REPOSITORY = "repository"

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploader.kt
@@ -19,6 +19,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okio.Buffer
 import okio.BufferedSink
 import okio.ForwardingSink
 import okio.GzipSink
@@ -114,8 +115,17 @@ internal class OkHttpUploader : Uploader {
     ): MultipartBody {
         val fileBody = fileInfo.file.asRequestBody(fileInfo.encoding.toMediaTypeOrNull())
         val mappingFileBody = if (fileInfo.compressed) {
+            val uncompressedSize = fileInfo.file.length()
+            LOGGER.info(
+                "Compressing ${fileInfo.fileName} content with GZIP ($uncompressedSize bytes uncompressed)."
+            )
             // stream-compressed, so the whole file is never held in memory at once
-            fileBody.gzip()
+            fileBody.gzip { compressedSize ->
+                LOGGER.info(
+                    "Compressed ${fileInfo.fileName} content from $uncompressedSize" +
+                        " to $compressedSize bytes with GZIP."
+                )
+            }
         } else {
             fileBody
         }
@@ -255,7 +265,7 @@ internal class OkHttpUploader : Uploader {
 
     // endregion
 
-    private fun RequestBody.gzip(): RequestBody {
+    private fun RequestBody.gzip(onCompressedSize: ((Long) -> Unit)? = null): RequestBody {
         val uncompressedBody = this
         return object : RequestBody() {
             override fun contentType(): MediaType? {
@@ -272,9 +282,11 @@ internal class OkHttpUploader : Uploader {
                 // its delegate; when this body is just one part of a MultipartBody, the delegate
                 // sink is shared with the other parts, so closing it here would break the rest of
                 // the multipart write. Wrap it so only the gzip stream itself gets closed.
-                val gzipSink = GzipSink(NonClosingSink(sink)).buffer()
+                val countingSink = ByteCountingSink(NonClosingSink(sink))
+                val gzipSink = GzipSink(countingSink).buffer()
                 uncompressedBody.writeTo(gzipSink)
                 gzipSink.close()
+                onCompressedSize?.invoke(countingSink.byteCount)
             }
 
             override fun isOneShot(): Boolean {
@@ -288,6 +300,18 @@ internal class OkHttpUploader : Uploader {
     private class NonClosingSink(delegate: Sink) : ForwardingSink(delegate) {
         override fun close() {
             // intentionally not propagated: the delegate's lifecycle is owned by the caller
+        }
+    }
+
+    // Counts the bytes actually handed to the delegate, so the compressed size can be reported
+    // without buffering the compressed output.
+    private class ByteCountingSink(delegate: Sink) : ForwardingSink(delegate) {
+        var byteCount: Long = 0
+            private set
+
+        override fun write(source: Buffer, byteCount: Long) {
+            super.write(source, byteCount)
+            this.byteCount += byteCount
         }
     }
 

--- a/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
+++ b/dd-sdk-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/internal/Uploader.kt
@@ -43,7 +43,14 @@ internal interface Uploader {
         /**
          * Any extra attributes to provide to intake, such as the architecture of an NDK symbol file.
          */
-        val extraAttributes: Map<String, String> = emptyMap()
+        val extraAttributes: Map<String, String> = emptyMap(),
+
+        /**
+         * Whether the file content should be gzip-compressed before being attached to the
+         * upload request, with the compression declared to intake via the `compression` event
+         * attribute. Only supported by intake for JVM/Android mapping files.
+         */
+        val compressed: Boolean = false
     )
 
     // endregion

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -733,10 +733,10 @@ internal class DdAndroidGradlePluginFunctionalTest {
         )
     }
 
-    @Test
     // NB: runs with -Pdd-emulate-upload-call, so the request body is never written and no gzip
     // actually happens here -- OkHttpUploaderTest covers the compression itself. This only checks
     // that the Gradle property reaches the uploader.
+    @Test
     fun `M declare gzip compression W upload { mapping file compression enabled }`(forge: Forge) {
         // Given
         stubGradleBuildFromResourceFile(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -769,6 +769,41 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
+    fun `M not compress mapping file W upload { mapping file compression set to false }`(forge: Forge) {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_with_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+        val color = forge.anElementFrom(colors)
+        val version = forge.anElementFrom(versions)
+        val variant = "${version.lowercase()}$color"
+        val taskName = resolveMappingUploadTask(variant)
+
+        // When
+        // since there is no explicit dependency between assemble and upload tasks, Gradle may
+        // optimize the execution and run them in parallel, ignoring the order in the command
+        // line, so we do the explicit split
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
+            .build()
+
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-compress-mapping-file=false",
+                "-Pdd-emulate-upload-call"
+            )
+        }
+            .build()
+
+        // Then
+        assertThat(result).doesNotContainInOutput("\"compression\":\"gzip\"")
+    }
+
+    @Test
     fun `M try to upload the mapping file W upload { datadog-ci file, parent dir }`(forge: Forge) {
         // Given
         stubGradleBuildFromResourceFile(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -768,7 +768,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .build()
 
         // Then
-        assertThat(result).containsInOutput("\"compression\":\"gzip\"")
+        assertThat(result).containsInOutput("\"mapping_compression\":\"gzip\"")
         assertThat(result).containsInOutput("Compressing jvm_mapping content with GZIP (")
     }
 
@@ -804,7 +804,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
             .build()
 
         // Then
-        assertThat(result).doesNotContainInOutput("\"compression\":\"gzip\"")
+        assertThat(result).doesNotContainInOutput("\"mapping_compression\":\"gzip\"")
     }
 
     @Test

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -734,6 +734,41 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
+    fun `M gzip-compress mapping file W upload { mapping file compression enabled }`(forge: Forge) {
+        // Given
+        stubGradleBuildFromResourceFile(
+            "build_with_datadog_dep.gradle",
+            appBuildGradleFile
+        )
+        val color = forge.anElementFrom(colors)
+        val version = forge.anElementFrom(versions)
+        val variant = "${version.lowercase()}$color"
+        val taskName = resolveMappingUploadTask(variant)
+
+        // When
+        // since there is no explicit dependency between assemble and upload tasks, Gradle may
+        // optimize the execution and run them in parallel, ignoring the order in the command
+        // line, so we do the explicit split
+        gradleRunner { withArguments("--info", ":samples:app:assembleRelease") }
+            .build()
+
+        val result = gradleRunner {
+            withArguments(
+                taskName,
+                "--info",
+                "--stacktrace",
+                "-PDD_API_KEY=fakekey",
+                "-Pdd-compress-mapping-file",
+                "-Pdd-emulate-upload-call"
+            )
+        }
+            .build()
+
+        // Then
+        assertThat(result).containsInOutput("\"compression\":\"gzip\"")
+    }
+
+    @Test
     fun `M try to upload the mapping file W upload { datadog-ci file, parent dir }`(forge: Forge) {
         // Given
         stubGradleBuildFromResourceFile(

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -766,6 +766,7 @@ internal class DdAndroidGradlePluginFunctionalTest {
 
         // Then
         assertThat(result).containsInOutput("\"compression\":\"gzip\"")
+        assertThat(result).containsInOutput("Compressing jvm_mapping content with GZIP (")
     }
 
     @Test

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePluginFunctionalTest.kt
@@ -734,7 +734,10 @@ internal class DdAndroidGradlePluginFunctionalTest {
     }
 
     @Test
-    fun `M gzip-compress mapping file W upload { mapping file compression enabled }`(forge: Forge) {
+    // NB: runs with -Pdd-emulate-upload-call, so the request body is never written and no gzip
+    // actually happens here -- OkHttpUploaderTest covers the compression itself. This only checks
+    // that the Gradle property reaches the uploader.
+    fun `M declare gzip compression W upload { mapping file compression enabled }`(forge: Forge) {
         // Given
         stubGradleBuildFromResourceFile(
             "build_with_datadog_dep.gradle",

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -17,10 +17,14 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.MultipartReader
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import okio.GzipSource
+import okio.buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
@@ -199,6 +203,45 @@ internal class OkHttpUploaderTest {
                 "repository",
                 fakeRepositoryFileContent,
                 "application/json"
+            )
+    }
+
+    @Test
+    fun `M gzip-compress mapping file content and declare compression W upload() { compressed file }`() {
+        // Given
+        mockUploadResponse = MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+            .setBody("{}")
+        val fakeCompressedMappingFileInfo = fakeMappingFileInfo.copy(compressed = true)
+
+        // When
+        testedUploader.upload(
+            mockSite,
+            fakeCompressedMappingFileInfo,
+            fakeRepositoryFile,
+            fakeApiKey,
+            fakeIdentifier,
+            fakeRepositoryInfo,
+            useGzip = false,
+            emulateNetworkCall = false
+        )
+
+        // Then
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+        val request = dispatchedUploadRequest
+        checkNotNull(request)
+        val decompressedFilePartContent = readGzippedMultipartFileContent(
+            request,
+            fakeCompressedMappingFileInfo.fileKey
+        )
+        assertThat(decompressedFilePartContent).isEqualTo(fakeMappingFileContent)
+        assertThat(request)
+            .doesNotHaveHeader("Content-Encoding")
+            .containsMultipartFile(
+                "event",
+                "event",
+                fakeIdentifier.toMappingFileEvent(fakeCompressedMappingFileInfo.fileType, compression = "gzip"),
+                "application/json; charset=utf-8"
             )
     }
 
@@ -648,13 +691,40 @@ internal class OkHttpUploaderTest {
 
     // region Internal
 
-    private fun DdAppIdentifier.toMappingFileEvent(type: String): String {
+    private fun DdAppIdentifier.toMappingFileEvent(type: String, compression: String? = null): String {
+        val compressionField = if (compression != null) "\"compression\":\"$compression\"," else ""
         return "{\"build_id\":\"${buildId}\"," +
             "\"service\":\"${serviceName}\"," +
             "\"variant\":\"${variant}\"," +
             "\"version_code\":$versionCode," +
             "\"type\":\"${type}\"," +
+            compressionField +
             "\"version\":\"${version}\"}"
+    }
+
+    // JSONObject preserves insertion order, and "compression" is put right after "type" and
+    // before "version" in OkHttpUploader#createBody.
+    private fun readGzippedMultipartFileContent(request: RecordedRequest, partName: String): String {
+        val contentType = requireNotNull(request.getHeader("Content-Type")) {
+            "Missing Content-Type header on upload request"
+        }
+        val boundary = requireNotNull(Regex("boundary=([^;]+)").find(contentType)) {
+            "Missing multipart boundary in Content-Type header: $contentType"
+        }.groupValues[1]
+
+        // clone(): RecordedRequest#body is a single mutable Buffer that other assertions in this
+        // test also read from; MultipartReader would otherwise drain it as a side effect.
+        MultipartReader(request.body.clone(), boundary).use { reader ->
+            while (true) {
+                val part = reader.nextPart() ?: break
+                val disposition = part.headers["Content-Disposition"].orEmpty()
+                if (disposition.contains("name=\"$partName\"")) {
+                    val gzippedBytes = part.body.readByteArray()
+                    return GzipSource(Buffer().write(gzippedBytes)).buffer().readUtf8()
+                }
+            }
+        }
+        error("Multipart part named \"$partName\" not found in request body")
     }
 
     inner class MockDispatcher : Dispatcher() {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -741,18 +741,19 @@ internal class OkHttpUploaderTest {
     // region Internal
 
     private fun DdAppIdentifier.toMappingFileEvent(type: String, compression: String? = null): String {
-        val compressionField = if (compression != null) "\"compression\":\"$compression\"," else ""
+        val compressionField = if (compression != null) "\"mapping_compression\":\"$compression\"," else ""
         return "{\"build_id\":\"${buildId}\"," +
             "\"service\":\"${serviceName}\"," +
             "\"variant\":\"${variant}\"," +
             "\"version_code\":$versionCode," +
-            "\"type\":\"${type}\"," +
             compressionField +
+            "\"type\":\"${type}\"," +
             "\"version\":\"${version}\"}"
     }
 
-    // JSONObject preserves insertion order, and "compression" is put right after "type" and
-    // before "version" in OkHttpUploader#createBody.
+    // JSONObject serializes keys in java.util.HashMap bucket order, not insertion order -- for
+    // this fixed key set, that happens to put "mapping_compression" right after "version_code"
+    // and before "type".
     private fun readGzippedMultipartFileContent(request: RecordedRequest, partName: String): String {
         val contentType = requireNotNull(request.getHeader("Content-Type")) {
             "Missing Content-Type header on upload request"

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/OkHttpUploaderTest.kt
@@ -23,6 +23,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import okio.Buffer
+import okio.BufferedSource
 import okio.GzipSource
 import okio.buffer
 import org.assertj.core.api.Assertions.assertThat
@@ -243,6 +244,54 @@ internal class OkHttpUploaderTest {
                 fakeIdentifier.toMappingFileEvent(fakeCompressedMappingFileInfo.fileType, compression = "gzip"),
                 "application/json; charset=utf-8"
             )
+    }
+
+    @Test
+    fun `M double-compress mapping file W upload() { compressed file, transport gzip }`() {
+        // Given
+        mockUploadResponse = MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_OK)
+            .setBody("{}")
+        val fakeCompressedMappingFileInfo = fakeMappingFileInfo.copy(compressed = true)
+
+        // When
+        testedUploader.upload(
+            mockSite,
+            fakeCompressedMappingFileInfo,
+            fakeRepositoryFile,
+            fakeApiKey,
+            fakeIdentifier,
+            fakeRepositoryInfo,
+            useGzip = true,
+            emulateNetworkCall = false
+        )
+
+        // Then
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+        val request = dispatchedUploadRequest
+        checkNotNull(request)
+        // NB: don't use the custom assertThat(RecordedRequest) helper here (or anywhere before the
+        // raw reads below) -- its constructor eagerly drains request.body as a side effect.
+        assertThat(request.getHeader("Content-Encoding")).isEqualTo("gzip")
+
+        // un-gzip the whole request (transport-level Content-Encoding) to get the raw multipart body
+        val decompressedMultipartBody = GzipSource(request.body.clone()).buffer()
+        val parts = readMultipartParts(decompressedMultipartBody, requireNotNull(request.getHeader("Content-Type")))
+
+        // metadata is plain text once the transport-level gzip is undone
+        val eventJsonText = requireNotNull(parts["event"]).toString(Charsets.UTF_8)
+        assertThat(eventJsonText).isEqualTo(
+            fakeIdentifier.toMappingFileEvent(fakeCompressedMappingFileInfo.fileType, compression = "gzip")
+        )
+
+        // the mapping file part is still gzip-compressed: undoing only the transport-level gzip
+        // is not enough to read it back, it carries its own, independent gzip layer
+        val filePartBytes = requireNotNull(parts[fakeCompressedMappingFileInfo.fileKey])
+        assertThat(filePartBytes.copyOfRange(0, 2)).isEqualTo(byteArrayOf(0x1F, 0x8B.toByte()))
+
+        // un-gzip the mapping file part itself, on top of the already-undone transport gzip
+        val decompressedFileContent = GzipSource(Buffer().write(filePartBytes)).buffer().readUtf8()
+        assertThat(decompressedFileContent).isEqualTo(fakeMappingFileContent)
     }
 
     @Test
@@ -708,23 +757,33 @@ internal class OkHttpUploaderTest {
         val contentType = requireNotNull(request.getHeader("Content-Type")) {
             "Missing Content-Type header on upload request"
         }
-        val boundary = requireNotNull(Regex("boundary=([^;]+)").find(contentType)) {
-            "Missing multipart boundary in Content-Type header: $contentType"
+        // clone(): RecordedRequest#body is a single mutable Buffer that other assertions in this
+        // test also read from; readMultipartParts would otherwise drain it as a side effect.
+        val gzippedBytes = requireNotNull(
+            readMultipartParts(request.body.clone(), contentType)[partName]
+        ) {
+            "Multipart part named \"$partName\" not found in request body"
+        }
+        return GzipSource(Buffer().write(gzippedBytes)).buffer().readUtf8()
+    }
+
+    private fun readMultipartParts(source: BufferedSource, contentTypeHeader: String): Map<String, ByteArray> {
+        val boundary = requireNotNull(Regex("boundary=([^;]+)").find(contentTypeHeader)) {
+            "Missing multipart boundary in Content-Type header: $contentTypeHeader"
         }.groupValues[1]
 
-        // clone(): RecordedRequest#body is a single mutable Buffer that other assertions in this
-        // test also read from; MultipartReader would otherwise drain it as a side effect.
-        MultipartReader(request.body.clone(), boundary).use { reader ->
+        val parts = mutableMapOf<String, ByteArray>()
+        MultipartReader(source, boundary).use { reader ->
             while (true) {
                 val part = reader.nextPart() ?: break
                 val disposition = part.headers["Content-Disposition"].orEmpty()
-                if (disposition.contains("name=\"$partName\"")) {
-                    val gzippedBytes = part.body.readByteArray()
-                    return GzipSource(Buffer().write(gzippedBytes)).buffer().readUtf8()
-                }
+                val name = requireNotNull(Regex("name=\"([^\"]+)\"").find(disposition)) {
+                    "Missing name in Content-Disposition: $disposition"
+                }.groupValues[1]
+                parts[name] = part.body.readByteArray()
             }
         }
-        error("Multipart part named \"$partName\" not found in request body")
+        return parts
     }
 
     inner class MockDispatcher : Dispatcher() {

--- a/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/BuildResultAssert.kt
+++ b/dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/utils/assertj/BuildResultAssert.kt
@@ -21,6 +21,11 @@ internal class BuildResultAssert(actual: BuildResult) :
         return this
     }
 
+    fun doesNotContainInOutput(text: String): BuildResultAssert {
+        assertThat(actual.output).doesNotContain(text)
+        return this
+    }
+
     fun hasSuccessfulTaskOutcome(taskName: String): BuildResultAssert {
         val task = actual.task(taskName)
         assertThat(task)


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `dd-compress-mapping-file` Gradle property. When set, the JVM/Android mapping file content is gzip-compressed before being attached to the upload request, and a `compression: "gzip"` field is added to the `event` metadata JSON so the intake/`sourcemap-processor` knows to decompress it.

Only the JVM mapping file upload is affected (NDK symbol file uploads are untouched), matching backend support which is JVM-mapping-specific.

### Motivation

Backend support for accepting gzip-compressed JVM/Android mapping files was added in `dd-go` PR [#2682](https://github.com/ddoghq/dd-go/pull/2682) (`sourcemap-processor` now decompresses the mapping blob in memory when `Metadata.Compression == "gzip"`). ProGuard/R8 mapping files are highly compressible text (often 10-20x), so compressing the upload reduces both upload payload size and stored blob size, and helps users hit the existing max-mapping-file-size limit less often.

The feature is kept **opt-in** (not default-on) since the backend rollout may lag across Datadog sites/regions; a site whose `sourcemap-processor` doesn't yet understand `compression: gzip` would otherwise store the mapping file permanently gzip-compressed, breaking deobfuscation. The default can be flipped in a later release once the backend is confirmed rolled out everywhere.

### Additional Notes

- `Uploader.UploadFileInfo` gained a `compressed: Boolean` field, driven per-call-site rather than hardcoded by file type, so only `MappingFileUploadTask` sets it (gated by the new Gradle property).
- `OkHttpUploader` gzip-compresses the file part content (independent of the existing `useGzip`/`Content-Encoding: gzip` transport-level compression, which is unrelated) and adds the `compression` event field. Compression is **streamed** (via the existing `RequestBody.gzip()` wrapper, reused for a single multipart part) rather than loading the whole mapping file into memory, so peak memory stays flat regardless of file size — see benchmarks below.
- Tests: `OkHttpUploaderTest` verifies the uploaded file part is actually gzip-compressed and decompresses back to the original content (including a combined case with the outer transport-level gzip also enabled, gunzipping both layers and diffing against the original file), and that the `compression` field is present in the event JSON. `DdAndroidGradlePluginFunctionalTest` verifies the Gradle property wiring end-to-end on a real `assembleRelease` build.
- Documented the new opt-in property in the README, under "Compressing the mapping file upload".

### Benchmarks

Benchmarked the real `OkHttpUploader#upload` code path end-to-end: a real OkHttp request/response round-trip through a local `MockWebServer` bound to `127.0.0.1` (no real/remote endpoint is ever contacted). Run as a standalone JVM process outside Gradle to avoid Gradle/JVM-startup noise. Platform: macOS/arm64, JDK 17, using `/usr/bin/time -l` (peak RSS) and `/usr/bin/time -p` (wall time).

**Wall time**

| Mapping file size | No compression | With compression | Δ |
|---|---|---|---|
| 20 MB | ~0.68s | ~0.76s | +0.08s |
| 150 MB | ~0.78s | ~1.53s | +0.75s |

Compression adds real, roughly file-size-linear CPU time. In the real upload flow this is traded against a much smaller payload to transmit (at ~23x compression, a 150 MB upload becomes ~6.5 MB), so on any bandwidth-constrained connection the transfer-time savings should outweigh the added compression time.

**Peak RSS**

| Mapping file size | No compression | With compression | Δ |
|---|---|---|---|
| 20 MB | ~228 MB | ~229 MB | noise (no clear signal) |
| 150 MB | ~370 MB | ~225 MB | **-145 MB (compression uses *less* memory)** |

At 20 MB the ~220 MB of fixed JVM/OkHttp/Mockito/MockWebServer class-loading overhead dominates and swamps any signal. At 150 MB, compression comes out clearly *ahead* on memory too: `MockWebServer` fully buffers whatever bytes actually cross the wire as part of recording the request, so the uncompressed run has to hold the full ~150 MB mapping file in memory on top of the baseline, while the compressed run only holds the ~6.5 MB gzip output. In other words, once you account for what has to be buffered on the receiving side (a proxy, the real intake service, etc.), not just the sending side, compression is a net memory win, not just a network-payload win. An isolated micro-benchmark of only the client-side gzip step (excluding anything downstream) showed a small, flat, streaming-related overhead instead (+1-1.5 MB regardless of file size) — that number is real too, but it's a narrower measurement than this end-to-end one.

<details>
<summary>Reproduction steps</summary>

`BenchMain.kt` below drives the actual `OkHttpUploader` class directly (not a reimplementation). It's not committed to the repo (it's a throwaway benchmarking entry point, not a test), so drop it into the test source set locally to reproduce:

1. Save it as `dd-sdk-android-gradle-plugin/src/test/kotlin/com/datadog/gradle/plugin/internal/BenchMain.kt`.
2. Compile it as part of the module (so it can see `internal` declarations) and grab the test runtime classpath:
   ```bash
   ./gradlew --configure-on-demand :dd-sdk-android-gradle-plugin:compileTestKotlin

   cat > /tmp/print_classpath.gradle.kts <<'EOF'
   allprojects {
       if (project.path == ":dd-sdk-android-gradle-plugin") {
           afterEvaluate {
               tasks.register("printTestClasspath") {
                   doLast {
                       val testSourceSet = project.extensions.getByType(org.gradle.api.tasks.SourceSetContainer::class.java).getByName("test")
                       val cp = testSourceSet.runtimeClasspath.files.joinToString(":") { it.absolutePath }
                       java.io.File("/tmp/bench/testcp.txt").writeText(cp)
                   }
               }
           }
       }
   }
   EOF
   mkdir -p /tmp/bench
   ./gradlew --configure-on-demand -I /tmp/print_classpath.gradle.kts :dd-sdk-android-gradle-plugin:printTestClasspath
   ```
3. Generate a large, highly-compressible synthetic mapping file:
   ```bash
   python3 - <<'PYEOF'
   lines = []
   size = 0
   i = 0
   while size < 150 * 1024 * 1024:
       header = f"com.example.foo.Class{i % 5000} -> a.a.{i}:\n"
       lines.append(header)
       size += len(header)
       for j in range(20):
           member = f"    {j*3+1}:{j*3+3}:void method{j}(int,java.lang.String) -> {chr(97+j%26)}\n"
           lines.append(member)
           size += len(member)
       i += 1
   open("/tmp/bench/mapping.txt", "w").writelines(lines)
   PYEOF
   ```
4. Run it directly as a plain `java` process (bypassing Gradle's test runner so `/usr/bin/time` can wrap the exact process):
   ```bash
   CP="dd-sdk-android-gradle-plugin/build/classes/kotlin/main:dd-sdk-android-gradle-plugin/build/classes/kotlin/test:$(cat /tmp/bench/testcp.txt)"

   # RSS (peak resident set size)
   /usr/bin/time -l java -cp "$CP" com.datadog.gradle.plugin.internal.BenchMainKt streamed /tmp/bench/mapping.txt   # no compression
   /usr/bin/time -l java -cp "$CP" com.datadog.gradle.plugin.internal.BenchMainKt compressed /tmp/bench/mapping.txt # with compression

   # Wall time
   /usr/bin/time -p java -cp "$CP" com.datadog.gradle.plugin.internal.BenchMainKt streamed /tmp/bench/mapping.txt
   /usr/bin/time -p java -cp "$CP" com.datadog.gradle.plugin.internal.BenchMainKt compressed /tmp/bench/mapping.txt
   ```

`BenchMain.kt`:
```kotlin
package com.datadog.gradle.plugin.internal

import com.datadog.gradle.plugin.DatadogSite
import okhttp3.mockwebserver.MockResponse
import okhttp3.mockwebserver.MockWebServer
import org.mockito.kotlin.doReturn
import org.mockito.kotlin.mock
import org.mockito.kotlin.whenever
import java.io.File

// Standalone entry point (not a @Test) to benchmark the real OkHttpUploader#upload code path
// (RSS / wall time) outside of Gradle's own overhead. Run with `java -cp <classpath> BenchMainKt
// <streamed|compressed> <path-to-mapping-file>`, wrapped in `/usr/bin/time`.
//
// Uploads only ever go to a local MockWebServer bound to 127.0.0.1 -- no real network call is
// made and no real Datadog endpoint is ever contacted.
fun main(args: Array<String>) {
    val mode = args[0]
    val path = args[1]

    val mockWebServer = MockWebServer()
    mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
    mockWebServer.start()

    val mockSite: DatadogSite = mock()
    whenever(mockSite.uploadEndpoint()) doReturn mockWebServer.url("/upload").toString()

    val fileInfo = Uploader.UploadFileInfo(
        fileKey = "jvm_mapping_file",
        file = File(path),
        encoding = "text/plain",
        fileType = "jvm_mapping_file",
        fileName = "jvm_mapping",
        compressed = mode == "compressed"
    )

    val identifier = DdAppIdentifier(
        serviceName = "bench-service",
        version = "1.0",
        versionCode = 1,
        variant = "release",
        buildId = "bench-build-id"
    )

    OkHttpUploader().upload(
        site = mockSite,
        fileInfo = fileInfo,
        repositoryFile = null,
        apiKey = "fake-api-key",
        identifier = identifier,
        repositoryInfo = null,
        useGzip = false,
        emulateNetworkCall = false
    )

    mockWebServer.shutdown()
    println("done mode=$mode")
}
```

</details>

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

